### PR TITLE
Document watch and incremental build plan

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -136,6 +136,26 @@ _Avoid_: Build run, compiler instance
 A long-lived compiler lifecycle that observes input changes and triggers compilations from compiler-owned state.
 _Avoid_: Watch mode, dev server loop
 
+**Watching**:
+The JavaScript API handle returned from starting a watch session.
+_Avoid_: Watch session, watcher instance
+
+**Watch Options**:
+The JavaScript API options that control file watching and rebuild coalescing for a watch session.
+_Avoid_: Compiler options, cache options
+
+**Watch Dependency Set**:
+The compilation-reported filesystem inputs that a watch session uses to subscribe to future changes.
+_Avoid_: Module dependency, import dependency
+
+**Cache Options**:
+The JavaScript API options that enable, disable, and configure build cache layers.
+_Avoid_: Watch options, output options
+
+**Snapshot Options**:
+The JavaScript API options that configure snapshot strategies by snapshot category.
+_Avoid_: Cache options, watch options
+
 **Build Cache**:
 Compiler-owned reusable build information that can be validated and reused across compilations.
 _Avoid_: Compilation cache, module graph reuse
@@ -187,6 +207,10 @@ _Avoid_: Build error, compilation error, fatal error
 **Concurrent Run Error**:
 An infrastructure error reported when a JavaScript API caller starts a compiler run while the same compiler instance is already running.
 _Avoid_: Compilation error, duplicate build warning
+
+**Compiler Running Error**:
+An infrastructure error reported when a JavaScript API caller tries to close a compiler while it owns active run or watch work.
+_Avoid_: Close error, watcher close error
 
 **Compilation Error**:
 A problem found while processing application modules during a completed compiler run.

--- a/docs/adr/0046-normalize-javascript-options-in-the-typescript-wrapper.md
+++ b/docs/adr/0046-normalize-javascript-options-in-the-typescript-wrapper.md
@@ -1,3 +1,7 @@
+---
+status: superseded by ADR-0079
+---
+
 # Normalize JavaScript options in the TypeScript wrapper
 
 The TypeScript wrapper will own JavaScript-facing option validation, defaulting, and normalization, then pass a narrow normalized object to the native addon. Top-level option validation failures during `unpack(options, callback?)` are synchronous `TypeError`s, even when a callback is provided, because no compiler can be created; the first wrapper accepts only `context`, `entry`, and `output` top-level options and rejects unknown options instead of silently ignoring webpack-shaped configuration. This keeps user-facing `TypeError` behavior and webpack-like convenience shapes in TypeScript while the N-API layer focuses on converting normalized options into Rust compiler options, running the core, emitting assets, and returning stats data.

--- a/docs/adr/0070-do-not-expose-watch-in-the-first-javascript-api.md
+++ b/docs/adr/0070-do-not-expose-watch-in-the-first-javascript-api.md
@@ -1,3 +1,7 @@
+---
+status: superseded by ADR-0074
+---
+
 # Do not expose watch in the first JavaScript API
 
 The first JavaScript `Compiler` API will expose `run` and `close`, but not `watch`. Watch mode would require explicit invalidation, watcher lifecycle, incremental compilation, and additional close semantics, so it remains outside the first JavaScript API surface.

--- a/docs/adr/0074-expose-compiler-watch-in-the-javascript-api.md
+++ b/docs/adr/0074-expose-compiler-watch-in-the-javascript-api.md
@@ -1,0 +1,3 @@
+# Expose compiler watch in the JavaScript API
+
+Unpack will expose `compiler.watch(watchOptions, handler)` in the JavaScript API and return a `Watching` handle for closing and invalidating the watch session. This supersedes the earlier first-API decision to omit watch because the JavaScript wrapper and native boundary now exist, and watch must be a compiler-owned lifecycle so it can share incremental build cache, file snapshot validation, persistent cache idle flush, and close semantics with `run`.

--- a/docs/adr/0075-keep-watching-api-surface-minimal.md
+++ b/docs/adr/0075-keep-watching-api-surface-minimal.md
@@ -1,0 +1,3 @@
+# Keep the Watching API surface minimal
+
+The JavaScript `Watching` handle will initially expose `close(callback)` and `invalidate()`. Closing a watching handle must stop future file watching, wait for any active compilation to finish, and wait for pending persistent cache flushes; invalidation triggers a rebuild or coalesces into the next rebuild when compilation is already active, matching webpack's core watch lifecycle without exposing extra suspend, resume, or inspection methods before Unpack has a need for them.

