### PR TITLE
Rebuild watch sessions from dependency sets

### DIFF
--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
 
 use tokio::sync::Mutex;
 
@@ -19,6 +19,7 @@ pub struct Compilation {
     assets: Vec<Asset>,
     entries: Vec<ModuleId>,
     errors: Vec<Error>,
+    watch_dependencies: WatchDependencies,
 }
 
 impl Compilation {
@@ -36,6 +37,7 @@ impl Compilation {
             assets: Vec::new(),
             entries: Vec::new(),
             errors: Vec::new(),
+            watch_dependencies: WatchDependencies::default(),
         }
     }
 
@@ -63,6 +65,10 @@ impl Compilation {
         &self.errors
     }
 
+    pub fn watch_dependencies(&self) -> &WatchDependencies {
+        &self.watch_dependencies
+    }
+
     pub async fn make(&mut self) -> Result<()> {
         let state = Arc::new(Mutex::new(MakeState::default()));
         let result = make::run(
@@ -77,6 +83,11 @@ impl Compilation {
         self.module_graph = std::mem::take(&mut state.module_graph);
         self.entries = std::mem::take(&mut state.entries).into_values().collect();
         self.errors = std::mem::take(&mut state.errors);
+        self.watch_dependencies = WatchDependencies {
+            files: std::mem::take(&mut state.file_dependencies),
+            contexts: std::mem::take(&mut state.context_dependencies),
+            missing: std::mem::take(&mut state.missing_dependencies),
+        };
 
         result
     }
@@ -92,5 +103,26 @@ impl Compilation {
             &self.chunk_graph,
             &self.entries,
         );
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WatchDependencies {
+    files: BTreeSet<PathBuf>,
+    contexts: BTreeSet<PathBuf>,
+    missing: BTreeSet<PathBuf>,
+}
+
+impl WatchDependencies {
+    pub fn files(&self) -> &BTreeSet<PathBuf> {
+        &self.files
+    }
+
+    pub fn contexts(&self) -> &BTreeSet<PathBuf> {
+        &self.contexts
+    }
+
+    pub fn missing(&self) -> &BTreeSet<PathBuf> {
+        &self.missing
     }
 }

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -19,7 +19,7 @@ pub use chunk_graph::{
     AsyncBlockOrigin, Chunk, ChunkGraph, ChunkGroup, ChunkGroupId, ChunkGroupKind, ChunkId,
 };
 pub use code_generation::{Asset, RuntimeRequirement, RuntimeRequirements};
-pub use compilation::Compilation;
+pub use compilation::{Compilation, WatchDependencies};
 pub use compiler::{Compiler, CompilerOptions, DEFAULT_EXTENSIONS, Entry};
 pub use dependency::{
     AsyncDependenciesBlock, ConstDependency, Dependency, DependencyKind, EntryDependency,

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -20,6 +20,9 @@ pub(crate) struct MakeState {
     pub module_graph: ModuleGraph,
     pub entries: BTreeMap<usize, ModuleId>,
     pub errors: Vec<Error>,
+    pub file_dependencies: BTreeSet<PathBuf>,
+    pub context_dependencies: BTreeSet<PathBuf>,
+    pub missing_dependencies: BTreeSet<PathBuf>,
     modules_by_identity: HashMap<ModuleIdentity, ModuleId>,
 }
 
@@ -123,6 +126,7 @@ async fn process_request(
         Err(error) if error.is_compilation_error() => {
             let identity = failed_module_identity(&request.context, &request.dependency);
             let mut state = state.lock().await;
+            state.missing_dependencies.insert(identity.resource.clone());
             let add_result = state.add_or_connect(
                 request.origin_module,
                 request.entry_index,
@@ -139,7 +143,9 @@ async fn process_request(
     let resource = factorized.resource;
 
     let add_result = {
-        state.lock().await.add_or_connect(
+        let mut state = state.lock().await;
+        state.file_dependencies.insert(resource.clone());
+        state.add_or_connect(
             request.origin_module,
             request.entry_index,
             request.origin_block,
@@ -256,7 +262,19 @@ fn failed_module_identity(context: &Path, dependency: &Dependency) -> ModuleIden
     } else {
         context.join(request)
     };
-    ModuleIdentity::new(resource)
+    ModuleIdentity::new(normalize_missing_resource(resource))
+}
+
+fn normalize_missing_resource(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir if normalized.pop() => {}
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
 }
 
 impl MakeState {

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -86,6 +86,15 @@ pub struct NativeStatsJson {
     pub assets: Vec<NativeAsset>,
     #[napi(js_name = "outputPath")]
     pub output_path: String,
+    #[napi(js_name = "watchDependencies")]
+    pub watch_dependencies: NativeWatchDependencies,
+}
+
+#[napi(object)]
+pub struct NativeWatchDependencies {
+    pub files: Vec<String>,
+    pub contexts: Vec<String>,
+    pub missing: Vec<String>,
 }
 
 #[napi(object)]
@@ -284,6 +293,7 @@ fn run_compiler_inner(compiler: Option<&Compiler>, output_path: &Path) -> Native
             warnings: Vec::new(),
             assets: compilation.assets().iter().map(asset_stats).collect(),
             output_path: output_path.to_string_lossy().into_owned(),
+            watch_dependencies: watch_dependencies(compilation.watch_dependencies()),
         }),
     }
 }
@@ -367,5 +377,25 @@ fn asset_stats(asset: &Asset) -> NativeAsset {
     NativeAsset {
         name: asset.filename.clone(),
         size: asset.source.len().try_into().unwrap_or(u32::MAX),
+    }
+}
+
+fn watch_dependencies(dependencies: &unpack_core::WatchDependencies) -> NativeWatchDependencies {
+    NativeWatchDependencies {
+        files: dependencies
+            .files()
+            .iter()
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect(),
+        contexts: dependencies
+            .contexts()
+            .iter()
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect(),
+        missing: dependencies
+            .missing()
+            .iter()
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect(),
     }
 }

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -1,4 +1,6 @@
 import { createRequire } from "node:module";
+import { watch as watchFileSystem } from "node:fs";
+import type { FSWatcher } from "node:fs";
 import { isAbsolute, resolve } from "node:path";
 
 export interface UnpackOptions {
@@ -52,6 +54,13 @@ export interface StatsJson {
   warnings: StatsError[];
   assets: StatsAsset[];
   outputPath: string;
+  watchDependencies: WatchDependencySets;
+}
+
+export interface WatchDependencySets {
+  files: string[];
+  contexts: string[];
+  missing: string[];
 }
 
 export interface Stats {
@@ -70,7 +79,9 @@ export interface Watching {
   invalidate(): void;
 }
 
-export interface WatchOptions {}
+export interface WatchOptions {
+  aggregateTimeout?: number;
+}
 
 export type RunCallback = (err: Error | null, stats?: Stats) => void;
 export type WatchHandler = (err: Error | null, stats?: Stats) => void;
@@ -115,12 +126,18 @@ interface NormalizedSnapshotStrategy {
   hash: boolean;
 }
 
+interface NormalizedWatchOptions {
+  aggregateTimeout: number;
+}
+
 interface NativeStatsJson {
   errors: StatsError[];
   warnings?: StatsError[];
   assets: StatsAsset[];
   outputPath?: string;
   output_path?: string;
+  watchDependencies?: WatchDependencySets;
+  watch_dependencies?: WatchDependencySets;
 }
 
 interface NativeRunResult {
@@ -218,7 +235,7 @@ class CompilerImpl implements Compiler {
   }
 
   watch(watchOptions: WatchOptions, handler: WatchHandler): Watching {
-    normalizeWatchOptions(watchOptions);
+    const normalizedWatchOptions = normalizeWatchOptions(watchOptions);
     assertFunction(handler, "handler");
 
     if (this.#closed) {
@@ -227,7 +244,8 @@ class CompilerImpl implements Compiler {
           defer(() => watchHandler(namedError("CompilerClosedError", "compiler is closed")));
         },
         () => Promise.resolve(null),
-        () => {}
+        () => {},
+        { aggregateTimeout: 20 }
       );
       watching.start(handler);
       return watching;
@@ -241,7 +259,8 @@ class CompilerImpl implements Compiler {
           );
         },
         () => Promise.resolve(null),
-        () => {}
+        () => {},
+        { aggregateTimeout: 20 }
       );
       watching.start(handler);
       return watching;
@@ -254,7 +273,8 @@ class CompilerImpl implements Compiler {
         if (this.#watching === watching) {
           this.#watching = undefined;
         }
-      }
+      },
+      normalizedWatchOptions
     );
     this.#watching = watching;
     watching.start(handler);
@@ -374,19 +394,24 @@ class WatchingImpl implements Watching {
   #running = false;
   #invalidated = false;
   #handler: WatchHandler | undefined;
+  #rebuildTimer: ReturnType<typeof setTimeout> | undefined;
+  readonly #watchers: FSWatcher[] = [];
   readonly #runCompilation: (handler: WatchHandler) => Promise<void> | void;
   readonly #flushCache: () => Promise<Error | null>;
   readonly #onClose: () => void;
+  readonly #watchOptions: NormalizedWatchOptions;
   readonly #closeCallbacks: CloseCallback[] = [];
 
   constructor(
     runCompilation: (handler: WatchHandler) => Promise<void> | void,
     flushCache: () => Promise<Error | null>,
-    onClose: () => void
+    onClose: () => void,
+    watchOptions: NormalizedWatchOptions
   ) {
     this.#runCompilation = runCompilation;
     this.#flushCache = flushCache;
     this.#onClose = onClose;
+    this.#watchOptions = watchOptions;
   }
 
   start(handler: WatchHandler): void {
@@ -398,6 +423,8 @@ class WatchingImpl implements Watching {
     if (this.#closed) {
       return;
     }
+
+    this.#clearRebuildTimer();
 
     if (this.#running) {
       this.#invalidated = true;
@@ -417,6 +444,8 @@ class WatchingImpl implements Watching {
 
     this.#closed = true;
     this.#invalidated = false;
+    this.#clearRebuildTimer();
+    this.#closeWatchers();
     this.#closeCallbacks.push(callback);
 
     if (!this.#running) {
@@ -430,8 +459,18 @@ class WatchingImpl implements Watching {
     }
 
     this.#running = true;
-    await this.#runCompilation(this.#handler);
+    let latestStats: Stats | undefined;
+    await this.#runCompilation((err, stats) => {
+      if (!err && stats) {
+        latestStats = stats;
+      }
+      this.#handler?.(err, stats);
+    });
     this.#running = false;
+
+    if (!this.#closed && latestStats) {
+      this.#replaceWatchers(latestStats.toJson().watchDependencies);
+    }
 
     if (this.#closed) {
       await this.#finishClose();
@@ -452,6 +491,47 @@ class WatchingImpl implements Watching {
       callback(flushError);
     }
   }
+
+  #replaceWatchers(dependencies: WatchDependencySets): void {
+    this.#closeWatchers();
+    for (const file of dependencies.files) {
+      try {
+        this.#watchers.push(
+          watchFileSystem(file, { persistent: false }, () => {
+            this.#queueRebuild();
+          })
+        );
+      } catch {
+        // Missing or unsupported watch targets are represented in stats but should not
+        // make an otherwise successful compilation fail.
+      }
+    }
+  }
+
+  #queueRebuild(): void {
+    if (this.#closed) {
+      return;
+    }
+
+    this.#clearRebuildTimer();
+    this.#rebuildTimer = setTimeout(() => {
+      this.#rebuildTimer = undefined;
+      this.invalidate();
+    }, this.#watchOptions.aggregateTimeout);
+  }
+
+  #clearRebuildTimer(): void {
+    if (this.#rebuildTimer !== undefined) {
+      clearTimeout(this.#rebuildTimer);
+      this.#rebuildTimer = undefined;
+    }
+  }
+
+  #closeWatchers(): void {
+    while (this.#watchers.length > 0) {
+      this.#watchers.pop()?.close();
+    }
+  }
 }
 
 class StatsImpl implements Stats {
@@ -466,7 +546,8 @@ class StatsImpl implements Stats {
       errors: this.json.errors.map(cloneStatsError),
       warnings: this.json.warnings.map(cloneStatsError),
       assets: this.json.assets.map((asset) => ({ ...asset })),
-      outputPath: this.json.outputPath
+      outputPath: this.json.outputPath,
+      watchDependencies: cloneWatchDependencies(this.json.watchDependencies)
     };
   }
 }
@@ -692,20 +773,35 @@ function normalizeSnapshotStrategy(
   };
 }
 
-function normalizeWatchOptions(watchOptions: WatchOptions): void {
+function normalizeWatchOptions(watchOptions: WatchOptions): NormalizedWatchOptions {
   assertPlainObject(watchOptions, "watchOptions");
-  assertKnownKeys(watchOptions, [], "watchOptions");
+  assertKnownKeys(watchOptions, ["aggregateTimeout"], "watchOptions");
+  return {
+    aggregateTimeout:
+      watchOptions.aggregateTimeout === undefined
+        ? 20
+        : assertNonNegativeInteger(watchOptions.aggregateTimeout, "watchOptions.aggregateTimeout")
+  };
 }
 
 function normalizeNativeStats(stats: NativeStatsJson | null | undefined): StatsJson {
   if (!stats) {
-    return { errors: [], warnings: [], assets: [], outputPath: "" };
+    return {
+      errors: [],
+      warnings: [],
+      assets: [],
+      outputPath: "",
+      watchDependencies: emptyWatchDependencies()
+    };
   }
   return {
     errors: stats.errors.map(cloneStatsError),
     warnings: (stats.warnings ?? []).map(cloneStatsError),
     assets: stats.assets.map((asset) => ({ ...asset })),
-    outputPath: stats.outputPath ?? stats.output_path ?? ""
+    outputPath: stats.outputPath ?? stats.output_path ?? "",
+    watchDependencies: cloneWatchDependencies(
+      stats.watchDependencies ?? stats.watch_dependencies ?? emptyWatchDependencies()
+    )
   };
 }
 
@@ -716,6 +812,22 @@ function cloneStatsError(error: StatsError): StatsError {
     ...(error.request === undefined ? {} : { request: error.request }),
     ...(error.issuer === undefined ? {} : { issuer: error.issuer }),
     ...(error.stack === undefined ? {} : { stack: error.stack })
+  };
+}
+
+function cloneWatchDependencies(dependencies: WatchDependencySets): WatchDependencySets {
+  return {
+    files: [...dependencies.files],
+    contexts: [...dependencies.contexts],
+    missing: [...dependencies.missing]
+  };
+}
+
+function emptyWatchDependencies(): WatchDependencySets {
+  return {
+    files: [],
+    contexts: [],
+    missing: []
   };
 }
 

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -370,6 +370,93 @@ test("watch invalidate triggers rebuild", async () => {
   }
 });
 
