### PR TITLE
Flush persistent cache during compiler idle

### DIFF
--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -96,6 +96,7 @@ pub struct BuildDependency {
 #[derive(Debug, Default)]
 struct BuildCacheInner {
     module_builds: HashMap<ModuleIdentity, ModuleBuildRecord>,
+    dirty: bool,
     module_hits: usize,
     module_misses: usize,
 }
@@ -166,22 +167,41 @@ impl BuildCache {
             return;
         }
 
-        let module_builds = {
+        {
             let mut inner = self
                 .inner
                 .lock()
                 .expect("build cache mutex should not be poisoned");
             inner.module_builds.insert(identity, record);
             if self.options.kind == CacheKind::Filesystem {
-                Some(inner.module_builds.clone())
-            } else {
-                None
+                inner.dirty = true;
             }
+        }
+    }
+
+    pub(crate) fn flush_to_filesystem(&self) -> io::Result<()> {
+        if self.options.kind != CacheKind::Filesystem {
+            return Ok(());
+        }
+
+        let module_builds = {
+            let inner = self
+                .inner
+                .lock()
+                .expect("build cache mutex should not be poisoned");
+            if !inner.dirty {
+                return Ok(());
+            }
+            inner.module_builds.clone()
         };
 
-        if let Some(module_builds) = module_builds {
-            let _ = self.write_filesystem_cache(&module_builds);
-        }
+        self.write_filesystem_cache(&module_builds)?;
+
+        self.inner
+            .lock()
+            .expect("build cache mutex should not be poisoned")
+            .dirty = false;
+        Ok(())
     }
 
     #[cfg(test)]

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -83,6 +83,12 @@ impl Compiler {
         compilation.create_assets();
         Ok(compilation)
     }
+
+    pub fn flush_cache(&self) -> std::result::Result<(), String> {
+        self.build_cache
+            .flush_to_filesystem()
+            .map_err(|error| error.to_string())
+    }
 }
 
 fn default_resolve_options() -> ResolveOptions {
@@ -205,6 +211,7 @@ mod tests {
 
         let first_compiler = Compiler::new(options.clone());
         let first = first_compiler.run().await?;
+        first_compiler.flush_cache()?;
         assert_eq!(first.errors(), []);
         assert!(cache_location.join("container.json").exists());
         assert!(cache_location.join("packs/modules.cbor").exists());
@@ -240,7 +247,9 @@ mod tests {
             files: vec![config.clone()],
         }];
 
-        Compiler::new(options.clone()).run().await?;
+        let first_compiler = Compiler::new(options.clone());
+        first_compiler.run().await?;
+        first_compiler.flush_cache()?;
         assert_eq!(
             Compiler::new(options.clone())
                 .build_cache

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -100,6 +100,11 @@ pub struct NativeRunResult {
     pub stats: Option<NativeStatsJson>,
 }
 
+#[napi(object)]
+pub struct NativeFlushResult {
+    pub error: Option<NativeInfrastructureError>,
+}
+
 #[napi(js_name = "createCompiler")]
 pub fn create_compiler(options: NativeCompilerOptions) -> NativeCompiler {
     NativeCompiler::new(options)
@@ -118,6 +123,13 @@ impl NativeCompiler {
         AsyncTask::new(RunCompilerTask {
             compiler: self.compiler.clone(),
             output_path: self.output_path.clone(),
+        })
+    }
+
+    #[napi(js_name = "flushCache")]
+    pub fn flush_cache(&self) -> AsyncTask<FlushCacheTask> {
+        AsyncTask::new(FlushCacheTask {
+            compiler: self.compiler.clone(),
         })
     }
 
@@ -190,6 +202,10 @@ pub struct RunCompilerTask {
     output_path: PathBuf,
 }
 
+pub struct FlushCacheTask {
+    compiler: Option<Arc<Compiler>>,
+}
+
 impl Task for RunCompilerTask {
     type Output = NativeRunResult;
     type JsValue = NativeRunResult;
@@ -199,6 +215,36 @@ impl Task for RunCompilerTask {
             self.compiler.as_deref(),
             &self.output_path,
         ))
+    }
+
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        Ok(output)
+    }
+}
+
+impl Task for FlushCacheTask {
+    type Output = NativeFlushResult;
+    type JsValue = NativeFlushResult;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        let Some(compiler) = self.compiler.as_deref() else {
+            return Ok(NativeFlushResult {
+                error: Some(NativeInfrastructureError {
+                    name: "CompilerClosedError".to_string(),
+                    message: "compiler is closed".to_string(),
+                }),
+            });
+        };
+
+        Ok(match compiler.flush_cache() {
+            Ok(()) => NativeFlushResult { error: None },
+            Err(message) => NativeFlushResult {
+                error: Some(NativeInfrastructureError {
+                    name: "CacheFlushError".to_string(),
+                    message,
+                }),
+            },
+        })
     }
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -61,10 +61,19 @@ export interface Stats {
 
 export interface Compiler {
   run(callback: RunCallback): void;
+  watch(watchOptions: WatchOptions, handler: WatchHandler): Watching;
   close(callback: CloseCallback): void;
 }
 
+export interface Watching {
+  close(callback: CloseCallback): void;
+  invalidate(): void;
+}
+
+export interface WatchOptions {}
+
 export type RunCallback = (err: Error | null, stats?: Stats) => void;
+export type WatchHandler = (err: Error | null, stats?: Stats) => void;
 export type CloseCallback = (err: Error | null) => void;
 
 interface NormalizedEntry {
@@ -145,6 +154,7 @@ const native = require("./unpack_node.node") as NativeBinding;
 class CompilerImpl implements Compiler {
   #closed = false;
   #running = false;
+  #watching: WatchingImpl | undefined;
   #idleFlushTimer: ReturnType<typeof setTimeout> | undefined;
   #pendingCacheFlush: Promise<NativeFlushResult> | undefined;
   readonly #filesystemCache: boolean;
@@ -168,6 +178,13 @@ class CompilerImpl implements Compiler {
     if (this.#running) {
       defer(() =>
         callback(namedError("ConcurrentRunError", "compiler is already running"))
+      );
+      return;
+    }
+
+    if (this.#watching) {
+      defer(() =>
+        callback(namedError("ConcurrentRunError", "compiler is already watching"))
       );
       return;
     }
@@ -200,6 +217,50 @@ class CompilerImpl implements Compiler {
     );
   }
 
+  watch(watchOptions: WatchOptions, handler: WatchHandler): Watching {
+    normalizeWatchOptions(watchOptions);
+    assertFunction(handler, "handler");
+
+    if (this.#closed) {
+      const watching = new WatchingImpl(
+        (watchHandler) => {
+          defer(() => watchHandler(namedError("CompilerClosedError", "compiler is closed")));
+        },
+        () => Promise.resolve(null),
+        () => {}
+      );
+      watching.start(handler);
+      return watching;
+    }
+
+    if (this.#running || this.#watching) {
+      const watching = new WatchingImpl(
+        (watchHandler) => {
+          defer(() =>
+            watchHandler(namedError("ConcurrentRunError", "compiler is already running"))
+          );
+        },
+        () => Promise.resolve(null),
+        () => {}
+      );
+      watching.start(handler);
+      return watching;
+    }
+
+    const watching = new WatchingImpl(
+      (watchHandler) => this.#runWatchCompilation(watchHandler),
+      () => this.#flushCacheNow(),
+      () => {
+        if (this.#watching === watching) {
+          this.#watching = undefined;
+        }
+      }
+    );
+    this.#watching = watching;
+    watching.start(handler);
+    return watching;
+  }
+
   close(callback: CloseCallback): void {
     assertFunction(callback, "callback");
 
@@ -207,6 +268,15 @@ class CompilerImpl implements Compiler {
       defer(() =>
         callback(
           namedError("CompilerRunningError", "compiler cannot close while running")
+        )
+      );
+      return;
+    }
+
+    if (this.#watching) {
+      defer(() =>
+        callback(
+          namedError("CompilerRunningError", "compiler cannot close while watching")
         )
       );
       return;
@@ -230,6 +300,29 @@ class CompilerImpl implements Compiler {
       });
     } catch (error) {
       defer(() => callback(toError(error, "InfrastructureError")));
+    }
+  }
+
+  async #runWatchCompilation(handler: WatchHandler): Promise<void> {
+    let run: Promise<NativeRunResult>;
+    try {
+      run = this.#nativeCompiler.run();
+    } catch (error) {
+      handler(toError(error, "InfrastructureError"));
+      return;
+    }
+
+    try {
+      const result = await run;
+      if (result.error) {
+        handler(namedError(result.error.name, result.error.message));
+        return;
+      }
+
+      this.#scheduleIdleCacheFlush();
+      handler(null, new StatsImpl(normalizeNativeStats(result.stats)));
+    } catch (error) {
+      handler(toError(error, "InfrastructureError"));
     }
   }
 
@@ -272,6 +365,91 @@ class CompilerImpl implements Compiler {
       if (this.#pendingCacheFlush === flush) {
         this.#pendingCacheFlush = undefined;
       }
+    }
+  }
+}
+
+class WatchingImpl implements Watching {
+  #closed = false;
+  #running = false;
+  #invalidated = false;
+  #handler: WatchHandler | undefined;
+  readonly #runCompilation: (handler: WatchHandler) => Promise<void> | void;
+  readonly #flushCache: () => Promise<Error | null>;
+  readonly #onClose: () => void;
+  readonly #closeCallbacks: CloseCallback[] = [];
+
+  constructor(
+    runCompilation: (handler: WatchHandler) => Promise<void> | void,
+    flushCache: () => Promise<Error | null>,
+    onClose: () => void
+  ) {
+    this.#runCompilation = runCompilation;
+    this.#flushCache = flushCache;
+    this.#onClose = onClose;
+  }
+
+  start(handler: WatchHandler): void {
+    this.#handler = handler;
+    this.#run();
+  }
+
+  invalidate(): void {
+    if (this.#closed) {
+      return;
+    }
+
+    if (this.#running) {
+      this.#invalidated = true;
+      return;
+    }
+
+    this.#run();
+  }
+
+  close(callback: CloseCallback): void {
+    assertFunction(callback, "callback");
+
+    if (this.#closed && !this.#running) {
+      defer(() => callback(null));
+      return;
+    }
+
+    this.#closed = true;
+    this.#invalidated = false;
+    this.#closeCallbacks.push(callback);
+
+    if (!this.#running) {
+      void this.#finishClose();
+    }
+  }
+
+  async #run(): Promise<void> {
+    if (this.#closed || this.#running || !this.#handler) {
+      return;
+    }
+
+    this.#running = true;
+    await this.#runCompilation(this.#handler);
+    this.#running = false;
+
+    if (this.#closed) {
+      await this.#finishClose();
+      return;
+    }
+
+    if (this.#invalidated) {
+      this.#invalidated = false;
+      await this.#run();
+    }
+  }
+
+  async #finishClose(): Promise<void> {
+    const callbacks = this.#closeCallbacks.splice(0);
+    const flushError = await this.#flushCache();
+    this.#onClose();
+    for (const callback of callbacks) {
+      callback(flushError);
     }
   }
 }
