### PR TITLE
Expose cache and snapshot options

### DIFF
--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    path::Path,
+    path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
 
@@ -8,7 +8,80 @@ use crate::{ModuleIdentity, SnapshotStrategy, parser::ParsedModule, snapshot::Fi
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct BuildCache {
+    options: CacheOptions,
     inner: Arc<Mutex<BuildCacheInner>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CacheOptions {
+    pub kind: CacheKind,
+    pub cache_directory: Option<PathBuf>,
+    pub cache_location: Option<PathBuf>,
+    pub name: Option<String>,
+    pub version: Option<String>,
+    pub build_dependencies: Vec<BuildDependency>,
+    pub max_memory_generations: Option<u32>,
+    pub idle_timeout: Option<u32>,
+}
+
+impl Default for CacheOptions {
+    fn default() -> Self {
+        Self::memory()
+    }
+}
+
+impl CacheOptions {
+    pub fn disabled() -> Self {
+        Self {
+            kind: CacheKind::Disabled,
+            cache_directory: None,
+            cache_location: None,
+            name: None,
+            version: None,
+            build_dependencies: Vec::new(),
+            max_memory_generations: None,
+            idle_timeout: None,
+        }
+    }
+
+    pub fn memory() -> Self {
+        Self {
+            kind: CacheKind::Memory,
+            cache_directory: None,
+            cache_location: None,
+            name: None,
+            version: None,
+            build_dependencies: Vec::new(),
+            max_memory_generations: None,
+            idle_timeout: None,
+        }
+    }
+
+    pub fn filesystem() -> Self {
+        Self {
+            kind: CacheKind::Filesystem,
+            cache_directory: None,
+            cache_location: None,
+            name: None,
+            version: None,
+            build_dependencies: Vec::new(),
+            max_memory_generations: None,
+            idle_timeout: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheKind {
+    Disabled,
+    Memory,
+    Filesystem,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildDependency {
+    pub name: String,
+    pub files: Vec<PathBuf>,
 }
 
 #[derive(Debug, Default)]
@@ -48,7 +121,18 @@ impl ModuleBuildRecord {
 }
 
 impl BuildCache {
+    pub(crate) fn new(options: CacheOptions) -> Self {
+        Self {
+            options,
+            inner: Arc::new(Mutex::new(BuildCacheInner::default())),
+        }
+    }
+
     pub(crate) fn get_module_build(&self, identity: &ModuleIdentity) -> Option<ModuleBuildRecord> {
+        if self.options.kind == CacheKind::Disabled {
+            return None;
+        }
+
         let mut inner = self
             .inner
             .lock()
@@ -63,6 +147,10 @@ impl BuildCache {
     }
 
     pub(crate) fn store_module_build(&self, identity: ModuleIdentity, record: ModuleBuildRecord) {
+        if self.options.kind == CacheKind::Disabled {
+            return;
+        }
+
         self.inner
             .lock()
             .expect("build cache mutex should not be poisoned")

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
 use crate::{
-    Compilation, ResolveOptions, Result, SnapshotOptions, UnpackResolver, build_cache::BuildCache,
+    CacheOptions, Compilation, ResolveOptions, Result, SnapshotOptions, UnpackResolver,
+    build_cache::BuildCache,
 };
 
 pub const DEFAULT_EXTENSIONS: &[&str] = &[".ts", ".tsx", ".js", ".jsx"];
@@ -25,6 +26,7 @@ impl Entry {
 pub struct CompilerOptions {
     pub context: PathBuf,
     pub entries: Vec<Entry>,
+    pub cache: CacheOptions,
     pub resolve: ResolveOptions,
     pub snapshot: SnapshotOptions,
     pub parallelism: usize,
@@ -35,6 +37,7 @@ impl CompilerOptions {
         Self {
             context: normalize_context(context.into()),
             entries,
+            cache: CacheOptions::default(),
             resolve: default_resolve_options(),
             snapshot: SnapshotOptions::default(),
             parallelism: 100,
@@ -52,10 +55,11 @@ pub struct Compiler {
 impl Compiler {
     pub fn new(options: CompilerOptions) -> Self {
         let resolver = UnpackResolver::new(options.resolve.clone());
+        let build_cache = BuildCache::new(options.cache.clone());
         Self {
             options,
             resolver,
-            build_cache: BuildCache::default(),
+            build_cache,
         }
     }
 

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -14,6 +14,7 @@ mod parser;
 mod resolver;
 mod snapshot;
 
+pub use build_cache::{BuildDependency, CacheKind, CacheOptions};
 pub use chunk_graph::{
     AsyncBlockOrigin, Chunk, ChunkGraph, ChunkGroup, ChunkGroupId, ChunkGroupKind, ChunkId,
 };

--- a/crates/unpack_core/src/snapshot.rs
+++ b/crates/unpack_core/src/snapshot.rs
@@ -5,12 +5,14 @@ use crate::{Error, Result};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SnapshotOptions {
     pub module: SnapshotStrategy,
+    pub build_dependencies: SnapshotStrategy,
 }
 
 impl Default for SnapshotOptions {
     fn default() -> Self {
         Self {
             module: SnapshotStrategy::timestamp(),
+            build_dependencies: SnapshotStrategy::timestamp_and_hash(),
         }
     }
 }

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -6,7 +6,10 @@ use std::{
 
 use napi::{Env, Result, Task, bindgen_prelude::AsyncTask};
 use napi_derive::napi;
-use unpack_core::{Asset, Compiler, CompilerOptions, Entry, Error as CoreError};
+use unpack_core::{
+    Asset, BuildDependency, CacheOptions, Compiler, CompilerOptions, Entry, Error as CoreError,
+    SnapshotOptions, SnapshotStrategy,
+};
 
 #[napi(object)]
 pub struct NativeEntry {
@@ -20,6 +23,45 @@ pub struct NativeCompilerOptions {
     pub entries: Vec<NativeEntry>,
     #[napi(js_name = "outputPath")]
     pub output_path: String,
+    pub cache: NativeCacheOptions,
+    pub snapshot: NativeSnapshotOptions,
+}
+
+#[napi(object)]
+pub struct NativeCacheOptions {
+    #[napi(js_name = "type")]
+    pub cache_type: String,
+    #[napi(js_name = "cacheDirectory")]
+    pub cache_directory: Option<String>,
+    #[napi(js_name = "cacheLocation")]
+    pub cache_location: Option<String>,
+    pub name: Option<String>,
+    pub version: Option<String>,
+    #[napi(js_name = "buildDependencies")]
+    pub build_dependencies: Vec<NativeBuildDependency>,
+    #[napi(js_name = "maxMemoryGenerations")]
+    pub max_memory_generations: Option<u32>,
+    #[napi(js_name = "idleTimeout")]
+    pub idle_timeout: Option<u32>,
+}
+
+#[napi(object)]
+pub struct NativeBuildDependency {
+    pub name: String,
+    pub files: Vec<String>,
+}
+
+#[napi(object)]
+pub struct NativeSnapshotOptions {
+    pub module: NativeSnapshotStrategy,
+    #[napi(js_name = "buildDependencies")]
+    pub build_dependencies: NativeSnapshotStrategy,
+}
+
+#[napi(object)]
+pub struct NativeSnapshotStrategy {
+    pub timestamp: bool,
+    pub hash: bool,
 }
 
 #[napi(object)]
@@ -94,12 +136,52 @@ impl NativeCompiler {
             .into_iter()
             .map(|entry| Entry::new(entry.name, entry.request))
             .collect::<Vec<_>>();
-        let compiler = Compiler::new(CompilerOptions::new(context, entries));
+        let mut compiler_options = CompilerOptions::new(context, entries);
+        compiler_options.cache = cache_options_from_native(options.cache);
+        compiler_options.snapshot = snapshot_options_from_native(options.snapshot);
+        let compiler = Compiler::new(compiler_options);
 
         Self {
             compiler: Some(Arc::new(compiler)),
             output_path,
         }
+    }
+}
+
+fn cache_options_from_native(options: NativeCacheOptions) -> CacheOptions {
+    let mut cache = match options.cache_type.as_str() {
+        "disabled" => CacheOptions::disabled(),
+        "filesystem" => CacheOptions::filesystem(),
+        _ => CacheOptions::memory(),
+    };
+    cache.cache_directory = options.cache_directory.map(PathBuf::from);
+    cache.cache_location = options.cache_location.map(PathBuf::from);
+    cache.name = options.name;
+    cache.version = options.version;
+    cache.build_dependencies = options
+        .build_dependencies
+        .into_iter()
+        .map(|dependency| BuildDependency {
+            name: dependency.name,
+            files: dependency.files.into_iter().map(PathBuf::from).collect(),
+        })
+        .collect();
+    cache.max_memory_generations = options.max_memory_generations;
+    cache.idle_timeout = options.idle_timeout;
+    cache
+}
+
+fn snapshot_options_from_native(options: NativeSnapshotOptions) -> SnapshotOptions {
+    SnapshotOptions {
+        module: snapshot_strategy_from_native(options.module),
+        build_dependencies: snapshot_strategy_from_native(options.build_dependencies),
+    }
+}
+
+fn snapshot_strategy_from_native(strategy: NativeSnapshotStrategy) -> SnapshotStrategy {
+    SnapshotStrategy {
+        timestamp: strategy.timestamp,
+        hash: strategy.hash,
     }
 }
 

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -7,6 +7,31 @@ export interface UnpackOptions {
   output?: {
     path?: string;
   };
+  cache?: CacheOptions;
+  snapshot?: SnapshotOptions;
+}
+
+export type CacheOptions =
+  | boolean
+  | {
+      type?: "memory" | "filesystem";
+      cacheDirectory?: string;
+      cacheLocation?: string;
+      name?: string;
+      version?: string;
+      buildDependencies?: Record<string, string[]>;
+      maxMemoryGenerations?: number;
+      idleTimeout?: number;
+    };
+
+export interface SnapshotOptions {
+  module?: SnapshotStrategyOptions;
+  buildDependencies?: SnapshotStrategyOptions;
+}
+
+export interface SnapshotStrategyOptions {
+  timestamp?: boolean;
+  hash?: boolean;
 }
 
 export interface StatsError {
@@ -51,6 +76,34 @@ interface NormalizedOptions {
   context: string;
   entries: NormalizedEntry[];
   outputPath: string;
+  cache: NormalizedCacheOptions;
+  snapshot: NormalizedSnapshotOptions;
+}
+
+interface NormalizedCacheOptions {
+  type: "disabled" | "memory" | "filesystem";
+  cacheDirectory?: string;
+  cacheLocation?: string;
+  name?: string;
+  version?: string;
+  buildDependencies: NormalizedBuildDependency[];
+  maxMemoryGenerations?: number;
+  idleTimeout?: number;
+}
+
+interface NormalizedBuildDependency {
+  name: string;
+  files: string[];
+}
+
+interface NormalizedSnapshotOptions {
+  module: NormalizedSnapshotStrategy;
+  buildDependencies: NormalizedSnapshotStrategy;
+}
+
+interface NormalizedSnapshotStrategy {
+  timestamp: boolean;
+  hash: boolean;
 }
 
 interface NativeStatsJson {
@@ -192,7 +245,7 @@ export default function unpack(
 
 function normalizeOptions(options: UnpackOptions): NormalizedOptions {
   assertPlainObject(options, "options");
-  assertKnownKeys(options, ["context", "entry", "output"], "options");
+  assertKnownKeys(options, ["context", "entry", "output", "cache", "snapshot"], "options");
 
   const context =
     options.context === undefined
@@ -214,7 +267,9 @@ function normalizeOptions(options: UnpackOptions): NormalizedOptions {
   return {
     context: normalizedContext,
     entries: normalizeEntry(options.entry),
-    outputPath
+    outputPath,
+    cache: normalizeCacheOptions(options.cache, normalizedContext),
+    snapshot: normalizeSnapshotOptions(options.snapshot)
   };
 }
 
@@ -236,6 +291,158 @@ function normalizeEntry(entry: UnpackOptions["entry"]): NormalizedEntry[] {
   }
 
   return entries;
+}
+
+function normalizeCacheOptions(
+  cache: CacheOptions | undefined,
+  context: string
+): NormalizedCacheOptions {
+  if (cache === undefined || cache === true) {
+    return {
+      type: "memory",
+      buildDependencies: []
+    };
+  }
+
+  if (cache === false) {
+    return {
+      type: "disabled",
+      buildDependencies: []
+    };
+  }
+
+  if (typeof cache !== "object" || cache === null || Array.isArray(cache)) {
+    throw new TypeError("options.cache must be a boolean or an object");
+  }
+
+  assertKnownKeys(
+    cache,
+    [
+      "type",
+      "cacheDirectory",
+      "cacheLocation",
+      "name",
+      "version",
+      "buildDependencies",
+      "maxMemoryGenerations",
+      "idleTimeout"
+    ],
+    "options.cache"
+  );
+
+  const type = cache.type === undefined ? "memory" : assertCacheType(cache.type);
+  const name =
+    cache.name === undefined ? undefined : assertNonEmptyString(cache.name, "options.cache.name");
+  const cacheDirectory =
+    cache.cacheDirectory === undefined
+      ? type === "filesystem"
+        ? resolve(context, "node_modules/.cache/unpack")
+        : undefined
+      : normalizePath(cache.cacheDirectory, "options.cache.cacheDirectory", context);
+  const cacheLocation =
+    cache.cacheLocation === undefined
+      ? type === "filesystem" && cacheDirectory
+        ? resolve(cacheDirectory, name ?? "default")
+        : undefined
+      : normalizePath(cache.cacheLocation, "options.cache.cacheLocation", context);
+
+  return {
+    type,
+    ...(cacheDirectory === undefined ? {} : { cacheDirectory }),
+    ...(cacheLocation === undefined ? {} : { cacheLocation }),
+    ...(name === undefined ? {} : { name }),
+    ...(cache.version === undefined
+      ? {}
+      : { version: assertString(cache.version, "options.cache.version") }),
+    buildDependencies: normalizeBuildDependencies(cache.buildDependencies, context),
+    ...(cache.maxMemoryGenerations === undefined
+      ? {}
+      : {
+          maxMemoryGenerations: assertNonNegativeInteger(
+            cache.maxMemoryGenerations,
+            "options.cache.maxMemoryGenerations"
+          )
+        }),
+    ...(cache.idleTimeout === undefined
+      ? {}
+      : {
+          idleTimeout: assertNonNegativeInteger(
+            cache.idleTimeout,
+            "options.cache.idleTimeout"
+          )
+        })
+  };
+}
+
+function normalizeBuildDependencies(
+  buildDependencies: Record<string, string[]> | undefined,
+  context: string
+): NormalizedBuildDependency[] {
+  if (buildDependencies === undefined) {
+    return [];
+  }
+
+  assertPlainObject(buildDependencies, "options.cache.buildDependencies");
+  return Object.entries(buildDependencies).map(([name, files]) => {
+    if (!Array.isArray(files)) {
+      throw new TypeError(`options.cache.buildDependencies.${name} must be an array`);
+    }
+    return {
+      name,
+      files: files.map((file, index) =>
+        normalizePath(file, `options.cache.buildDependencies.${name}[${index}]`, context)
+      )
+    };
+  });
+}
+
+function normalizeSnapshotOptions(
+  snapshot: SnapshotOptions | undefined
+): NormalizedSnapshotOptions {
+  if (snapshot === undefined) {
+    return {
+      module: { timestamp: true, hash: false },
+      buildDependencies: { timestamp: true, hash: true }
+    };
+  }
+
+  assertPlainObject(snapshot, "options.snapshot");
+  assertKnownKeys(snapshot, ["module", "buildDependencies"], "options.snapshot");
+
+  return {
+    module: normalizeSnapshotStrategy(snapshot.module, "options.snapshot.module", {
+      timestamp: true,
+      hash: false
+    }),
+    buildDependencies: normalizeSnapshotStrategy(
+      snapshot.buildDependencies,
+      "options.snapshot.buildDependencies",
+      {
+        timestamp: true,
+        hash: true
+      }
+    )
+  };
+}
+
+function normalizeSnapshotStrategy(
+  strategy: unknown,
+  name: string,
+  defaults: NormalizedSnapshotStrategy
+): NormalizedSnapshotStrategy {
+  if (strategy === undefined) {
+    return { ...defaults };
+  }
+
+  assertPlainObject(strategy, name);
+  assertKnownKeys(strategy, ["timestamp", "hash"], name);
+  return {
+    timestamp:
+      strategy.timestamp === undefined
+        ? defaults.timestamp
+        : assertBoolean(strategy.timestamp, `${name}.timestamp`),
+    hash: strategy.hash === undefined ? defaults.hash : assertBoolean(strategy.hash, `${name}.hash`)
+  };
 }
 
 function normalizeNativeStats(stats: NativeStatsJson | null | undefined): StatsJson {
@@ -285,6 +492,36 @@ function assertPlainObject(value: unknown, name: string): asserts value is Recor
 function assertString(value: unknown, name: string): string {
   if (typeof value !== "string") {
     throw new TypeError(`${name} must be a string`);
+  }
+  return value;
+}
+
+function normalizePath(value: unknown, name: string, context: string): string {
+  const path = assertString(value, name);
+  return isAbsolute(path) ? path : resolve(context, path);
+}
+
+function assertCacheType(value: unknown): "memory" | "filesystem" {
+  if (value !== "memory" && value !== "filesystem") {
+    throw new TypeError("options.cache.type must be 'memory' or 'filesystem'");
+  }
+  return value;
+}
+
+function assertBoolean(value: unknown, name: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new TypeError(`${name} must be a boolean`);
+  }
+  return value;
+}
+
+function assertNonNegativeInteger(value: unknown, name: string): number {
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    value < 0
+  ) {
+    throw new TypeError(`${name} must be a non-negative integer`);
   }
   return value;
 }

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -141,6 +141,104 @@ test("manual compiler rerun emits source edits", async () => {
   }
 });
 
+test("cache false disables module build cache reuse", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 'before';"
+  });
+  const entry = join(fixture, "src/index.js");
+  const stableTime = new Date("2020-01-01T00:00:00.000Z");
+  await utimes(entry, stableTime, stableTime);
+  const compiler = unpack({
+    context: fixture,
+    entry: "./src/index.js",
+    cache: false
+  });
+
+  try {
+    const first = await runExistingCompiler(compiler);
+    assert.equal(first.err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /before/);
+
+    await writeFile(entry, "export const value = 'after';", { encoding: "utf8" });
+    await utimes(entry, stableTime, stableTime);
+
+    const second = await runExistingCompiler(compiler);
+    assert.equal(second.err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /after/);
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("snapshot module hash detects same-timestamp source edits", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 'before';"
+  });
+  const entry = join(fixture, "src/index.js");
+  const stableTime = new Date("2020-01-01T00:00:00.000Z");
+  await utimes(entry, stableTime, stableTime);
+  const compiler = unpack({
+    context: fixture,
+    entry: "./src/index.js",
+    cache: true,
+    snapshot: {
+      module: { timestamp: false, hash: true },
+      buildDependencies: { timestamp: true, hash: true }
+    }
+  });
+
+  try {
+    const first = await runExistingCompiler(compiler);
+    assert.equal(first.err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /before/);
+
+    await writeFile(entry, "export const value = 'after';", { encoding: "utf8" });
+    await utimes(entry, stableTime, stableTime);
+
+    const second = await runExistingCompiler(compiler);
+    assert.equal(second.err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /after/);
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("accepts filesystem cache option shape", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;",
+    "config/build.js": "export default {};"
+  });
+
+  try {
+    const { err, stats } = await runCompiler({
+      context: fixture,
+      entry: "./src/index.js",
+      cache: {
+        type: "filesystem",
+        cacheDirectory: ".cache/unpack",
+        name: "test-cache",
+        version: "v1",
+        buildDependencies: {
+          config: ["./config/build.js"]
+        },
+        maxMemoryGenerations: 2,
+        idleTimeout: 10
+      },
+      snapshot: {
+        module: { timestamp: true, hash: false },
+        buildDependencies: { timestamp: true, hash: true }
+      }
+    });
+
+    assert.equal(err, null);
+    assert.equal(stats?.hasErrors(), false);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 test("run callback is asynchronous", async () => {
   const fixture = await createFixture({
     "src/index.js": "export const value = 1;"
@@ -218,6 +316,54 @@ test("top-level option validation throws synchronously", () => {
         null
       ),
     /options must be an object/
+  );
+});
+
+test("cache and snapshot option validation throws synchronously", () => {
+  assert.throws(
+    () =>
+      unpack({
+        entry: "./src/index.js",
+        // @ts-expect-error intentionally testing runtime validation
+        cache: "memory"
+      }),
+    /options.cache must be a boolean or an object/
+  );
+  assert.throws(
+    () =>
+      unpack({
+        entry: "./src/index.js",
+        cache: {
+          type: "memory",
+          // @ts-expect-error intentionally testing runtime validation
+          unknown: true
+        }
+      }),
+    /options.cache contains unknown option 'unknown'/
+  );
+  assert.throws(
+    () =>
+      unpack({
+        entry: "./src/index.js",
+        snapshot: {
+          // @ts-expect-error intentionally testing runtime validation
+          resolve: {}
+        }
+      }),
+    /options.snapshot contains unknown option 'resolve'/
+  );
+  assert.throws(
+    () =>
+      unpack({
+        entry: "./src/index.js",
+        snapshot: {
+          module: {
+            // @ts-expect-error intentionally testing runtime validation
+            timestamp: "yes"
+          }
+        }
+      }),
+    /options.snapshot.module.timestamp must be a boolean/
   );
 });
 


### PR DESCRIPTION
## Summary

- Expose public JavaScript `cache` and `snapshot` options with strict synchronous validation.
- Normalize cache and snapshot convenience shapes in the TypeScript wrapper before crossing N-API.
- Pass normalized cache and snapshot options through native into core compiler options.
- Implement `cache: false` by disabling Build Cache reuse while keeping omitted cache and `cache: true` as memory cache.

Persistent filesystem cache storage is still scoped to the next stacked PR.

## Validation

- cargo fmt --all --check
- cargo test --workspace
- pnpm --filter @unpack-js/core typecheck
- pnpm --filter @unpack-js/core test

Closes #4