### PR TITLE
Add filesystem persistent cache packs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbor4ii"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faed1a83001dc2c9201451030cc317e35bef36c84d3781d7c5bb9f343c397da8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,10 +1203,13 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 name = "unpack_core"
 version = "0.1.0"
 dependencies = [
+ "cbor4ii",
  "codspeed-divan-compat",
  "futures",
  "rspack_resolver",
  "rspack_sources",
+ "serde",
+ "serde_json",
  "swc_experimental_allocator",
  "swc_experimental_ecma_ast",
  "swc_experimental_ecma_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 repository = "https://github.com/unpack-dev/unpack"
 
 [workspace.dependencies]
+cbor4ii = { version = "1.2.2", features = ["serde1"] }
 divan = { package = "codspeed-divan-compat", version = "5.0.1" }
 futures = "0.3.31"
 napi = "3.9.4"
@@ -15,6 +16,8 @@ napi-build = "2.3.2"
 napi-derive = "3.5.7"
 rspack_resolver = { version = "0.9.3", default-features = false }
 rspack_sources = "0.101.1"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 swc_experimental_allocator = "0.11.0"
 swc_experimental_ecma_ast = "0.11.0"
 swc_experimental_ecma_parser = "0.11.0"

--- a/crates/unpack_core/Cargo.toml
+++ b/crates/unpack_core/Cargo.toml
@@ -6,9 +6,12 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+cbor4ii = { workspace = true }
 futures = { workspace = true }
 rspack_resolver = { workspace = true }
 rspack_sources = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 swc_experimental_allocator = { workspace = true }
 swc_experimental_ecma_ast = { workspace = true }
 swc_experimental_ecma_parser = { workspace = true }

--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -1,14 +1,23 @@
 use std::{
     collections::HashMap,
+    fs, io,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
 
 use crate::{ModuleIdentity, SnapshotStrategy, parser::ParsedModule, snapshot::FileSnapshot};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Default)]
+const CACHE_MAGIC: &str = "UNPACK_PERSISTENT_CACHE";
+const PACK_MAGIC: &[u8] = b"UNPACK-CACHE-PACK\0";
+const CACHE_SCHEMA_VERSION: u32 = 1;
+const DEFAULT_PACK_FILE: &str = "packs/modules.cbor";
+const MANIFEST_FILE: &str = "container.json";
+
+#[derive(Debug, Clone)]
 pub(crate) struct BuildCache {
     options: CacheOptions,
+    build_dependency_snapshot_strategy: SnapshotStrategy,
     inner: Arc<Mutex<BuildCacheInner>>,
 }
 