+test("stats exposes watch dependency sets", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "import './dep'; import './missing'; export const value = dep;",
+    "src/dep.js": "export const dep = 'dep';"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+
+  try {
+    const result = await runExistingCompiler(compiler);
+    assert.equal(result.err, null);
+    const json = result.stats?.toJson();
+    const sourceRoot = await realpath(join(fixture, "src"));
+    assert.ok(json);
+    assert.equal(json.errors.length, 1);
+    assert.deepEqual(json.watchDependencies.files.sort(), [
+      join(sourceRoot, "dep.js"),
+      join(sourceRoot, "index.js")
+    ]);
+    assert.deepEqual(json.watchDependencies.contexts, []);
+    assert.deepEqual(json.watchDependencies.missing, [join(sourceRoot, "missing")]);
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("watch rebuilds when a watched dependency changes", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "import { value } from './dep'; export const result = value;",
+    "src/dep.js": "export const value = 'before';"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+  const dependency = join(fixture, "src/dep.js");
+
+  try {
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch({}, results.handler);
+    assert.equal((await first).err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /before/);
+
+    const second = results.next();
+    await writeFile(dependency, "export const value = 'after';", { encoding: "utf8" });
+    const changedTime = new Date(Date.now() + 2000);
+    await utimes(dependency, changedTime, changedTime);
+
+    assert.equal((await second).err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /after/);
+    await closeWatching(watching);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("watch aggregateTimeout coalesces rapid changes", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 'initial';"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+  const entry = join(fixture, "src/index.js");
+
+  try {
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch({ aggregateTimeout: 50 }, results.handler);
+    assert.equal((await first).err, null);
+
+    const second = results.next();
+    await writeFile(entry, "export const value = 'first';", { encoding: "utf8" });
+    const firstTime = new Date(Date.now() + 2000);
+    await utimes(entry, firstTime, firstTime);
+    await writeFile(entry, "export const value = 'second';", { encoding: "utf8" });
+    const secondTime = new Date(Date.now() + 4000);
+    await utimes(entry, secondTime, secondTime);
+
+    assert.equal((await second).err, null);
+    await delay(150);
+    assert.equal(results.calls(), 2);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /second/);
+    await closeWatching(watching);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 test("watch conflicts with run watch and compiler close", async () => {
   const fixture = await createFixture({
     "src/index.js": "export const value = 1;"
@@ -575,14 +662,17 @@ async function closeWatching(watching: ReturnType<ReturnType<typeof unpack>["wat
 
 function collectWatchResults() {
   const resolvers: Array<(result: { err: Error | null; stats?: Stats }) => void> = [];
+  let calls = 0;
   return {
     handler: (err: Error | null, stats?: Stats) => {
+      calls += 1;
       resolvers.shift()?.({ err, stats });
     },
     next: () =>
       new Promise<{ err: Error | null; stats?: Stats }>((resolve) => {
         resolvers.push(resolve);
-      })
+      }),
+    calls: () => calls
   };
 }
 


### PR DESCRIPTION
## Summary
- expose watch dependency sets in stats from core through the JavaScript API
- resubscribe watch sessions after each completed compilation
- rebuild on watched source changes and coalesce rapid changes with aggregateTimeout

## Tests
- cargo fmt --all --check
- cargo test --workspace
- pnpm --filter @unpack-js/core test

Closes #8

Stacked on #18.