### PR TITLE
Expose compiler watch API

### DIFF
--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -61,10 +61,19 @@ export interface Stats {
 
 export interface Compiler {
   run(callback: RunCallback): void;
+  watch(watchOptions: WatchOptions, handler: WatchHandler): Watching;
   close(callback: CloseCallback): void;
 }
 
+export interface Watching {
+  close(callback: CloseCallback): void;
+  invalidate(): void;
+}
+
+export interface WatchOptions {}
+
 export type RunCallback = (err: Error | null, stats?: Stats) => void;
+export type WatchHandler = (err: Error | null, stats?: Stats) => void;
 export type CloseCallback = (err: Error | null) => void;
 
 interface NormalizedEntry {
@@ -145,6 +154,7 @@ const native = require("./unpack_node.node") as NativeBinding;
 class CompilerImpl implements Compiler {
   #closed = false;
   #running = false;
+  #watching: WatchingImpl | undefined;
   #idleFlushTimer: ReturnType<typeof setTimeout> | undefined;
   #pendingCacheFlush: Promise<NativeFlushResult> | undefined;
   readonly #filesystemCache: boolean;
@@ -168,6 +178,13 @@ class CompilerImpl implements Compiler {
     if (this.#running) {
       defer(() =>
         callback(namedError("ConcurrentRunError", "compiler is already running"))
+      );
+      return;
+    }
+
+    if (this.#watching) {
+      defer(() =>
+        callback(namedError("ConcurrentRunError", "compiler is already watching"))
       );
       return;
     }
@@ -200,6 +217,50 @@ class CompilerImpl implements Compiler {
     );
   }
 
+  watch(watchOptions: WatchOptions, handler: WatchHandler): Watching {
+    normalizeWatchOptions(watchOptions);
+    assertFunction(handler, "handler");
+
+    if (this.#closed) {
+      const watching = new WatchingImpl(
+        (watchHandler) => {
+          defer(() => watchHandler(namedError("CompilerClosedError", "compiler is closed")));
+        },
+        () => Promise.resolve(null),
+        () => {}
+      );
+      watching.start(handler);
+      return watching;
+    }
+
+    if (this.#running || this.#watching) {
+      const watching = new WatchingImpl(
+        (watchHandler) => {
+          defer(() =>
+            watchHandler(namedError("ConcurrentRunError", "compiler is already running"))
+          );
+        },
+        () => Promise.resolve(null),
+        () => {}
+      );
+      watching.start(handler);
+      return watching;
+    }
+
+    const watching = new WatchingImpl(
+      (watchHandler) => this.#runWatchCompilation(watchHandler),
+      () => this.#flushCacheNow(),
+      () => {
+        if (this.#watching === watching) {
+          this.#watching = undefined;
+        }
+      }
+    );
+    this.#watching = watching;
+    watching.start(handler);
+    return watching;
+  }
+
   close(callback: CloseCallback): void {
     assertFunction(callback, "callback");
 
@@ -207,6 +268,15 @@ class CompilerImpl implements Compiler {
       defer(() =>
         callback(
           namedError("CompilerRunningError", "compiler cannot close while running")
+        )
+      );
+      return;
+    }
+
+    if (this.#watching) {
+      defer(() =>
+        callback(
+          namedError("CompilerRunningError", "compiler cannot close while watching")
         )
       );
       return;
@@ -230,6 +300,29 @@ class CompilerImpl implements Compiler {
       });
     } catch (error) {
       defer(() => callback(toError(error, "InfrastructureError")));
+    }
+  }
+
+  async #runWatchCompilation(handler: WatchHandler): Promise<void> {
+    let run: Promise<NativeRunResult>;
+    try {
+      run = this.#nativeCompiler.run();
+    } catch (error) {
+      handler(toError(error, "InfrastructureError"));
+      return;
+    }
+
+    try {
+      const result = await run;
+      if (result.error) {
+        handler(namedError(result.error.name, result.error.message));
+        return;
+      }
+
+      this.#scheduleIdleCacheFlush();
+      handler(null, new StatsImpl(normalizeNativeStats(result.stats)));
+    } catch (error) {
+      handler(toError(error, "InfrastructureError"));
     }
   }
 
@@ -272,6 +365,91 @@ class CompilerImpl implements Compiler {
       if (this.#pendingCacheFlush === flush) {
         this.#pendingCacheFlush = undefined;
       }
+    }
+  }
+}
+
+class WatchingImpl implements Watching {
+  #closed = false;
+  #running = false;
+  #invalidated = false;
+  #handler: WatchHandler | undefined;
+  readonly #runCompilation: (handler: WatchHandler) => Promise<void> | void;
+  readonly #flushCache: () => Promise<Error | null>;
+  readonly #onClose: () => void;
+  readonly #closeCallbacks: CloseCallback[] = [];
+
+  constructor(
+    runCompilation: (handler: WatchHandler) => Promise<void> | void,
+    flushCache: () => Promise<Error | null>,
+    onClose: () => void
+  ) {
+    this.#runCompilation = runCompilation;
+    this.#flushCache = flushCache;
+    this.#onClose = onClose;
+  }
+
+  start(handler: WatchHandler): void {
+    this.#handler = handler;
+    this.#run();
+  }
+
+  invalidate(): void {
+    if (this.#closed) {
+      return;
+    }
+
+    if (this.#running) {
+      this.#invalidated = true;
+      return;
+    }
+
+    this.#run();
+  }
+
+  close(callback: CloseCallback): void {
+    assertFunction(callback, "callback");
+
+    if (this.#closed && !this.#running) {
+      defer(() => callback(null));
+      return;
+    }
+
+    this.#closed = true;
+    this.#invalidated = false;
+    this.#closeCallbacks.push(callback);
+
+    if (!this.#running) {
+      void this.#finishClose();
+    }
+  }
+
+  async #run(): Promise<void> {
+    if (this.#closed || this.#running || !this.#handler) {
+      return;
+    }
+
+    this.#running = true;
+    await this.#runCompilation(this.#handler);
+    this.#running = false;
+
+    if (this.#closed) {
+      await this.#finishClose();
+      return;
+    }
+
+    if (this.#invalidated) {
+      this.#invalidated = false;
+      await this.#run();
+    }
+  }
+
+  async #finishClose(): Promise<void> {
+    const callbacks = this.#closeCallbacks.splice(0);
+    const flushError = await this.#flushCache();
+    this.#onClose();
+    for (const callback of callbacks) {
+      callback(flushError);
     }
   }
 }
