### PR TITLE
Introduce stateful native Compiler handle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md instructions
+
+When creating GitHub pull requests, do not prefix the PR title with "codex",
+"[codex]", "Codex:", or any other Codex marker. Use a normal human-readable
+title that directly summarizes the change.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs are tracked in GitHub Issues for `unpack-dev/unpack`; external PRs are not a triage request surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the default five-label triage vocabulary: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, and `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context repo: read root `CONTEXT.md` and relevant ADRs under `docs/adr/`. See `docs/agents/domain.md`.

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -1,6 +1,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use napi::{Env, Result, Task, bindgen_prelude::AsyncTask};
@@ -57,13 +58,54 @@ pub struct NativeRunResult {
     pub stats: Option<NativeStatsJson>,
 }
 
-#[napi(js_name = "runCompiler")]
-pub fn run_compiler(options: NativeCompilerOptions) -> AsyncTask<RunCompilerTask> {
-    AsyncTask::new(RunCompilerTask { options })
+#[napi(js_name = "createCompiler")]
+pub fn create_compiler(options: NativeCompilerOptions) -> NativeCompiler {
+    NativeCompiler::new(options)
+}
+
+#[napi]
+pub struct NativeCompiler {
+    compiler: Option<Arc<Compiler>>,
+    output_path: PathBuf,
+}
+
+#[napi]
+impl NativeCompiler {
+    #[napi]
+    pub fn run(&self) -> AsyncTask<RunCompilerTask> {
+        AsyncTask::new(RunCompilerTask {
+            compiler: self.compiler.clone(),
+            output_path: self.output_path.clone(),
+        })
+    }
+
+    #[napi]
+    pub fn close(&mut self) {
+        self.compiler = None;
+    }
+}
+
+impl NativeCompiler {
+    fn new(options: NativeCompilerOptions) -> Self {
+        let context = PathBuf::from(&options.context);
+        let output_path = PathBuf::from(&options.output_path);
+        let entries = options
+            .entries
+            .into_iter()
+            .map(|entry| Entry::new(entry.name, entry.request))
+            .collect::<Vec<_>>();
+        let compiler = Compiler::new(CompilerOptions::new(context, entries));
+
+        Self {
+            compiler: Some(Arc::new(compiler)),
+            output_path,
+        }
+    }
 }
 
 pub struct RunCompilerTask {
-    options: NativeCompilerOptions,
+    compiler: Option<Arc<Compiler>>,
+    output_path: PathBuf,
 }
 
 impl Task for RunCompilerTask {
@@ -71,7 +113,10 @@ impl Task for RunCompilerTask {
     type JsValue = NativeRunResult;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        Ok(run_compiler_inner(&self.options))
+        Ok(run_compiler_inner(
+            self.compiler.as_deref(),
+            &self.output_path,
+        ))
     }
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
@@ -79,16 +124,10 @@ impl Task for RunCompilerTask {
     }
 }
 
-fn run_compiler_inner(options: &NativeCompilerOptions) -> NativeRunResult {
-    let context = PathBuf::from(&options.context);
-    let output_path = PathBuf::from(&options.output_path);
-    let entries = options
-        .entries
-        .iter()
-        .map(|entry| Entry::new(entry.name.clone(), entry.request.clone()))
-        .collect::<Vec<_>>();
-    let compiler = Compiler::new(CompilerOptions::new(context, entries));
-
+fn run_compiler_inner(compiler: Option<&Compiler>, output_path: &Path) -> NativeRunResult {
+    let Some(compiler) = compiler else {
+        return infrastructure_error("CompilerClosedError", "compiler is closed");
+    };
     let runtime = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -106,7 +145,7 @@ fn run_compiler_inner(options: &NativeCompilerOptions) -> NativeRunResult {
         }
     };
 
-    if let Err(error) = emit_assets(&output_path, compilation.assets()) {
+    if let Err(error) = emit_assets(output_path, compilation.assets()) {
         return infrastructure_error("OutputWriteError", error);
     }
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,24 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Layout
+
+This is a single-context repo.
+
+## Before exploring, read these
+
+- `CONTEXT.md` at the repo root.
+- Relevant ADRs under `docs/adr/`.
+
+If either location does not contain relevant context, proceed silently. Do not suggest creating extra documentation upfront; domain docs should be updated when terms or decisions actually get resolved.
+
+## Use the glossary's vocabulary
+
+When output names a domain concept in an issue title, PRD, refactor proposal, hypothesis, or test name, use the term as defined in `CONTEXT.md`. Do not drift to synonyms the glossary explicitly avoids.
+
+If the concept is missing from the glossary, either reconsider whether the language fits this project or note the gap for domain modeling.
+
+## Flag ADR conflicts
+
+If output contradicts an existing ADR, surface that conflict explicitly instead of silently overriding it.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,32 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Repository
+
+Use `unpack-dev/unpack`.
+
+When running `gh` commands from inside this clone, infer the repo from `git remote -v`.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels when needed.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.**
+
+Do not pull external PRs into the `/triage` queue. Treat `/triage` as an issue-only workflow for this repo unless this file is updated.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue in `unpack-dev/unpack`.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments` from inside this repo.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role, use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary this repo actually uses.

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -69,8 +69,13 @@ interface NativeRunResult {
   stats?: NativeStatsJson | null;
 }
 
+interface NativeCompiler {
+  run(): Promise<NativeRunResult>;
+  close(): void;
+}
+
 interface NativeBinding {
-  runCompiler(options: NormalizedOptions): Promise<NativeRunResult>;
+  createCompiler(options: NormalizedOptions): NativeCompiler;
 }
 
 const require = createRequire(import.meta.url);
@@ -79,8 +84,11 @@ const native = require("./unpack_node.node") as NativeBinding;
 class CompilerImpl implements Compiler {
   #closed = false;
   #running = false;
+  readonly #nativeCompiler: NativeCompiler;
 
-  constructor(private readonly options: NormalizedOptions) {}
+  constructor(options: NormalizedOptions) {
+    this.#nativeCompiler = native.createCompiler(options);
+  }
 
   run(callback: RunCallback): void {
     assertFunction(callback, "callback");
@@ -100,7 +108,7 @@ class CompilerImpl implements Compiler {
     this.#running = true;
     let run: Promise<NativeRunResult>;
     try {
-      run = native.runCompiler(this.options);
+      run = this.#nativeCompiler.run();
     } catch (error) {
       this.#running = false;
       defer(() => callback(toError(error, "InfrastructureError")));
@@ -136,8 +144,13 @@ class CompilerImpl implements Compiler {
       return;
     }
 
-    this.#closed = true;
-    defer(() => callback(null));
+    try {
+      this.#nativeCompiler.close();
+      this.#closed = true;
+      defer(() => callback(null));
+    } catch (error) {
+      defer(() => callback(toError(error, "InfrastructureError")));
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Implements the stateful native Compiler handle required by issue #1.

- Replaces the one-shot native `runCompiler(options)` boundary with `createCompiler(options)` returning a native compiler handle
- Moves Rust `Compiler` ownership into the native handle so JavaScript `run` reuses that lifecycle
- Adds native `run()` and `close()` methods while preserving the existing public JavaScript `Compiler` API
- Keeps existing closed-compiler, concurrent-run, auto-close, and callback timing behavior intact

## Tracking

Closes https://github.com/unpack-dev/unpack/issues/1
Parent: https://github.com/unpack-dev/unpack/issues/10

## Validation

- `pnpm --filter @unpack-js/core typecheck`
- `cargo test --workspace`
- `pnpm --filter @unpack-js/core test`
- `pnpm test`