--- a/docs/adr/0076-reject-run-watch-and-close-conflicts-per-compiler.md
+++ b/docs/adr/0076-reject-run-watch-and-close-conflicts-per-compiler.md
@@ -1,0 +1,3 @@
+# Reject run, watch, and close conflicts per compiler
+
+A JavaScript `Compiler` will allow only one active run or watch session at a time. Calling `run` or `watch` while the same compiler is running or watching reports an asynchronous concurrent-run infrastructure error; calling `compiler.close` while a run or watch session is active reports a compiler-running infrastructure error and requires callers to close the `Watching` handle first. Closing a `Watching` handle stops that watch lifecycle without closing the compiler, so the compiler may be reused for later `run` or `watch` calls until `compiler.close` is called.

--- a/docs/adr/0077-start-with-a-minimal-watch-options-subset.md
+++ b/docs/adr/0077-start-with-a-minimal-watch-options-subset.md
@@ -1,0 +1,3 @@
+# Start with a minimal watch options subset
+
+The JavaScript `compiler.watch` API will accept a webpack-familiar but intentionally narrow `watchOptions` shape: `aggregateTimeout`, `ignored`, and `poll`. Unknown watch option keys will throw synchronous `TypeError`s, matching the wrapper's strict option normalization style, while `followSymlinks`, `stdin`, and other watcher controls remain out of scope until Unpack has a concrete need to support them.

--- a/docs/adr/0078-report-watch-dependency-sets-from-compilations.md
+++ b/docs/adr/0078-report-watch-dependency-sets-from-compilations.md
@@ -1,0 +1,3 @@
+# Report watch dependency sets from compilations
+
+Each compilation will report watch dependency sets for files, directories, and missing paths, and a watch session will replace its subscriptions from the latest completed compilation. The first implementation primarily fills file dependencies from resolved module resources and may use missing dependencies for unresolved requests, while context dependencies remain available for future context-module support.

--- a/docs/adr/0079-expose-cache-and-snapshot-options-in-the-javascript-api.md
+++ b/docs/adr/0079-expose-cache-and-snapshot-options-in-the-javascript-api.md
@@ -1,0 +1,5 @@
+# Expose cache and snapshot options in the JavaScript API
+
+The JavaScript API will accept cache options and snapshot options in addition to `context`, `entry`, `output`, and watch options. The TypeScript wrapper remains responsible for strict validation, defaulting, and normalization before passing a narrow native shape across N-API; `cache` may be disabled, memory-backed, or filesystem-backed, while `snapshot` configures module and build-dependency validation strategies. This supersedes the earlier first-wrapper option surface that accepted only `context`, `entry`, and `output`.
+
+The initial public cache shape is `cache?: boolean | { type?: "memory" | "filesystem"; cacheDirectory?: string; cacheLocation?: string; name?: string; version?: string; buildDependencies?: Record<string, string[]>; maxMemoryGenerations?: number; idleTimeout?: number }`. The initial public snapshot shape is `snapshot?: { module?: { timestamp?: boolean; hash?: boolean }; buildDependencies?: { timestamp?: boolean; hash?: boolean } }`. Unknown keys continue to throw synchronous `TypeError`s.

--- a/docs/adr/0080-default-to-memory-cache.md
+++ b/docs/adr/0080-default-to-memory-cache.md
@@ -1,0 +1,3 @@
+# Default to memory cache
+
+Unpack will treat omitted `cache` and `cache: true` as memory cache, while persistent filesystem cache requires `cache: { type: "filesystem" }`. This keeps watch and repeated runs on the same compiler fast by default, follows webpack's cache default, and makes cross-process persistent cache an explicit opt-in while its invalidation and serialization behavior matures.

--- a/docs/adr/0081-use-category-specific-default-snapshot-strategies.md
+++ b/docs/adr/0081-use-category-specific-default-snapshot-strategies.md
@@ -1,0 +1,3 @@
+# Use category-specific default snapshot strategies
+
+Unpack will default module resource snapshots to timestamp validation and build-dependency snapshots to timestamp plus content-hash validation. Module resources sit on the watch and rebuild hot path, so the default should stay light for local development, while build dependencies change less often and have broader persistent-cache correctness impact; users can enable module hashing explicitly for CI or filesystems where timestamps are unreliable.

--- a/docs/adr/0082-use-json-manifests-and-cbor4ii-cache-packs.md
+++ b/docs/adr/0082-use-json-manifests-and-cbor4ii-cache-packs.md
@@ -1,0 +1,3 @@
+# Use JSON manifests and cbor4ii cache packs
+
+Unpack's persistent cache will store human-inspectable container and manifest metadata as JSON, while cache pack shards will store cache item DTOs with `cbor4ii` CBOR serialization. The cache format is an Unpack-private schema guarded by magic bytes, schema version, and cache version; using CBOR improves evolvability and debuggability compared with a compact Rust-specific binary format, while the schema version avoids treating `cbor4ii`'s Serde mapping as a cross-implementation compatibility promise.

