### PR TITLE
Validate module cache records with snapshots

### DIFF
--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -1,9 +1,10 @@
 use std::{
     collections::HashMap,
+    path::Path,
     sync::{Arc, Mutex},
 };
 
-use crate::{ModuleIdentity, parser::ParsedModule};
+use crate::{ModuleIdentity, SnapshotStrategy, parser::ParsedModule, snapshot::FileSnapshot};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct BuildCache {
@@ -21,11 +22,16 @@ struct BuildCacheInner {
 pub(crate) struct ModuleBuildRecord {
     parsed: ParsedModule,
     source: String,
+    snapshot: FileSnapshot,
 }
 
 impl ModuleBuildRecord {
-    pub(crate) fn new(parsed: ParsedModule, source: String) -> Self {
-        Self { parsed, source }
+    pub(crate) fn new(parsed: ParsedModule, source: String, snapshot: FileSnapshot) -> Self {
+        Self {
+            parsed,
+            source,
+            snapshot,
+        }
     }
 
     pub(crate) fn parsed(&self) -> &ParsedModule {
@@ -34,6 +40,10 @@ impl ModuleBuildRecord {
 
     pub(crate) fn into_parts(self) -> (ParsedModule, String) {
         (self.parsed, self.source)
+    }
+
+    pub(crate) async fn is_valid(&self, path: &Path, strategy: SnapshotStrategy) -> bool {
+        self.snapshot.is_valid(path, strategy).await
     }
 }
 

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
-use crate::{Compilation, ResolveOptions, Result, UnpackResolver, build_cache::BuildCache};
+use crate::{
+    Compilation, ResolveOptions, Result, SnapshotOptions, UnpackResolver, build_cache::BuildCache,
+};
 
 pub const DEFAULT_EXTENSIONS: &[&str] = &[".ts", ".tsx", ".js", ".jsx"];
 
@@ -24,6 +26,7 @@ pub struct CompilerOptions {
     pub context: PathBuf,
     pub entries: Vec<Entry>,
     pub resolve: ResolveOptions,
+    pub snapshot: SnapshotOptions,
     pub parallelism: usize,
 }
 
@@ -33,6 +36,7 @@ impl CompilerOptions {
             context: normalize_context(context.into()),
             entries,
             resolve: default_resolve_options(),
+            snapshot: SnapshotOptions::default(),
             parallelism: 100,
         }
     }
@@ -97,7 +101,7 @@ fn normalize_context(context: PathBuf) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeMap, fs, path::PathBuf};
+    use std::{collections::BTreeMap, fs, path::Path};
 
     use super::*;
 
@@ -143,7 +147,40 @@ mod tests {
         Ok(())
     }
 
-    fn write(path: PathBuf, source: &str) -> std::io::Result<()> {
+    #[tokio::test]
+    async fn hash_module_snapshot_strategy_invalidates_changed_source()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let entry = temp.path().join("index.js");
+        write(&entry, "export const value = 'before';")?;
+
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.snapshot.module = crate::SnapshotStrategy::hash();
+        let compiler = Compiler::new(options);
+
+        let first = compiler.run().await?;
+        assert!(
+            asset_sources(&first)
+                .get("main.js")
+                .expect("main asset should exist")
+                .contains("before")
+        );
+
+        write(&entry, "export const value = 'after';")?;
+
+        let second = compiler.run().await?;
+        assert!(
+            asset_sources(&second)
+                .get("main.js")
+                .expect("main asset should exist")
+                .contains("after")
+        );
+
+        Ok(())
+    }
+
+    fn write(path: impl AsRef<Path>, source: &str) -> std::io::Result<()> {
+        let path = path.as_ref();
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -12,6 +12,7 @@ mod module_graph;
 mod normal_module_factory;
 mod parser;
 mod resolver;
+mod snapshot;
 
 pub use chunk_graph::{
     AsyncBlockOrigin, Chunk, ChunkGraph, ChunkGroup, ChunkGroupId, ChunkGroupKind, ChunkId,
@@ -32,3 +33,4 @@ pub use module::{Module, ModuleId, ModuleIdentity, ModuleType};
 pub use module_graph::{ModuleGraph, ModuleGraphConnection};
 pub use normal_module_factory::{FactorizedModule, NormalModuleFactory};
 pub use resolver::{ResolveOptions, ResolvedResource, UnpackResolver};
+pub use snapshot::{SnapshotOptions, SnapshotStrategy};

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -9,9 +9,10 @@ use tokio::sync::{Mutex, Semaphore};
 
 use crate::{
     CompilerOptions, Dependency, DependencyKind, Error, ModuleGraph, ModuleId, ModuleIdentity,
-    NormalModuleFactory, Result, UnpackResolver,
+    NormalModuleFactory, Result, SnapshotStrategy, UnpackResolver,
     build_cache::{BuildCache, ModuleBuildRecord},
     parser::{ParsedModule, parse_module_dependencies},
+    snapshot::FileSnapshot,
 };
 
 #[derive(Debug, Default)]
@@ -26,6 +27,7 @@ pub(crate) struct MakeState {
 struct MakeServices {
     factory: NormalModuleFactory,
     build_cache: BuildCache,
+    module_snapshot_strategy: SnapshotStrategy,
     semaphore: Arc<Semaphore>,
 }
 
@@ -53,6 +55,7 @@ pub(crate) async fn run(
     let services = MakeServices {
         factory: NormalModuleFactory::new(resolver),
         build_cache,
+        module_snapshot_strategy: options.snapshot.module,
         semaphore: Arc::new(Semaphore::new(options.parallelism.max(1))),
     };
 
@@ -155,14 +158,19 @@ async fn process_request(
         .to_path_buf();
 
     if let Some(record) = services.build_cache.get_module_build(&identity) {
-        let children =
-            module_build_children(add_result.module_id, &issuer_context, record.parsed());
-        let (parsed, source) = record.into_parts();
-        state
-            .lock()
+        if record
+            .is_valid(&resource, services.module_snapshot_strategy)
             .await
-            .finish_build(add_result.module_id, parsed, source)?;
-        return Ok(children);
+        {
+            let children =
+                module_build_children(add_result.module_id, &issuer_context, record.parsed());
+            let (parsed, source) = record.into_parts();
+            state
+                .lock()
+                .await
+                .finish_build(add_result.module_id, parsed, source)?;
+            return Ok(children);
+        }
     }
 
     let source = match tokio::fs::read_to_string(&resource).await {
@@ -188,7 +196,9 @@ async fn process_request(
         Err(error) => return Err(error),
     };
     let children = module_build_children(add_result.module_id, &issuer_context, &parsed);
-    let record = ModuleBuildRecord::new(parsed.clone(), source.clone());
+    let snapshot =
+        FileSnapshot::create(&resource, &source, services.module_snapshot_strategy).await?;
+    let record = ModuleBuildRecord::new(parsed.clone(), source.clone(), snapshot);
 
     state
         .lock()

--- a/crates/unpack_core/src/snapshot.rs
+++ b/crates/unpack_core/src/snapshot.rs
@@ -1,0 +1,112 @@
+use std::{path::Path, time::SystemTime};
+
+use crate::{Error, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotOptions {
+    pub module: SnapshotStrategy,
+}
+
+impl Default for SnapshotOptions {
+    fn default() -> Self {
+        Self {
+            module: SnapshotStrategy::timestamp(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotStrategy {
+    pub timestamp: bool,
+    pub hash: bool,
+}
+
+impl SnapshotStrategy {
+    pub const fn timestamp() -> Self {
+        Self {
+            timestamp: true,
+            hash: false,
+        }
+    }
+
+    pub const fn hash() -> Self {
+        Self {
+            timestamp: false,
+            hash: true,
+        }
+    }
+
+    pub const fn timestamp_and_hash() -> Self {
+        Self {
+            timestamp: true,
+            hash: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FileSnapshot {
+    modified: Option<SystemTime>,
+    source_hash: Option<u64>,
+}
+
+impl FileSnapshot {
+    pub(crate) async fn create(
+        path: &Path,
+        source: &str,
+        strategy: SnapshotStrategy,
+    ) -> Result<Self> {
+        let modified = if strategy.timestamp {
+            let metadata = tokio::fs::metadata(path)
+                .await
+                .map_err(|error| Error::read(path, error))?;
+            Some(
+                metadata
+                    .modified()
+                    .map_err(|error| Error::read(path, error))?,
+            )
+        } else {
+            None
+        };
+        let source_hash = strategy.hash.then(|| hash_source(source));
+
+        Ok(Self {
+            modified,
+            source_hash,
+        })
+    }
+
+    pub(crate) async fn is_valid(&self, path: &Path, strategy: SnapshotStrategy) -> bool {
+        if strategy.timestamp {
+            let Ok(metadata) = tokio::fs::metadata(path).await else {
+                return false;
+            };
+            let Ok(modified) = metadata.modified() else {
+                return false;
+            };
+            if Some(modified) != self.modified {
+                return false;
+            }
+        }
+
+        if strategy.hash {
+            let Ok(source) = tokio::fs::read_to_string(path).await else {
+                return false;
+            };
+            if Some(hash_source(&source)) != self.source_hash {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+fn hash_source(source: &str) -> u64 {
+    let mut hash = 0xcbf29ce484222325;
+    for byte in source.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -112,6 +112,31 @@ test("manual compiler remains reusable until close", async () => {
     await closeCompiler(compiler);
     assert.equal((await runExistingCompiler(compiler)).err?.name, "CompilerClosedError");
   } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("manual compiler rerun emits source edits", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 'before';"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+  const entry = join(fixture, "src/index.js");
+
+  try {
+    const first = await runExistingCompiler(compiler);
+    assert.equal(first.err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /before/);
+
+    await writeFile(entry, "export const value = 'after';", { encoding: "utf8" });
+    const changedTime = new Date(Date.now() + 2000);
+    await utimes(entry, changedTime, changedTime);
+
+    const second = await runExistingCompiler(compiler);
+    assert.equal(second.err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /after/);
+  } finally {
+    await closeCompiler(compiler);
     await rm(fixture, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

- Add core Snapshot Options and Snapshot Strategy types for module resources, defaulting module validation to timestamp checks.
- Store File Snapshot validation data on module build records and validate cached records before make phase reuse.
- Rebuild invalid module records on repeated non-watch runs so source edits emit updated assets.
- Add JS API coverage for repeated compiler runs after source edits and Rust core coverage for hash-based module snapshot invalidation.

Public JavaScript cache and snapshot option normalization remains scoped to issue #4.

## Validation

- cargo fmt --all --check
- cargo test --workspace
- pnpm --filter @unpack-js/core typecheck
- pnpm test

Closes #3