@@ -512,6 +690,11 @@ function normalizeSnapshotStrategy(
         : assertBoolean(strategy.timestamp, `${name}.timestamp`),
     hash: strategy.hash === undefined ? defaults.hash : assertBoolean(strategy.hash, `${name}.hash`)
   };
+}
+
+function normalizeWatchOptions(watchOptions: WatchOptions): void {
+  assertPlainObject(watchOptions, "watchOptions");
+  assertKnownKeys(watchOptions, [], "watchOptions");
 }
 
 function normalizeNativeStats(stats: NativeStatsJson | null | undefined): StatsJson {

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -122,8 +122,16 @@ interface NativeRunResult {
   stats?: NativeStatsJson | null;
 }
 
+interface NativeFlushResult {
+  error?: {
+    name: string;
+    message: string;
+  } | null;
+}
+
 interface NativeCompiler {
   run(): Promise<NativeRunResult>;
+  flushCache(): Promise<NativeFlushResult>;
   close(): void;
 }
 
@@ -137,10 +145,16 @@ const native = require("./unpack_node.node") as NativeBinding;
 class CompilerImpl implements Compiler {
   #closed = false;
   #running = false;
+  #idleFlushTimer: ReturnType<typeof setTimeout> | undefined;
+  #pendingCacheFlush: Promise<NativeFlushResult> | undefined;
+  readonly #filesystemCache: boolean;
+  readonly #cacheIdleTimeout: number;
   readonly #nativeCompiler: NativeCompiler;
 
   constructor(options: NormalizedOptions) {
     this.#nativeCompiler = native.createCompiler(options);
+    this.#filesystemCache = options.cache.type === "filesystem";
+    this.#cacheIdleTimeout = options.cache.idleTimeout ?? 0;
   }
 
   run(callback: RunCallback): void {
@@ -176,6 +190,7 @@ class CompilerImpl implements Compiler {
           return;
         }
 
+        this.#scheduleIdleCacheFlush();
         callback(null, new StatsImpl(normalizeNativeStats(result.stats)));
       },
       (error: unknown) => {
@@ -198,11 +213,65 @@ class CompilerImpl implements Compiler {
     }
 
     try {
-      this.#nativeCompiler.close();
-      this.#closed = true;
-      defer(() => callback(null));
+      this.#clearIdleFlushTimer();
+      this.#flushCacheNow().then((flushError) => {
+        if (flushError) {
+          callback(flushError);
+          return;
+        }
+
+        try {
+          this.#nativeCompiler.close();
+          this.#closed = true;
+          callback(null);
+        } catch (error) {
+          callback(toError(error, "InfrastructureError"));
+        }
+      });
     } catch (error) {
       defer(() => callback(toError(error, "InfrastructureError")));
+    }
+  }
+
+  #scheduleIdleCacheFlush(): void {
+    if (!this.#filesystemCache || this.#closed) {
+      return;
+    }
+
+    this.#clearIdleFlushTimer();
+    this.#idleFlushTimer = setTimeout(() => {
+      this.#idleFlushTimer = undefined;
+      void this.#flushCacheNow();
+    }, this.#cacheIdleTimeout);
+  }
+
+  #clearIdleFlushTimer(): void {
+    if (this.#idleFlushTimer !== undefined) {
+      clearTimeout(this.#idleFlushTimer);
+      this.#idleFlushTimer = undefined;
+    }
+  }
+
+  async #flushCacheNow(): Promise<Error | null> {
+    if (!this.#filesystemCache) {
+      return null;
+    }
+
+    const flush = this.#pendingCacheFlush ?? this.#nativeCompiler.flushCache();
+    this.#pendingCacheFlush = flush;
+
+    try {
+      const result = await flush;
+      if (result.error) {
+        return namedError(result.error.name, result.error.message);
+      }
+      return null;
+    } catch (error) {
+      return toError(error, "InfrastructureError");
+    } finally {
+      if (this.#pendingCacheFlush === flush) {
+        this.#pendingCacheFlush = undefined;
+      }
     }
   }
 }

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -227,12 +227,14 @@ test("accepts filesystem cache option shape", async () => {
   };
 
   try {
-    const first = await runCompiler({
+    const firstCompiler = unpack({
       context: fixture,
       entry: "./src/index.js",
       cache: cacheOptions,
       snapshot
     });
+    const first = await runExistingCompiler(firstCompiler);
+    await closeCompiler(firstCompiler);
 
     assert.equal(first.err, null);
     assert.equal(first.stats?.hasErrors(), false);
@@ -242,14 +244,76 @@ test("accepts filesystem cache option shape", async () => {
     );
     assert.ok(await readFile(join(fixture, ".cache/unpack/test-cache/packs/modules.cbor")));
 
-    const second = await runCompiler({
+    const secondCompiler = unpack({
       context: fixture,
       entry: "./src/index.js",
       cache: cacheOptions,
       snapshot
     });
+    const second = await runExistingCompiler(secondCompiler);
+    await closeCompiler(secondCompiler);
     assert.equal(second.err, null);
     assert.deepEqual(second.stats?.toJson(), first.stats?.toJson());
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("filesystem cache flushes after idle timeout", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const cacheLocation = join(fixture, ".cache/unpack/idle");
+  const compiler = unpack({
+    context: fixture,
+    entry: "./src/index.js",
+    cache: {
+      type: "filesystem",
+      cacheLocation,
+      idleTimeout: 30
+    }
+  });
+
+  try {
+    const result = await runExistingCompiler(compiler);
+    assert.equal(result.err, null);
+    await assert.rejects(readFile(join(cacheLocation, "container.json"), "utf8"));
+
+    await delay(100);
+    assert.match(
+      await readFile(join(cacheLocation, "container.json"), "utf8"),
+      /UNPACK_PERSISTENT_CACHE/
+    );
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("compiler close waits for pending filesystem cache flush", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const cacheLocation = join(fixture, ".cache/unpack/close");
+  const compiler = unpack({
+    context: fixture,
+    entry: "./src/index.js",
+    cache: {
+      type: "filesystem",
+      cacheLocation,
+      idleTimeout: 60_000
+    }
+  });
+
+  try {
+    const result = await runExistingCompiler(compiler);
+    assert.equal(result.err, null);
+
+    await closeCompiler(compiler);
+    assert.match(
+      await readFile(join(cacheLocation, "container.json"), "utf8"),
+      /UNPACK_PERSISTENT_CACHE/
+    );
   } finally {
     await rm(fixture, { recursive: true, force: true });
   }
@@ -406,6 +470,12 @@ async function closeCompiler(compiler: ReturnType<typeof unpack>) {
         resolve();
       }
     });
+  });
+}
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
   });
 }
 

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -319,6 +319,86 @@ test("compiler close waits for pending filesystem cache flush", async () => {
   }
 });
 
+test("watch performs initial build and close keeps compiler reusable", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+
+  try {
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch({}, results.handler);
+    const result = await first;
+    assert.equal(result.err, null);
+    assert.equal(result.stats?.hasErrors(), false);
+
+    await closeWatching(watching);
+    assert.equal((await runExistingCompiler(compiler)).err, null);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("watch invalidate triggers rebuild", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 'before';"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+  const entry = join(fixture, "src/index.js");
+
+  try {
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch({}, results.handler);
+    assert.equal((await first).err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /before/);
+
+    const second = results.next();
+    await writeFile(entry, "export const value = 'after';", { encoding: "utf8" });
+    const changedTime = new Date(Date.now() + 2000);
+    await utimes(entry, changedTime, changedTime);
+    watching.invalidate();
+
+    assert.equal((await second).err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /after/);
+    await closeWatching(watching);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("watch conflicts with run watch and compiler close", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+
+  try {
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch({}, results.handler);
+    assert.equal((await first).err, null);
+
+    assert.equal((await runExistingCompiler(compiler)).err?.name, "ConcurrentRunError");
+
+    const failedWatch = collectWatchResults();
+    const failed = failedWatch.next();
+    compiler.watch({}, failedWatch.handler);
+    assert.equal((await failed).err?.name, "ConcurrentRunError");
+
+    const closeResult = await closeCompilerResult(compiler);
+    assert.equal(closeResult?.name, "CompilerRunningError");
+
+    await closeWatching(watching);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 test("run callback is asynchronous", async () => {
   const fixture = await createFixture({
     "src/index.js": "export const value = 1;"
@@ -471,6 +551,39 @@ async function closeCompiler(compiler: ReturnType<typeof unpack>) {
       }
     });
   });
+}
+
+async function closeCompilerResult(compiler: ReturnType<typeof unpack>) {
+  return new Promise<Error | null>((resolve) => {
+    compiler.close((err) => {
+      resolve(err);
+    });
+  });
+}
+
+async function closeWatching(watching: ReturnType<ReturnType<typeof unpack>["watch"]>) {
+  await new Promise<void>((resolve, reject) => {
+    watching.close((err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function collectWatchResults() {
+  const resolvers: Array<(result: { err: Error | null; stats?: Stats }) => void> = [];
+  return {
+    handler: (err: Error | null, stats?: Stats) => {
+      resolvers.shift()?.({ err, stats });
+    },
+    next: () =>
+      new Promise<{ err: Error | null; stats?: Stats }>((resolve) => {
+        resolvers.push(resolve);
+      })
+  };
 }
 
 function delay(ms: number) {


### PR DESCRIPTION
## Summary

- Change persistent cache store operations to enqueue dirty cache state instead of writing packs during compilation.
- Add native/core cache flush entrypoints and schedule filesystem cache flushes from the JavaScript wrapper after compiler idle timeout.
- Make `compiler.close(callback)` wait for pending filesystem cache flush work and surface flush failures as infrastructure errors.
- Add public API tests for delayed idle flush and close waiting for pending cache work.

This PR is stacked on #16.

## Validation

- cargo fmt --all --check
- cargo test --workspace
- pnpm --filter @unpack-js/core typecheck
- pnpm --filter @unpack-js/core test

Closes #6