--- a/docs/implementation/watch-and-incremental-build.md
+++ b/docs/implementation/watch-and-incremental-build.md
@@ -1,0 +1,68 @@
+# Watch and Incremental Build Implementation Plan
+
+This plan implements watch, memory cache, and persistent filesystem cache across the Rust core, native Node binding, and JavaScript wrapper. The design is webpack-like without promising webpack API compatibility beyond the explicit JavaScript API shapes recorded in ADRs.
+
+## Target Shape
+
+Unpack should keep `Compilation` as a single bundling attempt while making `Compiler` own reusable state:
+
+1. `Compiler` owns a build cache and creates fresh compilations.
+2. `Compilation` reports assets, errors, and watch dependency sets.
+3. `WatchSession` observes dependency sets and triggers compilations.
+4. `Watching` is the JavaScript handle returned by `compiler.watch`.
+5. Persistent cache writes are queued and flushed during compiler idle.
+
+## Slice 1: Stateful Compiler Boundary
+
+Replace the native `runCompiler(options)` shape with a native compiler handle that can be reused by JavaScript `run`, `watch`, and `close`.
+
+- The TypeScript wrapper still validates and normalizes public options.
+- The native handle owns the Rust `Compiler` lifecycle.
+- `run`, `watch`, and `close` enforce the per-compiler conflict rules from ADR-0076.
+
+## Slice 2: Build Cache and Module Build Records
+
+Introduce a build-cache abstraction before implementing watch.
+
+- Start with memory cache as the default cache layer.
+- Cache module build records as cache items rather than whole compilations.
+- Make the make phase ask the cache before reading and parsing a module.
+- Reassemble module graph and chunk graph for each compilation.
+
+## Slice 3: File Snapshots and Build Dependencies
+
+Add file snapshot validation before persistent cache.
+
+- Support category-specific snapshot strategies for module resources and build dependencies.
+- Default module snapshots to timestamp validation.
+- Default build-dependency snapshots to timestamp plus content-hash validation.
+- Surface normalized cache and snapshot options through the native boundary.
+
+## Slice 4: Persistent Cache Packs
+
+Add filesystem cache as an opt-in cache layer.
+
+- Store persistent cache items in cache packs under a cache location.
+- Store container metadata for cache version, build-dependency snapshot, and cache item metadata.
+- Store manifest metadata as JSON and pack shards as `cbor4ii`-encoded cache DTOs.
+- Queue persistent writes and flush them during compiler idle.
+- Close waits for pending cache flushes or reports infrastructure errors.
+
+## Slice 5: Watch Dependency Sets and Watch Session
+
+Make compilations report watch dependency sets and use them to drive watching.
+
+- Report file dependencies from resolved module resources.
+- Report missing dependencies for unresolved requests where available.
+- Keep context dependencies available for future context module support.
+- Replace watcher subscriptions from each completed compilation.
+- Coalesce invalidations with `aggregateTimeout`.
+
+## Slice 6: JavaScript Watch API
+
+Expose the JavaScript API after the native and core lifecycle is stateful.
+
+- `compiler.watch(watchOptions, handler)` starts a watch session and performs the initial compilation.
+- The returned `Watching` exposes `close(callback)` and `invalidate()`.
+- `watchOptions` initially supports `aggregateTimeout`, `ignored`, and `poll`.
+- `unpack(options, callback)` remains a single run plus automatic compiler close.


### PR DESCRIPTION
## Summary

Documents the agreed watch and incremental build plan for Unpack.

- Adds glossary terms for Watching, Watch Options, Watch Dependency Set, Cache Options, Snapshot Options, and Compiler Running Error
- Supersedes earlier ADRs that excluded watch and limited the JavaScript option surface
- Adds ADRs for the JavaScript watch API, minimal Watching surface, compiler conflict rules, cache/snapshot options, memory cache defaults, snapshot defaults, and persistent cache pack serialization
- Adds the implementation plan for stateful compiler lifecycle, memory cache, snapshots, filesystem cache packs, watch dependency sets, and the JavaScript watch API

## Tracking

- PRD: https://github.com/unpack-dev/unpack/issues/10
- Implementation issues: https://github.com/unpack-dev/unpack/issues/1 through https://github.com/unpack-dev/unpack/issues/9

## Validation

- `git diff --cached --check`