@@ -512,6 +690,11 @@ function normalizeSnapshotStrategy(
         : assertBoolean(strategy.timestamp, `${name}.timestamp`),
     hash: strategy.hash === undefined ? defaults.hash : assertBoolean(strategy.hash, `${name}.hash`)
   };
+}
+
+function normalizeWatchOptions(watchOptions: WatchOptions): void {
+  assertPlainObject(watchOptions, "watchOptions");
+  assertKnownKeys(watchOptions, [], "watchOptions");
 }
 
 function normalizeNativeStats(stats: NativeStatsJson | null | undefined): StatsJson {

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -319,6 +319,86 @@ test("compiler close waits for pending filesystem cache flush", async () => {
   }
 });
 
+test("watch performs initial build and close keeps compiler reusable", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+
+  try {
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch({}, results.handler);
+    const result = await first;
+    assert.equal(result.err, null);
+    assert.equal(result.stats?.hasErrors(), false);
+
+    await closeWatching(watching);
+    assert.equal((await runExistingCompiler(compiler)).err, null);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("watch invalidate triggers rebuild", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 'before';"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+  const entry = join(fixture, "src/index.js");
+
+  try {
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch({}, results.handler);
+    assert.equal((await first).err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /before/);
+
+    const second = results.next();
+    await writeFile(entry, "export const value = 'after';", { encoding: "utf8" });
+    const changedTime = new Date(Date.now() + 2000);
+    await utimes(entry, changedTime, changedTime);
+    watching.invalidate();
+
+    assert.equal((await second).err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /after/);
+    await closeWatching(watching);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("watch conflicts with run watch and compiler close", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+
+  try {
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch({}, results.handler);
+    assert.equal((await first).err, null);
+
+    assert.equal((await runExistingCompiler(compiler)).err?.name, "ConcurrentRunError");
+
+    const failedWatch = collectWatchResults();
+    const failed = failedWatch.next();
+    compiler.watch({}, failedWatch.handler);
+    assert.equal((await failed).err?.name, "ConcurrentRunError");
+
+    const closeResult = await closeCompilerResult(compiler);
+    assert.equal(closeResult?.name, "CompilerRunningError");
+
+    await closeWatching(watching);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 test("run callback is asynchronous", async () => {
   const fixture = await createFixture({
     "src/index.js": "export const value = 1;"
@@ -471,6 +551,39 @@ async function closeCompiler(compiler: ReturnType<typeof unpack>) {
       }
     });
   });
+}
+
+async function closeCompilerResult(compiler: ReturnType<typeof unpack>) {
+  return new Promise<Error | null>((resolve) => {
+    compiler.close((err) => {
+      resolve(err);
+    });
+  });
+}
+
+async function closeWatching(watching: ReturnType<ReturnType<typeof unpack>["watch"]>) {
+  await new Promise<void>((resolve, reject) => {
+    watching.close((err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function collectWatchResults() {
+  const resolvers: Array<(result: { err: Error | null; stats?: Stats }) => void> = [];
+  return {
+    handler: (err: Error | null, stats?: Stats) => {
+      resolvers.shift()?.({ err, stats });
+    },
+    next: () =>
+      new Promise<{ err: Error | null; stats?: Stats }>((resolve) => {
+        resolvers.push(resolve);
+      })
+  };
 }
 
 function delay(ms: number) {


### PR DESCRIPTION
## Summary

- Add public `compiler.watch(watchOptions, handler)` and `Watching` handle types.
- Run an initial compilation through the watch handler with the same infrastructure-error/Stats split as `run`.
- Add `Watching.invalidate()` for manual rebuilds and `Watching.close(callback)` for clean shutdown without closing the compiler.
- Enforce run/watch/close conflicts while a watch session is active.

This PR is stacked on #17. File subscription driven rebuilds are scoped to the next stacked PR.

## Validation

- cargo fmt --all --check
- cargo test --workspace
- pnpm --filter @unpack-js/core typecheck
- pnpm --filter @unpack-js/core test

Closes #7