@@ -91,7 +100,7 @@ struct BuildCacheInner {
     module_misses: usize,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct ModuleBuildRecord {
     parsed: ParsedModule,
     source: String,
@@ -121,11 +130,17 @@ impl ModuleBuildRecord {
 }
 
 impl BuildCache {
-    pub(crate) fn new(options: CacheOptions) -> Self {
-        Self {
+    pub(crate) fn new(
+        options: CacheOptions,
+        build_dependency_snapshot_strategy: SnapshotStrategy,
+    ) -> Self {
+        let cache = Self {
             options,
+            build_dependency_snapshot_strategy,
             inner: Arc::new(Mutex::new(BuildCacheInner::default())),
-        }
+        };
+        cache.restore_from_filesystem();
+        cache
     }
 
     pub(crate) fn get_module_build(&self, identity: &ModuleIdentity) -> Option<ModuleBuildRecord> {
@@ -151,11 +166,22 @@ impl BuildCache {
             return;
         }
 
-        self.inner
-            .lock()
-            .expect("build cache mutex should not be poisoned")
-            .module_builds
-            .insert(identity, record);
+        let module_builds = {
+            let mut inner = self
+                .inner
+                .lock()
+                .expect("build cache mutex should not be poisoned");
+            inner.module_builds.insert(identity, record);
+            if self.options.kind == CacheKind::Filesystem {
+                Some(inner.module_builds.clone())
+            } else {
+                None
+            }
+        };
+
+        if let Some(module_builds) = module_builds {
+            let _ = self.write_filesystem_cache(&module_builds);
+        }
     }
 
     #[cfg(test)]
@@ -170,6 +196,191 @@ impl BuildCache {
             module_misses: inner.module_misses,
         }
     }
+}
+
+impl BuildCache {
+    fn restore_from_filesystem(&self) {
+        if self.options.kind != CacheKind::Filesystem {
+            return;
+        }
+        let Some(cache_location) = &self.options.cache_location else {
+            return;
+        };
+        let Some(manifest) = read_manifest(cache_location) else {
+            return;
+        };
+        if !self.manifest_is_valid(&manifest) {
+            return;
+        }
+
+        let Some(pack) = read_pack(cache_location, &manifest.pack_file) else {
+            return;
+        };
+        if pack.magic != CACHE_MAGIC
+            || pack.schema_version != CACHE_SCHEMA_VERSION
+            || pack.cache_version != self.cache_version()
+        {
+            return;
+        }
+
+        self.inner
+            .lock()
+            .expect("build cache mutex should not be poisoned")
+            .module_builds = pack.module_builds.into_iter().collect();
+    }
+
+    fn write_filesystem_cache(
+        &self,
+        module_builds: &HashMap<ModuleIdentity, ModuleBuildRecord>,
+    ) -> io::Result<()> {
+        let Some(cache_location) = &self.options.cache_location else {
+            return Ok(());
+        };
+
+        let pack_file = PathBuf::from(DEFAULT_PACK_FILE);
+        let pack_path = cache_location.join(&pack_file);
+        if let Some(parent) = pack_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let cache_version = self.cache_version();
+        let pack = CachePackDto {
+            magic: CACHE_MAGIC.to_string(),
+            schema_version: CACHE_SCHEMA_VERSION,
+            cache_version: cache_version.clone(),
+            module_builds: module_builds
+                .iter()
+                .map(|(identity, record)| (identity.clone(), record.clone()))
+                .collect(),
+        };
+        let pack_payload = cbor4ii::serde::to_vec(Vec::new(), &pack)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        let mut pack_bytes = PACK_MAGIC.to_vec();
+        pack_bytes.extend(pack_payload);
+        fs::write(pack_path, pack_bytes)?;
+
+        let manifest = CacheManifest {
+            magic: CACHE_MAGIC.to_string(),
+            schema_version: CACHE_SCHEMA_VERSION,
+            cache_version,
+            pack_file: pack_file.to_string_lossy().replace('\\', "/"),
+            build_dependencies: self.build_dependency_snapshots()?,
+        };
+        fs::create_dir_all(cache_location)?;
+        let manifest_json = serde_json::to_vec_pretty(&manifest)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        fs::write(cache_location.join(MANIFEST_FILE), manifest_json)?;
+        Ok(())
+    }
+
+    fn manifest_is_valid(&self, manifest: &CacheManifest) -> bool {
+        manifest.magic == CACHE_MAGIC
+            && manifest.schema_version == CACHE_SCHEMA_VERSION
+            && manifest.cache_version == self.cache_version()
+            && self.build_dependency_snapshots_are_valid(&manifest.build_dependencies)
+    }
+
+    fn cache_version(&self) -> String {
+        self.options.version.clone().unwrap_or_default()
+    }
+
+    fn build_dependency_snapshots(&self) -> io::Result<Vec<PersistentBuildDependencySnapshot>> {
+        self.options
+            .build_dependencies
+            .iter()
+            .map(|dependency| {
+                Ok(PersistentBuildDependencySnapshot {
+                    name: dependency.name.clone(),
+                    files: dependency
+                        .files
+                        .iter()
+                        .map(|path| {
+                            Ok(PersistentFileSnapshot {
+                                path: path.clone(),
+                                snapshot: FileSnapshot::create_from_file_sync(
+                                    path,
+                                    self.build_dependency_snapshot_strategy,
+                                )
+                                .map_err(|error| {
+                                    io::Error::new(io::ErrorKind::InvalidData, error)
+                                })?,
+                            })
+                        })
+                        .collect::<io::Result<Vec<_>>>()?,
+                })
+            })
+            .collect()
+    }
+
+    fn build_dependency_snapshots_are_valid(
+        &self,
+        snapshots: &[PersistentBuildDependencySnapshot],
+    ) -> bool {
+        if snapshots.len() != self.options.build_dependencies.len() {
+            return false;
+        }
+
+        self.options.build_dependencies.iter().all(|dependency| {
+            let Some(snapshot) = snapshots
+                .iter()
+                .find(|snapshot| snapshot.name == dependency.name)
+            else {
+                return false;
+            };
+            if snapshot.files.len() != dependency.files.len() {
+                return false;
+            }
+
+            dependency.files.iter().all(|path| {
+                snapshot.files.iter().any(|snapshot_file| {
+                    snapshot_file.path == *path
+                        && snapshot_file
+                            .snapshot
+                            .is_valid_sync(path, self.build_dependency_snapshot_strategy)
+                })
+            })
+        })
+    }
+}
+
+fn read_manifest(cache_location: &Path) -> Option<CacheManifest> {
+    let bytes = fs::read(cache_location.join(MANIFEST_FILE)).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn read_pack(cache_location: &Path, pack_file: &str) -> Option<CachePackDto> {
+    let bytes = fs::read(cache_location.join(pack_file)).ok()?;
+    let payload = bytes.strip_prefix(PACK_MAGIC)?;
+    cbor4ii::serde::from_slice(payload).ok()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CacheManifest {
+    magic: String,
+    schema_version: u32,
+    cache_version: String,
+    pack_file: String,
+    build_dependencies: Vec<PersistentBuildDependencySnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistentBuildDependencySnapshot {
+    name: String,
+    files: Vec<PersistentFileSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistentFileSnapshot {
+    path: PathBuf,
+    snapshot: FileSnapshot,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CachePackDto {
+    magic: String,
+    schema_version: u32,
+    cache_version: String,
+    module_builds: Vec<(ModuleIdentity, ModuleBuildRecord)>,
 }
 
 #[cfg(test)]

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -55,7 +55,8 @@ pub struct Compiler {
 impl Compiler {
     pub fn new(options: CompilerOptions) -> Self {
         let resolver = UnpackResolver::new(options.resolve.clone());
-        let build_cache = BuildCache::new(options.cache.clone());
+        let build_cache =
+            BuildCache::new(options.cache.clone(), options.snapshot.build_dependencies);
         Self {
             options,
             resolver,
@@ -179,6 +180,77 @@ mod tests {
                 .expect("main asset should exist")
                 .contains("after")
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn filesystem_cache_restores_module_build_records_for_later_compiler_instances()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write(
+            temp.path().join("index.js"),
+            r#"
+                import "./dep";
+                export const result = "ok";
+            "#,
+        )?;
+        write(temp.path().join("dep.js"), "export const value = 1;")?;
+        let cache_location = temp.path().join(".cache/unpack/default");
+
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache = CacheOptions::filesystem();
+        options.cache.cache_location = Some(cache_location.clone());
+        options.cache.version = Some("test-version".to_string());
+
+        let first_compiler = Compiler::new(options.clone());
+        let first = first_compiler.run().await?;
+        assert_eq!(first.errors(), []);
+        assert!(cache_location.join("container.json").exists());
+        assert!(cache_location.join("packs/modules.cbor").exists());
+        let manifest = fs::read_to_string(cache_location.join("container.json"))?;
+        assert!(manifest.contains("UNPACK_PERSISTENT_CACHE"));
+        assert!(manifest.contains("test-version"));
+
+        let second_compiler = Compiler::new(options);
+        assert_eq!(second_compiler.build_cache.stats().module_entries, 2);
+
+        let second = second_compiler.run().await?;
+        let second_cache = second_compiler.build_cache.stats();
+        assert_eq!(second_cache.module_hits, 2);
+        assert_eq!(asset_sources(&first), asset_sources(&second));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn filesystem_cache_rejects_invalid_build_dependency_snapshots()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write(temp.path().join("index.js"), "export const value = 1;")?;
+        let config = temp.path().join("config.js");
+        write(&config, "export default 'before';")?;
+        let cache_location = temp.path().join(".cache/unpack/default");
+
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache = CacheOptions::filesystem();
+        options.cache.cache_location = Some(cache_location);
+        options.cache.build_dependencies = vec![crate::BuildDependency {
+            name: "config".to_string(),
+            files: vec![config.clone()],
+        }];
+
+        Compiler::new(options.clone()).run().await?;
+        assert_eq!(
+            Compiler::new(options.clone())
+                .build_cache
+                .stats()
+                .module_entries,
+            1
+        );
+
+        write(&config, "export default 'after';")?;
+        assert_eq!(Compiler::new(options).build_cache.stats().module_entries, 0);
 
         Ok(())
     }

--- a/crates/unpack_core/src/dependency.rs
+++ b/crates/unpack_core/src/dependency.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct SourceRange {
     pub start: u32,
     pub end: u32,
@@ -23,7 +25,7 @@ impl SourceRange {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct AsyncDependenciesBlock {
     dependencies: Vec<Dependency>,
 }
@@ -38,7 +40,7 @@ impl AsyncDependenciesBlock {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Dependency {
     Entry(EntryDependency),
     HarmonyImportSideEffect(HarmonyImportSideEffectDependency),
@@ -161,7 +163,7 @@ impl Dependency {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ModuleDependency {
     pub request: String,
     pub user_request: String,
@@ -197,7 +199,7 @@ impl fmt::Debug for ModuleDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct EntryDependency {
     pub module: ModuleDependency,
 }
@@ -210,7 +212,7 @@ impl EntryDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HarmonyImportSideEffectDependency {
     pub module: ModuleDependency,
     pub import_var: Option<String>,
@@ -231,7 +233,7 @@ impl HarmonyImportSideEffectDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HarmonyImportSpecifierDependency {
     pub module: ModuleDependency,
     pub ids: Vec<String>,
@@ -258,7 +260,7 @@ impl HarmonyImportSpecifierDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HarmonyExportHeaderDependency {
     pub declaration_range: Option<SourceRange>,
     pub statement_range: SourceRange,
@@ -273,7 +275,7 @@ impl HarmonyExportHeaderDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HarmonyExportSpecifierDependency {
     pub id: String,
     pub name: String,
@@ -288,7 +290,7 @@ impl HarmonyExportSpecifierDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HarmonyExportExpressionDependency {
     pub range: SourceRange,
     pub statement_range: SourceRange,
@@ -309,7 +311,7 @@ impl HarmonyExportExpressionDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HarmonyExportImportedSpecifierDependency {
     pub module: ModuleDependency,
     pub ids: Vec<String>,
@@ -337,7 +339,7 @@ impl HarmonyExportImportedSpecifierDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ConstDependency {
     pub expression: String,
     pub range: SourceRange,
@@ -352,10 +354,10 @@ impl ConstDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct NullDependency;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ImportDependency {
     pub module: ModuleDependency,
 }
@@ -378,7 +380,7 @@ impl ImportDependency {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum DependencyKind {
     Entry,
     StaticImport,

--- a/crates/unpack_core/src/module.rs
+++ b/crates/unpack_core/src/module.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use serde::{Deserialize, Serialize};
+
 use crate::{AsyncDependenciesBlock, Dependency, Error, ExportsInfo};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -106,7 +108,7 @@ impl Module {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ModuleIdentity {
     pub module_type: ModuleType,
     pub resource: PathBuf,
@@ -129,7 +131,7 @@ impl ModuleIdentity {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ModuleType {
     JavaScriptAuto,
 }

--- a/crates/unpack_core/src/parser.rs
+++ b/crates/unpack_core/src/parser.rs
@@ -9,6 +9,7 @@ use crate::{
     HarmonyExportSpecifierDependency, HarmonyImportSideEffectDependency,
     HarmonyImportSpecifierDependency, ImportDependency, Result, SourceRange,
 };
+use serde::{Deserialize, Serialize};
 use swc_experimental_allocator::Allocator;
 use swc_experimental_allocator::atom::Wtf8Atom;
 use swc_experimental_ecma_ast::{
@@ -21,7 +22,7 @@ use swc_experimental_ecma_parser::{EsSyntax, Syntax, parse_file_as_module};
 const UNSUPPORTED_DYNAMIC_IMPORT_MESSAGE: &str =
     "only static string specifiers are supported; context modules are not supported yet";
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct ParsedModule {
     pub dependencies: Vec<Dependency>,
     pub blocks: Vec<AsyncDependenciesBlock>,

--- a/crates/unpack_core/src/snapshot.rs
+++ b/crates/unpack_core/src/snapshot.rs
@@ -1,8 +1,9 @@
-use std::{path::Path, time::SystemTime};
+use std::{fs, path::Path, time::SystemTime};
 
 use crate::{Error, Result};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SnapshotOptions {
     pub module: SnapshotStrategy,
     pub build_dependencies: SnapshotStrategy,
@@ -17,7 +18,7 @@ impl Default for SnapshotOptions {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SnapshotStrategy {
     pub timestamp: bool,
     pub hash: bool,
@@ -46,7 +47,7 @@ impl SnapshotStrategy {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct FileSnapshot {
     modified: Option<SystemTime>,
     source_hash: Option<u64>,
@@ -93,6 +94,51 @@ impl FileSnapshot {
 
         if strategy.hash {
             let Ok(source) = tokio::fs::read_to_string(path).await else {
+                return false;
+            };
+            if Some(hash_source(&source)) != self.source_hash {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    pub(crate) fn create_from_file_sync(path: &Path, strategy: SnapshotStrategy) -> Result<Self> {
+        let source = fs::read_to_string(path).map_err(|error| Error::read(path, error))?;
+        let modified = if strategy.timestamp {
+            let metadata = fs::metadata(path).map_err(|error| Error::read(path, error))?;
+            Some(
+                metadata
+                    .modified()
+                    .map_err(|error| Error::read(path, error))?,
+            )
+        } else {
+            None
+        };
+        let source_hash = strategy.hash.then(|| hash_source(&source));
+
+        Ok(Self {
+            modified,
+            source_hash,
+        })
+    }
+
+    pub(crate) fn is_valid_sync(&self, path: &Path, strategy: SnapshotStrategy) -> bool {
+        if strategy.timestamp {
+            let Ok(metadata) = fs::metadata(path) else {
+                return false;
+            };
+            let Ok(modified) = metadata.modified() else {
+                return false;
+            };
+            if Some(modified) != self.modified {
+                return false;
+            }
+        }
+
+        if strategy.hash {
+            let Ok(source) = fs::read_to_string(path) else {
                 return false;
             };
             if Some(hash_source(&source)) != self.source_hash {

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -210,30 +210,46 @@ test("accepts filesystem cache option shape", async () => {
     "src/index.js": "export const value = 1;",
     "config/build.js": "export default {};"
   });
+  const cacheOptions = {
+    type: "filesystem" as const,
+    cacheDirectory: ".cache/unpack",
+    name: "test-cache",
+    version: "v1",
+    buildDependencies: {
+      config: ["./config/build.js"]
+    },
+    maxMemoryGenerations: 2,
+    idleTimeout: 10
+  };
+  const snapshot = {
+    module: { timestamp: true, hash: false },
+    buildDependencies: { timestamp: true, hash: true }
+  };
 
   try {
-    const { err, stats } = await runCompiler({
+    const first = await runCompiler({
       context: fixture,
       entry: "./src/index.js",
-      cache: {
-        type: "filesystem",
-        cacheDirectory: ".cache/unpack",
-        name: "test-cache",
-        version: "v1",
-        buildDependencies: {
-          config: ["./config/build.js"]
-        },
-        maxMemoryGenerations: 2,
-        idleTimeout: 10
-      },
-      snapshot: {
-        module: { timestamp: true, hash: false },
-        buildDependencies: { timestamp: true, hash: true }
-      }
+      cache: cacheOptions,
+      snapshot
     });
 
-    assert.equal(err, null);
-    assert.equal(stats?.hasErrors(), false);
+    assert.equal(first.err, null);
+    assert.equal(first.stats?.hasErrors(), false);
+    assert.match(
+      await readFile(join(fixture, ".cache/unpack/test-cache/container.json"), "utf8"),
+      /UNPACK_PERSISTENT_CACHE/
+    );
+    assert.ok(await readFile(join(fixture, ".cache/unpack/test-cache/packs/modules.cbor")));
+
+    const second = await runCompiler({
+      context: fixture,
+      entry: "./src/index.js",
+      cache: cacheOptions,
+      snapshot
+    });
+    assert.equal(second.err, null);
+    assert.deepEqual(second.stats?.toJson(), first.stats?.toJson());
   } finally {
     await rm(fixture, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Add opt-in filesystem persistent cache storage for module build records.
- Store JSON container metadata and CBOR cache pack shards guarded by magic, schema version, and cache version.
- Restore valid cache records for later compiler instances when build dependency snapshots remain valid.
- Serialize module build record DTOs with cbor4ii and Serde.

This PR is stacked on #15. Moving writes off the compile path is scoped to the next stacked PR.

## Validation

- cargo fmt --all --check
- cargo test --workspace
- pnpm --filter @unpack-js/core typecheck
- pnpm --filter @unpack-js/core test

Closes #5