### PR TITLE
Add memory build cache for module records

### DIFF
--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -1,0 +1,83 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use crate::{ModuleIdentity, parser::ParsedModule};
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct BuildCache {
+    inner: Arc<Mutex<BuildCacheInner>>,
+}
+
+#[derive(Debug, Default)]
+struct BuildCacheInner {
+    module_builds: HashMap<ModuleIdentity, ModuleBuildRecord>,
+    module_hits: usize,
+    module_misses: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ModuleBuildRecord {
+    parsed: ParsedModule,
+    source: String,
+}
+
+impl ModuleBuildRecord {
+    pub(crate) fn new(parsed: ParsedModule, source: String) -> Self {
+        Self { parsed, source }
+    }
+
+    pub(crate) fn parsed(&self) -> &ParsedModule {
+        &self.parsed
+    }
+
+    pub(crate) fn into_parts(self) -> (ParsedModule, String) {
+        (self.parsed, self.source)
+    }
+}
+
+impl BuildCache {
+    pub(crate) fn get_module_build(&self, identity: &ModuleIdentity) -> Option<ModuleBuildRecord> {
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("build cache mutex should not be poisoned");
+        let record = inner.module_builds.get(identity).cloned();
+        if record.is_some() {
+            inner.module_hits += 1;
+        } else {
+            inner.module_misses += 1;
+        }
+        record
+    }
+
+    pub(crate) fn store_module_build(&self, identity: ModuleIdentity, record: ModuleBuildRecord) {
+        self.inner
+            .lock()
+            .expect("build cache mutex should not be poisoned")
+            .module_builds
+            .insert(identity, record);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn stats(&self) -> BuildCacheStats {
+        let inner = self
+            .inner
+            .lock()
+            .expect("build cache mutex should not be poisoned");
+        BuildCacheStats {
+            module_entries: inner.module_builds.len(),
+            module_hits: inner.module_hits,
+            module_misses: inner.module_misses,
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BuildCacheStats {
+    pub module_entries: usize,
+    pub module_hits: usize,
+    pub module_misses: usize,
+}

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -4,6 +4,7 @@ use tokio::sync::Mutex;
 
 use crate::{
     Asset, ChunkGraph, CompilerOptions, Error, ModuleGraph, ModuleId, Result, UnpackResolver,
+    build_cache::BuildCache,
     code_generation,
     make::{self, MakeState},
 };
@@ -12,6 +13,7 @@ use crate::{
 pub struct Compilation {
     options: CompilerOptions,
     resolver: UnpackResolver,
+    build_cache: BuildCache,
     module_graph: ModuleGraph,
     chunk_graph: ChunkGraph,
     assets: Vec<Asset>,
@@ -20,10 +22,15 @@ pub struct Compilation {
 }
 
 impl Compilation {
-    pub(crate) fn new(options: CompilerOptions, resolver: UnpackResolver) -> Self {
+    pub(crate) fn new(
+        options: CompilerOptions,
+        resolver: UnpackResolver,
+        build_cache: BuildCache,
+    ) -> Self {
         Self {
             options,
             resolver,
+            build_cache,
             module_graph: ModuleGraph::default(),
             chunk_graph: ChunkGraph::default(),
             assets: Vec::new(),
@@ -58,7 +65,13 @@ impl Compilation {
 
     pub async fn make(&mut self) -> Result<()> {
         let state = Arc::new(Mutex::new(MakeState::default()));
-        let result = make::run(&self.options, self.resolver.clone(), Arc::clone(&state)).await;
+        let result = make::run(
+            &self.options,
+            self.resolver.clone(),
+            self.build_cache.clone(),
+            Arc::clone(&state),
+        )
+        .await;
 
         let mut state = state.lock().await;
         self.module_graph = std::mem::take(&mut state.module_graph);

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::{Compilation, ResolveOptions, Result, UnpackResolver};
+use crate::{Compilation, ResolveOptions, Result, UnpackResolver, build_cache::BuildCache};
 
 pub const DEFAULT_EXTENSIONS: &[&str] = &[".ts", ".tsx", ".js", ".jsx"];
 
@@ -42,12 +42,17 @@ impl CompilerOptions {
 pub struct Compiler {
     options: CompilerOptions,
     resolver: UnpackResolver,
+    build_cache: BuildCache,
 }
 
 impl Compiler {
     pub fn new(options: CompilerOptions) -> Self {
         let resolver = UnpackResolver::new(options.resolve.clone());
-        Self { options, resolver }
+        Self {
+            options,
+            resolver,
+            build_cache: BuildCache::default(),
+        }
     }
 
     pub fn options(&self) -> &CompilerOptions {
@@ -55,7 +60,11 @@ impl Compiler {
     }
 
     pub fn create_compilation(&self) -> Compilation {
-        Compilation::new(self.options.clone(), self.resolver.clone())
+        Compilation::new(
+            self.options.clone(),
+            self.resolver.clone(),
+            self.build_cache.clone(),
+        )
     }
 
     pub async fn run(&self) -> Result<Compilation> {
@@ -83,5 +92,69 @@ fn normalize_context(context: PathBuf) -> PathBuf {
         std::env::current_dir()
             .map(|cwd| cwd.join(&context))
             .unwrap_or(context)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, fs, path::PathBuf};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn repeated_runs_reuse_memory_module_build_records_without_sharing_compilations()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write(
+            temp.path().join("index.js"),
+            r#"
+                import "./dep";
+                export const result = "ok";
+            "#,
+        )?;
+        write(temp.path().join("dep.js"), "export const value = 1;")?;
+
+        let compiler = Compiler::new(CompilerOptions::new(
+            temp.path(),
+            vec![Entry::new("main", "./index")],
+        ));
+
+        let first = compiler.run().await?;
+        let first_cache = compiler.build_cache.stats();
+        assert_eq!(first_cache.module_entries, 2);
+        assert_eq!(first_cache.module_hits, 0);
+        assert_eq!(first_cache.module_misses, 2);
+
+        let second = compiler.run().await?;
+        let second_cache = compiler.build_cache.stats();
+        assert_eq!(second_cache.module_entries, 2);
+        assert_eq!(second_cache.module_hits, 2);
+        assert_eq!(second_cache.module_misses, 2);
+
+        assert_eq!(first.errors(), []);
+        assert_eq!(second.errors(), []);
+        assert_eq!(asset_sources(&first), asset_sources(&second));
+        assert_eq!(first.module_graph(), second.module_graph());
+        assert_ne!(
+            first.module_graph().modules().as_ptr(),
+            second.module_graph().modules().as_ptr()
+        );
+
+        Ok(())
+    }
+
+    fn write(path: PathBuf, source: &str) -> std::io::Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(path, source)
+    }
+
+    fn asset_sources(compilation: &Compilation) -> BTreeMap<String, String> {
+        compilation
+            .assets()
+            .iter()
+            .map(|asset| (asset.filename.clone(), asset.source.clone()))
+            .collect()
     }
 }

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -1,3 +1,4 @@
+mod build_cache;
 mod chunk_graph;
 mod code_generation;
 mod compilation;

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -10,6 +10,7 @@ use tokio::sync::{Mutex, Semaphore};
 use crate::{
     CompilerOptions, Dependency, DependencyKind, Error, ModuleGraph, ModuleId, ModuleIdentity,
     NormalModuleFactory, Result, UnpackResolver,
+    build_cache::{BuildCache, ModuleBuildRecord},
     parser::{ParsedModule, parse_module_dependencies},
 };
 
@@ -24,6 +25,7 @@ pub(crate) struct MakeState {
 #[derive(Debug, Clone)]
 struct MakeServices {
     factory: NormalModuleFactory,
+    build_cache: BuildCache,
     semaphore: Arc<Semaphore>,
 }
 
@@ -45,10 +47,12 @@ struct AddModuleResult {
 pub(crate) async fn run(
     options: &CompilerOptions,
     resolver: UnpackResolver,
+    build_cache: BuildCache,
     state: Arc<Mutex<MakeState>>,
 ) -> Result<()> {
     let services = MakeServices {
         factory: NormalModuleFactory::new(resolver),
+        build_cache,
         semaphore: Arc::new(Semaphore::new(options.parallelism.max(1))),
     };
 
@@ -137,12 +141,28 @@ async fn process_request(
             request.entry_index,
             request.origin_block,
             request.dependency,
-            identity,
+            identity.clone(),
         )
     };
 
     if !add_result.is_new {
         return Ok(Vec::new());
+    }
+
+    let issuer_context = resource
+        .parent()
+        .ok_or(Error::MissingModuleDirectory(add_result.module_id))?
+        .to_path_buf();
+
+    if let Some(record) = services.build_cache.get_module_build(&identity) {
+        let children =
+            module_build_children(add_result.module_id, &issuer_context, record.parsed());
+        let (parsed, source) = record.into_parts();
+        state
+            .lock()
+            .await
+            .finish_build(add_result.module_id, parsed, source)?;
+        return Ok(children);
     }
 
     let source = match tokio::fs::read_to_string(&resource).await {
@@ -167,11 +187,24 @@ async fn process_request(
         }
         Err(error) => return Err(error),
     };
-    let issuer_context = resource
-        .parent()
-        .ok_or(Error::MissingModuleDirectory(add_result.module_id))?
-        .to_path_buf();
+    let children = module_build_children(add_result.module_id, &issuer_context, &parsed);
+    let record = ModuleBuildRecord::new(parsed.clone(), source.clone());
 
+    state
+        .lock()
+        .await
+        .finish_build(add_result.module_id, parsed, source)?;
+    services.build_cache.store_module_build(identity, record);
+
+    Ok(children)
+}
+
+fn module_build_children(
+    module_id: ModuleId,
+    issuer_context: &Path,
+    parsed: &ParsedModule,
+) -> Vec<MakeRequest> {
+    let issuer_context = issuer_context.to_path_buf();
     let mut children = parsed
         .dependencies
         .iter()
@@ -179,7 +212,7 @@ async fn process_request(
         .cloned()
         .map(|dependency| MakeRequest {
             entry_index: None,
-            origin_module: Some(add_result.module_id),
+            origin_module: Some(module_id),
             origin_block: None,
             context: issuer_context.clone(),
             dependency,
@@ -195,7 +228,7 @@ async fn process_request(
                 .cloned()
                 .map(|dependency| MakeRequest {
                     entry_index: None,
-                    origin_module: Some(add_result.module_id),
+                    origin_module: Some(module_id),
                     origin_block: Some(block_index),
                     context: issuer_context.clone(),
                     dependency,
@@ -203,12 +236,7 @@ async fn process_request(
         );
     }
 
-    state
-        .lock()
-        .await
-        .finish_build(add_result.module_id, parsed, source)?;
-
-    Ok(children)
+    children
 }
 
 fn failed_module_identity(context: &Path, dependency: &Dependency) -> ModuleIdentity {

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -91,7 +91,8 @@ test("unpack options callback closes the returned compiler", async () => {
 
 test("manual compiler remains reusable until close", async () => {
   const fixture = await createFixture({
-    "src/index.js": "export const value = 1;"
+    "src/index.js": "import './dep'; export const value = 1;",
+    "src/dep.js": "globalThis.__unpackDep = true;"
   });
 
   try {
@@ -102,8 +103,12 @@ test("manual compiler remains reusable until close", async () => {
       }
     );
 
-    assert.equal((await runExistingCompiler(compiler)).err, null);
-    assert.equal((await runExistingCompiler(compiler)).err, null);
+    const first = await runExistingCompiler(compiler);
+    const second = await runExistingCompiler(compiler);
+    assert.equal(first.err, null);
+    assert.equal(second.err, null);
+    assert.deepEqual(second.stats?.toJson(), first.stats?.toJson());
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /__unpackDep/);
     await closeCompiler(compiler);
     assert.equal((await runExistingCompiler(compiler)).err?.name, "CompilerClosedError");
   } finally {


### PR DESCRIPTION
## Summary

- Add a compiler-owned in-memory Build Cache keyed by module identity.
- Store reusable module build records as parsed module data plus source, not whole compilations.
- Reuse cached module build records in the make phase while each Compilation still assembles fresh graphs and assets.
- Tighten the JavaScript repeated-run test to compare Stats output and emitted bundle content.

Note: public cache and snapshot option normalization remains scoped to issue #4; this PR implements the default internal memory cache layer for repeated runs on the same compiler.

## Validation

- cargo fmt --all --check
- cargo test --workspace
- pnpm --filter @unpack-js/core typecheck
- pnpm --filter @unpack-js/core test
- pnpm test

Closes #2