### PR TITLE
Roll up persistent cache and watch implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbor4ii"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faed1a83001dc2c9201451030cc317e35bef36c84d3781d7c5bb9f343c397da8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,10 +1203,13 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 name = "unpack_core"
 version = "0.1.0"
 dependencies = [
+ "cbor4ii",
  "codspeed-divan-compat",
  "futures",
  "rspack_resolver",
  "rspack_sources",
+ "serde",
+ "serde_json",
  "swc_experimental_allocator",
  "swc_experimental_ecma_ast",
  "swc_experimental_ecma_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 repository = "https://github.com/unpack-dev/unpack"
 
 [workspace.dependencies]
+cbor4ii = { version = "1.2.2", features = ["serde1"] }
 divan = { package = "codspeed-divan-compat", version = "5.0.1" }
 futures = "0.3.31"
 napi = "3.9.4"
@@ -15,6 +16,8 @@ napi-build = "2.3.2"
 napi-derive = "3.5.7"
 rspack_resolver = { version = "0.9.3", default-features = false }
 rspack_sources = "0.101.1"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 swc_experimental_allocator = "0.11.0"
 swc_experimental_ecma_ast = "0.11.0"
 swc_experimental_ecma_parser = "0.11.0"

--- a/crates/unpack_core/Cargo.toml
+++ b/crates/unpack_core/Cargo.toml
@@ -6,9 +6,12 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+cbor4ii = { workspace = true }
 futures = { workspace = true }
 rspack_resolver = { workspace = true }
 rspack_sources = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 swc_experimental_allocator = { workspace = true }
 swc_experimental_ecma_ast = { workspace = true }
 swc_experimental_ecma_parser = { workspace = true }

--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -96,6 +96,7 @@ pub struct BuildDependency {
 #[derive(Debug, Default)]
 struct BuildCacheInner {
     module_builds: HashMap<ModuleIdentity, ModuleBuildRecord>,
+    dirty: bool,
     module_hits: usize,
     module_misses: usize,
 }
@@ -166,22 +167,41 @@ impl BuildCache {
             return;
         }
 
-        let module_builds = {
+        {
             let mut inner = self
                 .inner
                 .lock()
                 .expect("build cache mutex should not be poisoned");
             inner.module_builds.insert(identity, record);
             if self.options.kind == CacheKind::Filesystem {
-                Some(inner.module_builds.clone())
-            } else {
-                None
+                inner.dirty = true;
             }
+        }
+    }
+
+    pub(crate) fn flush_to_filesystem(&self) -> io::Result<()> {
+        if self.options.kind != CacheKind::Filesystem {
+            return Ok(());
+        }
+
+        let module_builds = {
+            let inner = self
+                .inner
+                .lock()
+                .expect("build cache mutex should not be poisoned");
+            if !inner.dirty {
+                return Ok(());
+            }
+            inner.module_builds.clone()
         };
 
-        if let Some(module_builds) = module_builds {
-            let _ = self.write_filesystem_cache(&module_builds);
-        }
+        self.write_filesystem_cache(&module_builds)?;
+
+        self.inner
+            .lock()
+            .expect("build cache mutex should not be poisoned")
+            .dirty = false;
+        Ok(())
     }
 
     #[cfg(test)]

--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -1,14 +1,23 @@
 use std::{
     collections::HashMap,
+    fs, io,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
 
 use crate::{ModuleIdentity, SnapshotStrategy, parser::ParsedModule, snapshot::FileSnapshot};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Default)]
+const CACHE_MAGIC: &str = "UNPACK_PERSISTENT_CACHE";
+const PACK_MAGIC: &[u8] = b"UNPACK-CACHE-PACK\0";
+const CACHE_SCHEMA_VERSION: u32 = 1;
+const DEFAULT_PACK_FILE: &str = "packs/modules.cbor";
+const MANIFEST_FILE: &str = "container.json";
+
+#[derive(Debug, Clone)]
 pub(crate) struct BuildCache {
     options: CacheOptions,
+    build_dependency_snapshot_strategy: SnapshotStrategy,
     inner: Arc<Mutex<BuildCacheInner>>,
 }
 
@@ -91,7 +100,7 @@ struct BuildCacheInner {
     module_misses: usize,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct ModuleBuildRecord {
     parsed: ParsedModule,
     source: String,
@@ -121,11 +130,17 @@ impl ModuleBuildRecord {
 }
 
 impl BuildCache {
-    pub(crate) fn new(options: CacheOptions) -> Self {
-        Self {
+    pub(crate) fn new(
+        options: CacheOptions,
+        build_dependency_snapshot_strategy: SnapshotStrategy,
+    ) -> Self {
+        let cache = Self {
             options,
+            build_dependency_snapshot_strategy,
             inner: Arc::new(Mutex::new(BuildCacheInner::default())),
-        }
+        };
+        cache.restore_from_filesystem();
+        cache
     }
 
     pub(crate) fn get_module_build(&self, identity: &ModuleIdentity) -> Option<ModuleBuildRecord> {
@@ -151,11 +166,22 @@ impl BuildCache {
             return;
         }
 
-        self.inner
-            .lock()
-            .expect("build cache mutex should not be poisoned")
-            .module_builds
-            .insert(identity, record);
+        let module_builds = {
+            let mut inner = self
+                .inner
+                .lock()
+                .expect("build cache mutex should not be poisoned");
+            inner.module_builds.insert(identity, record);
+            if self.options.kind == CacheKind::Filesystem {
+                Some(inner.module_builds.clone())
+            } else {
+                None
+            }
+        };
+
+        if let Some(module_builds) = module_builds {
+            let _ = self.write_filesystem_cache(&module_builds);
+        }
     }
 
     #[cfg(test)]
@@ -170,6 +196,191 @@ impl BuildCache {
             module_misses: inner.module_misses,
         }
     }
+}
+
+impl BuildCache {
+    fn restore_from_filesystem(&self) {
+        if self.options.kind != CacheKind::Filesystem {
+            return;
+        }
+        let Some(cache_location) = &self.options.cache_location else {
+            return;
+        };
+        let Some(manifest) = read_manifest(cache_location) else {
+            return;
+        };
+        if !self.manifest_is_valid(&manifest) {
+            return;
+        }
+
+        let Some(pack) = read_pack(cache_location, &manifest.pack_file) else {
+            return;
+        };
+        if pack.magic != CACHE_MAGIC
+            || pack.schema_version != CACHE_SCHEMA_VERSION
+            || pack.cache_version != self.cache_version()
+        {
+            return;
+        }
+
+        self.inner
+            .lock()
+            .expect("build cache mutex should not be poisoned")
+            .module_builds = pack.module_builds.into_iter().collect();
+    }
+
+    fn write_filesystem_cache(
+        &self,
+        module_builds: &HashMap<ModuleIdentity, ModuleBuildRecord>,
+    ) -> io::Result<()> {
+        let Some(cache_location) = &self.options.cache_location else {
+            return Ok(());
+        };
+
+        let pack_file = PathBuf::from(DEFAULT_PACK_FILE);
+        let pack_path = cache_location.join(&pack_file);
+        if let Some(parent) = pack_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let cache_version = self.cache_version();
+        let pack = CachePackDto {
+            magic: CACHE_MAGIC.to_string(),
+            schema_version: CACHE_SCHEMA_VERSION,
+            cache_version: cache_version.clone(),
+            module_builds: module_builds
+                .iter()
+                .map(|(identity, record)| (identity.clone(), record.clone()))
+                .collect(),
+        };
+        let pack_payload = cbor4ii::serde::to_vec(Vec::new(), &pack)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        let mut pack_bytes = PACK_MAGIC.to_vec();
+        pack_bytes.extend(pack_payload);
+        fs::write(pack_path, pack_bytes)?;
+
+        let manifest = CacheManifest {
+            magic: CACHE_MAGIC.to_string(),
+            schema_version: CACHE_SCHEMA_VERSION,
+            cache_version,
+            pack_file: pack_file.to_string_lossy().replace('\\', "/"),
+            build_dependencies: self.build_dependency_snapshots()?,
+        };
+        fs::create_dir_all(cache_location)?;
+        let manifest_json = serde_json::to_vec_pretty(&manifest)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        fs::write(cache_location.join(MANIFEST_FILE), manifest_json)?;
+        Ok(())
+    }
+
+    fn manifest_is_valid(&self, manifest: &CacheManifest) -> bool {
+        manifest.magic == CACHE_MAGIC
+            && manifest.schema_version == CACHE_SCHEMA_VERSION
+            && manifest.cache_version == self.cache_version()
+            && self.build_dependency_snapshots_are_valid(&manifest.build_dependencies)
+    }
+
+    fn cache_version(&self) -> String {
+        self.options.version.clone().unwrap_or_default()
+    }
+
+    fn build_dependency_snapshots(&self) -> io::Result<Vec<PersistentBuildDependencySnapshot>> {
+        self.options
+            .build_dependencies
+            .iter()
+            .map(|dependency| {
+                Ok(PersistentBuildDependencySnapshot {
+                    name: dependency.name.clone(),
+                    files: dependency
+                        .files
+                        .iter()
+                        .map(|path| {
+                            Ok(PersistentFileSnapshot {
+                                path: path.clone(),
+                                snapshot: FileSnapshot::create_from_file_sync(
+                                    path,
+                                    self.build_dependency_snapshot_strategy,
+                                )
+                                .map_err(|error| {
+                                    io::Error::new(io::ErrorKind::InvalidData, error)
+                                })?,
+                            })
+                        })
+                        .collect::<io::Result<Vec<_>>>()?,
+                })
+            })
+            .collect()
+    }
+
+    fn build_dependency_snapshots_are_valid(
+        &self,
+        snapshots: &[PersistentBuildDependencySnapshot],
+    ) -> bool {
+        if snapshots.len() != self.options.build_dependencies.len() {
+            return false;
+        }
+
+        self.options.build_dependencies.iter().all(|dependency| {
+            let Some(snapshot) = snapshots
+                .iter()
+                .find(|snapshot| snapshot.name == dependency.name)
+            else {
+                return false;
+            };
+            if snapshot.files.len() != dependency.files.len() {
+                return false;
+            }
+
+            dependency.files.iter().all(|path| {
+                snapshot.files.iter().any(|snapshot_file| {
+                    snapshot_file.path == *path
+                        && snapshot_file
+                            .snapshot
+                            .is_valid_sync(path, self.build_dependency_snapshot_strategy)
+                })
+            })
+        })
+    }
+}
+
+fn read_manifest(cache_location: &Path) -> Option<CacheManifest> {
+    let bytes = fs::read(cache_location.join(MANIFEST_FILE)).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn read_pack(cache_location: &Path, pack_file: &str) -> Option<CachePackDto> {
+    let bytes = fs::read(cache_location.join(pack_file)).ok()?;
+    let payload = bytes.strip_prefix(PACK_MAGIC)?;
+    cbor4ii::serde::from_slice(payload).ok()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CacheManifest {
+    magic: String,
+    schema_version: u32,
+    cache_version: String,
+    pack_file: String,
+    build_dependencies: Vec<PersistentBuildDependencySnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistentBuildDependencySnapshot {
+    name: String,
+    files: Vec<PersistentFileSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistentFileSnapshot {
+    path: PathBuf,
+    snapshot: FileSnapshot,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CachePackDto {
+    magic: String,
+    schema_version: u32,
+    cache_version: String,
+    module_builds: Vec<(ModuleIdentity, ModuleBuildRecord)>,
 }
 
 #[cfg(test)]

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
 
 use tokio::sync::Mutex;
 
@@ -19,6 +19,7 @@ pub struct Compilation {
     assets: Vec<Asset>,
     entries: Vec<ModuleId>,
     errors: Vec<Error>,
+    watch_dependencies: WatchDependencies,
 }
 
 impl Compilation {
@@ -36,6 +37,7 @@ impl Compilation {
             assets: Vec::new(),
             entries: Vec::new(),
             errors: Vec::new(),
+            watch_dependencies: WatchDependencies::default(),
         }
     }
 
@@ -63,6 +65,10 @@ impl Compilation {
         &self.errors
     }
 
+    pub fn watch_dependencies(&self) -> &WatchDependencies {
+        &self.watch_dependencies
+    }
+
     pub async fn make(&mut self) -> Result<()> {
         let state = Arc::new(Mutex::new(MakeState::default()));
         let result = make::run(
@@ -77,6 +83,11 @@ impl Compilation {
         self.module_graph = std::mem::take(&mut state.module_graph);
         self.entries = std::mem::take(&mut state.entries).into_values().collect();
         self.errors = std::mem::take(&mut state.errors);
+        self.watch_dependencies = WatchDependencies {
+            files: std::mem::take(&mut state.file_dependencies),
+            contexts: std::mem::take(&mut state.context_dependencies),
+            missing: std::mem::take(&mut state.missing_dependencies),
+        };
 
         result
     }
@@ -92,5 +103,26 @@ impl Compilation {
             &self.chunk_graph,
             &self.entries,
         );
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WatchDependencies {
+    files: BTreeSet<PathBuf>,
+    contexts: BTreeSet<PathBuf>,
+    missing: BTreeSet<PathBuf>,
+}
+
+impl WatchDependencies {
+    pub fn files(&self) -> &BTreeSet<PathBuf> {
+        &self.files
+    }
+
+    pub fn contexts(&self) -> &BTreeSet<PathBuf> {
+        &self.contexts
+    }
+
+    pub fn missing(&self) -> &BTreeSet<PathBuf> {
+        &self.missing
     }
 }

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -83,6 +83,12 @@ impl Compiler {
         compilation.create_assets();
         Ok(compilation)
     }
+
+    pub fn flush_cache(&self) -> std::result::Result<(), String> {
+        self.build_cache
+            .flush_to_filesystem()
+            .map_err(|error| error.to_string())
+    }
 }
 
 fn default_resolve_options() -> ResolveOptions {
@@ -205,6 +211,7 @@ mod tests {
 
         let first_compiler = Compiler::new(options.clone());
         let first = first_compiler.run().await?;
+        first_compiler.flush_cache()?;
         assert_eq!(first.errors(), []);
         assert!(cache_location.join("container.json").exists());
         assert!(cache_location.join("packs/modules.cbor").exists());
@@ -240,7 +247,9 @@ mod tests {
             files: vec![config.clone()],
         }];
 
-        Compiler::new(options.clone()).run().await?;
+        let first_compiler = Compiler::new(options.clone());
+        first_compiler.run().await?;
+        first_compiler.flush_cache()?;
         assert_eq!(
             Compiler::new(options.clone())
                 .build_cache

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -55,7 +55,8 @@ pub struct Compiler {
 impl Compiler {
     pub fn new(options: CompilerOptions) -> Self {
         let resolver = UnpackResolver::new(options.resolve.clone());
-        let build_cache = BuildCache::new(options.cache.clone());
+        let build_cache =
+            BuildCache::new(options.cache.clone(), options.snapshot.build_dependencies);
         Self {
             options,
             resolver,
@@ -179,6 +180,77 @@ mod tests {
                 .expect("main asset should exist")
                 .contains("after")
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn filesystem_cache_restores_module_build_records_for_later_compiler_instances()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write(
+            temp.path().join("index.js"),
+            r#"
+                import "./dep";
+                export const result = "ok";
+            "#,
+        )?;
+        write(temp.path().join("dep.js"), "export const value = 1;")?;
+        let cache_location = temp.path().join(".cache/unpack/default");
+
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache = CacheOptions::filesystem();
+        options.cache.cache_location = Some(cache_location.clone());
+        options.cache.version = Some("test-version".to_string());
+
+        let first_compiler = Compiler::new(options.clone());
+        let first = first_compiler.run().await?;
+        assert_eq!(first.errors(), []);
+        assert!(cache_location.join("container.json").exists());
+        assert!(cache_location.join("packs/modules.cbor").exists());
+        let manifest = fs::read_to_string(cache_location.join("container.json"))?;
+        assert!(manifest.contains("UNPACK_PERSISTENT_CACHE"));
+        assert!(manifest.contains("test-version"));
+
+        let second_compiler = Compiler::new(options);
+        assert_eq!(second_compiler.build_cache.stats().module_entries, 2);
+
+        let second = second_compiler.run().await?;
+        let second_cache = second_compiler.build_cache.stats();
+        assert_eq!(second_cache.module_hits, 2);
+        assert_eq!(asset_sources(&first), asset_sources(&second));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn filesystem_cache_rejects_invalid_build_dependency_snapshots()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write(temp.path().join("index.js"), "export const value = 1;")?;
+        let config = temp.path().join("config.js");
+        write(&config, "export default 'before';")?;
+        let cache_location = temp.path().join(".cache/unpack/default");
+
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache = CacheOptions::filesystem();
+        options.cache.cache_location = Some(cache_location);
+        options.cache.build_dependencies = vec![crate::BuildDependency {
+            name: "config".to_string(),
+            files: vec![config.clone()],
+        }];
+
+        Compiler::new(options.clone()).run().await?;
+        assert_eq!(
+            Compiler::new(options.clone())
+                .build_cache
+                .stats()
+                .module_entries,
+            1
+        );
+
+        write(&config, "export default 'after';")?;
+        assert_eq!(Compiler::new(options).build_cache.stats().module_entries, 0);
 
         Ok(())
     }

--- a/crates/unpack_core/src/dependency.rs
+++ b/crates/unpack_core/src/dependency.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct SourceRange {
     pub start: u32,
     pub end: u32,
@@ -23,7 +25,7 @@ impl SourceRange {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct AsyncDependenciesBlock {
     dependencies: Vec<Dependency>,
 }
@@ -38,7 +40,7 @@ impl AsyncDependenciesBlock {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Dependency {
     Entry(EntryDependency),
     HarmonyImportSideEffect(HarmonyImportSideEffectDependency),
@@ -161,7 +163,7 @@ impl Dependency {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ModuleDependency {
     pub request: String,
     pub user_request: String,
@@ -197,7 +199,7 @@ impl fmt::Debug for ModuleDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct EntryDependency {
     pub module: ModuleDependency,
 }
@@ -210,7 +212,7 @@ impl EntryDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HarmonyImportSideEffectDependency {
     pub module: ModuleDependency,
     pub import_var: Option<String>,
@@ -231,7 +233,7 @@ impl HarmonyImportSideEffectDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HarmonyImportSpecifierDependency {
     pub module: ModuleDependency,
     pub ids: Vec<String>,
@@ -258,7 +260,7 @@ impl HarmonyImportSpecifierDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HarmonyExportHeaderDependency {
     pub declaration_range: Option<SourceRange>,
     pub statement_range: SourceRange,
@@ -273,7 +275,7 @@ impl HarmonyExportHeaderDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HarmonyExportSpecifierDependency {
     pub id: String,
     pub name: String,
@@ -288,7 +290,7 @@ impl HarmonyExportSpecifierDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HarmonyExportExpressionDependency {
     pub range: SourceRange,
     pub statement_range: SourceRange,
@@ -309,7 +311,7 @@ impl HarmonyExportExpressionDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HarmonyExportImportedSpecifierDependency {
     pub module: ModuleDependency,
     pub ids: Vec<String>,
@@ -337,7 +339,7 @@ impl HarmonyExportImportedSpecifierDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ConstDependency {
     pub expression: String,
     pub range: SourceRange,
@@ -352,10 +354,10 @@ impl ConstDependency {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct NullDependency;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ImportDependency {
     pub module: ModuleDependency,
 }
@@ -378,7 +380,7 @@ impl ImportDependency {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum DependencyKind {
     Entry,
     StaticImport,

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -19,7 +19,7 @@ pub use chunk_graph::{
     AsyncBlockOrigin, Chunk, ChunkGraph, ChunkGroup, ChunkGroupId, ChunkGroupKind, ChunkId,
 };
 pub use code_generation::{Asset, RuntimeRequirement, RuntimeRequirements};
-pub use compilation::Compilation;
+pub use compilation::{Compilation, WatchDependencies};
 pub use compiler::{Compiler, CompilerOptions, DEFAULT_EXTENSIONS, Entry};
 pub use dependency::{
     AsyncDependenciesBlock, ConstDependency, Dependency, DependencyKind, EntryDependency,

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -20,6 +20,9 @@ pub(crate) struct MakeState {
     pub module_graph: ModuleGraph,
     pub entries: BTreeMap<usize, ModuleId>,
     pub errors: Vec<Error>,
+    pub file_dependencies: BTreeSet<PathBuf>,
+    pub context_dependencies: BTreeSet<PathBuf>,
+    pub missing_dependencies: BTreeSet<PathBuf>,
     modules_by_identity: HashMap<ModuleIdentity, ModuleId>,
 }
 
@@ -123,6 +126,7 @@ async fn process_request(
         Err(error) if error.is_compilation_error() => {
             let identity = failed_module_identity(&request.context, &request.dependency);
             let mut state = state.lock().await;
+            state.missing_dependencies.insert(identity.resource.clone());
             let add_result = state.add_or_connect(
                 request.origin_module,
                 request.entry_index,
@@ -139,7 +143,9 @@ async fn process_request(
     let resource = factorized.resource;
 
     let add_result = {
-        state.lock().await.add_or_connect(
+        let mut state = state.lock().await;
+        state.file_dependencies.insert(resource.clone());
+        state.add_or_connect(
             request.origin_module,
             request.entry_index,
             request.origin_block,
@@ -256,7 +262,19 @@ fn failed_module_identity(context: &Path, dependency: &Dependency) -> ModuleIden
     } else {
         context.join(request)
     };
-    ModuleIdentity::new(resource)
+    ModuleIdentity::new(normalize_missing_resource(resource))
+}
+
+fn normalize_missing_resource(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir if normalized.pop() => {}
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
 }
 
 impl MakeState {

--- a/crates/unpack_core/src/module.rs
+++ b/crates/unpack_core/src/module.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use serde::{Deserialize, Serialize};
+
 use crate::{AsyncDependenciesBlock, Dependency, Error, ExportsInfo};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -106,7 +108,7 @@ impl Module {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ModuleIdentity {
     pub module_type: ModuleType,
     pub resource: PathBuf,
@@ -129,7 +131,7 @@ impl ModuleIdentity {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ModuleType {
     JavaScriptAuto,
 }

--- a/crates/unpack_core/src/parser.rs
+++ b/crates/unpack_core/src/parser.rs
@@ -9,6 +9,7 @@ use crate::{
     HarmonyExportSpecifierDependency, HarmonyImportSideEffectDependency,
     HarmonyImportSpecifierDependency, ImportDependency, Result, SourceRange,
 };
+use serde::{Deserialize, Serialize};
 use swc_experimental_allocator::Allocator;
 use swc_experimental_allocator::atom::Wtf8Atom;
 use swc_experimental_ecma_ast::{
@@ -21,7 +22,7 @@ use swc_experimental_ecma_parser::{EsSyntax, Syntax, parse_file_as_module};
 const UNSUPPORTED_DYNAMIC_IMPORT_MESSAGE: &str =
     "only static string specifiers are supported; context modules are not supported yet";
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct ParsedModule {
     pub dependencies: Vec<Dependency>,
     pub blocks: Vec<AsyncDependenciesBlock>,

--- a/crates/unpack_core/src/snapshot.rs
+++ b/crates/unpack_core/src/snapshot.rs
@@ -1,8 +1,9 @@
-use std::{path::Path, time::SystemTime};
+use std::{fs, path::Path, time::SystemTime};
 
 use crate::{Error, Result};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SnapshotOptions {
     pub module: SnapshotStrategy,
     pub build_dependencies: SnapshotStrategy,
@@ -17,7 +18,7 @@ impl Default for SnapshotOptions {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SnapshotStrategy {
     pub timestamp: bool,
     pub hash: bool,
@@ -46,7 +47,7 @@ impl SnapshotStrategy {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct FileSnapshot {
     modified: Option<SystemTime>,
     source_hash: Option<u64>,
@@ -93,6 +94,51 @@ impl FileSnapshot {
 
         if strategy.hash {
             let Ok(source) = tokio::fs::read_to_string(path).await else {
+                return false;
+            };
+            if Some(hash_source(&source)) != self.source_hash {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    pub(crate) fn create_from_file_sync(path: &Path, strategy: SnapshotStrategy) -> Result<Self> {
+        let source = fs::read_to_string(path).map_err(|error| Error::read(path, error))?;
+        let modified = if strategy.timestamp {
+            let metadata = fs::metadata(path).map_err(|error| Error::read(path, error))?;
+            Some(
+                metadata
+                    .modified()
+                    .map_err(|error| Error::read(path, error))?,
+            )
+        } else {
+            None
+        };
+        let source_hash = strategy.hash.then(|| hash_source(&source));
+
+        Ok(Self {
+            modified,
+            source_hash,
+        })
+    }
+
+    pub(crate) fn is_valid_sync(&self, path: &Path, strategy: SnapshotStrategy) -> bool {
+        if strategy.timestamp {
+            let Ok(metadata) = fs::metadata(path) else {
+                return false;
+            };
+            let Ok(modified) = metadata.modified() else {
+                return false;
+            };
+            if Some(modified) != self.modified {
+                return false;
+            }
+        }
+
+        if strategy.hash {
+            let Ok(source) = fs::read_to_string(path) else {
                 return false;
             };
             if Some(hash_source(&source)) != self.source_hash {

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -86,6 +86,15 @@ pub struct NativeStatsJson {
     pub assets: Vec<NativeAsset>,
     #[napi(js_name = "outputPath")]
     pub output_path: String,
+    #[napi(js_name = "watchDependencies")]
+    pub watch_dependencies: NativeWatchDependencies,
+}
+
+#[napi(object)]
+pub struct NativeWatchDependencies {
+    pub files: Vec<String>,
+    pub contexts: Vec<String>,
+    pub missing: Vec<String>,
 }
 
 #[napi(object)]
@@ -284,6 +293,7 @@ fn run_compiler_inner(compiler: Option<&Compiler>, output_path: &Path) -> Native
             warnings: Vec::new(),
             assets: compilation.assets().iter().map(asset_stats).collect(),
             output_path: output_path.to_string_lossy().into_owned(),
+            watch_dependencies: watch_dependencies(compilation.watch_dependencies()),
         }),
     }
 }
@@ -367,5 +377,25 @@ fn asset_stats(asset: &Asset) -> NativeAsset {
     NativeAsset {
         name: asset.filename.clone(),
         size: asset.source.len().try_into().unwrap_or(u32::MAX),
+    }
+}
+
+fn watch_dependencies(dependencies: &unpack_core::WatchDependencies) -> NativeWatchDependencies {
+    NativeWatchDependencies {
+        files: dependencies
+            .files()
+            .iter()
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect(),
+        contexts: dependencies
+            .contexts()
+            .iter()
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect(),
+        missing: dependencies
+            .missing()
+            .iter()
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect(),
     }
 }

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -100,6 +100,11 @@ pub struct NativeRunResult {
     pub stats: Option<NativeStatsJson>,
 }
 
+#[napi(object)]
+pub struct NativeFlushResult {
+    pub error: Option<NativeInfrastructureError>,
+}
+
 #[napi(js_name = "createCompiler")]
 pub fn create_compiler(options: NativeCompilerOptions) -> NativeCompiler {
     NativeCompiler::new(options)
@@ -118,6 +123,13 @@ impl NativeCompiler {
         AsyncTask::new(RunCompilerTask {
             compiler: self.compiler.clone(),
             output_path: self.output_path.clone(),
+        })
+    }
+
+    #[napi(js_name = "flushCache")]
+    pub fn flush_cache(&self) -> AsyncTask<FlushCacheTask> {
+        AsyncTask::new(FlushCacheTask {
+            compiler: self.compiler.clone(),
         })
     }
 
@@ -190,6 +202,10 @@ pub struct RunCompilerTask {
     output_path: PathBuf,
 }
 
+pub struct FlushCacheTask {
+    compiler: Option<Arc<Compiler>>,
+}
+
 impl Task for RunCompilerTask {
     type Output = NativeRunResult;
     type JsValue = NativeRunResult;
@@ -199,6 +215,36 @@ impl Task for RunCompilerTask {
             self.compiler.as_deref(),
             &self.output_path,
         ))
+    }
+
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        Ok(output)
+    }
+}
+
+impl Task for FlushCacheTask {
+    type Output = NativeFlushResult;
+    type JsValue = NativeFlushResult;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        let Some(compiler) = self.compiler.as_deref() else {
+            return Ok(NativeFlushResult {
+                error: Some(NativeInfrastructureError {
+                    name: "CompilerClosedError".to_string(),
+                    message: "compiler is closed".to_string(),
+                }),
+            });
+        };
+
+        Ok(match compiler.flush_cache() {
+            Ok(()) => NativeFlushResult { error: None },
+            Err(message) => NativeFlushResult {
+                error: Some(NativeInfrastructureError {
+                    name: "CacheFlushError".to_string(),
+                    message,
+                }),
+            },
+        })
     }
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -61,10 +61,19 @@ export interface Stats {
 
 export interface Compiler {
   run(callback: RunCallback): void;
+  watch(watchOptions: WatchOptions, handler: WatchHandler): Watching;
   close(callback: CloseCallback): void;
 }
 
+export interface Watching {
+  close(callback: CloseCallback): void;
+  invalidate(): void;
+}
+
+export interface WatchOptions {}
+
 export type RunCallback = (err: Error | null, stats?: Stats) => void;
+export type WatchHandler = (err: Error | null, stats?: Stats) => void;
 export type CloseCallback = (err: Error | null) => void;
 
 interface NormalizedEntry {
@@ -145,6 +154,7 @@ const native = require("./unpack_node.node") as NativeBinding;
 class CompilerImpl implements Compiler {
   #closed = false;
   #running = false;
+  #watching: WatchingImpl | undefined;
   #idleFlushTimer: ReturnType<typeof setTimeout> | undefined;
   #pendingCacheFlush: Promise<NativeFlushResult> | undefined;
   readonly #filesystemCache: boolean;
@@ -168,6 +178,13 @@ class CompilerImpl implements Compiler {
     if (this.#running) {
       defer(() =>
         callback(namedError("ConcurrentRunError", "compiler is already running"))
+      );
+      return;
+    }
+
+    if (this.#watching) {
+      defer(() =>
+        callback(namedError("ConcurrentRunError", "compiler is already watching"))
       );
       return;
     }
@@ -200,6 +217,50 @@ class CompilerImpl implements Compiler {
     );
   }
 
+  watch(watchOptions: WatchOptions, handler: WatchHandler): Watching {
+    normalizeWatchOptions(watchOptions);
+    assertFunction(handler, "handler");
+
+    if (this.#closed) {
+      const watching = new WatchingImpl(
+        (watchHandler) => {
+          defer(() => watchHandler(namedError("CompilerClosedError", "compiler is closed")));
+        },
+        () => Promise.resolve(null),
+        () => {}
+      );
+      watching.start(handler);
+      return watching;
+    }
+
+    if (this.#running || this.#watching) {
+      const watching = new WatchingImpl(
+        (watchHandler) => {
+          defer(() =>
+            watchHandler(namedError("ConcurrentRunError", "compiler is already running"))
+          );
+        },
+        () => Promise.resolve(null),
+        () => {}
+      );
+      watching.start(handler);
+      return watching;
+    }
+
+    const watching = new WatchingImpl(
+      (watchHandler) => this.#runWatchCompilation(watchHandler),
+      () => this.#flushCacheNow(),
+      () => {
+        if (this.#watching === watching) {
+          this.#watching = undefined;
+        }
+      }
+    );
+    this.#watching = watching;
+    watching.start(handler);
+    return watching;
+  }
+
   close(callback: CloseCallback): void {
     assertFunction(callback, "callback");
 
@@ -207,6 +268,15 @@ class CompilerImpl implements Compiler {
       defer(() =>
         callback(
           namedError("CompilerRunningError", "compiler cannot close while running")
+        )
+      );
+      return;
+    }
+
+    if (this.#watching) {
+      defer(() =>
+        callback(
+          namedError("CompilerRunningError", "compiler cannot close while watching")
         )
       );
       return;
@@ -230,6 +300,29 @@ class CompilerImpl implements Compiler {
       });
     } catch (error) {
       defer(() => callback(toError(error, "InfrastructureError")));
+    }
+  }
+
+  async #runWatchCompilation(handler: WatchHandler): Promise<void> {
+    let run: Promise<NativeRunResult>;
+    try {
+      run = this.#nativeCompiler.run();
+    } catch (error) {
+      handler(toError(error, "InfrastructureError"));
+      return;
+    }
+
+    try {
+      const result = await run;
+      if (result.error) {
+        handler(namedError(result.error.name, result.error.message));
+        return;
+      }
+
+      this.#scheduleIdleCacheFlush();
+      handler(null, new StatsImpl(normalizeNativeStats(result.stats)));
+    } catch (error) {
+      handler(toError(error, "InfrastructureError"));
     }
   }
 
@@ -272,6 +365,91 @@ class CompilerImpl implements Compiler {
       if (this.#pendingCacheFlush === flush) {
         this.#pendingCacheFlush = undefined;
       }
+    }
+  }
+}
+
+class WatchingImpl implements Watching {
+  #closed = false;
+  #running = false;
+  #invalidated = false;
+  #handler: WatchHandler | undefined;
+  readonly #runCompilation: (handler: WatchHandler) => Promise<void> | void;
+  readonly #flushCache: () => Promise<Error | null>;
+  readonly #onClose: () => void;
+  readonly #closeCallbacks: CloseCallback[] = [];
+
+  constructor(
+    runCompilation: (handler: WatchHandler) => Promise<void> | void,
+    flushCache: () => Promise<Error | null>,
+    onClose: () => void
+  ) {
+    this.#runCompilation = runCompilation;
+    this.#flushCache = flushCache;
+    this.#onClose = onClose;
+  }
+
+  start(handler: WatchHandler): void {
+    this.#handler = handler;
+    this.#run();
+  }
+
+  invalidate(): void {
+    if (this.#closed) {
+      return;
+    }
+
+    if (this.#running) {
+      this.#invalidated = true;
+      return;
+    }
+
+    this.#run();
+  }
+
+  close(callback: CloseCallback): void {
+    assertFunction(callback, "callback");
+
+    if (this.#closed && !this.#running) {
+      defer(() => callback(null));
+      return;
+    }
+
+    this.#closed = true;
+    this.#invalidated = false;
+    this.#closeCallbacks.push(callback);
+
+    if (!this.#running) {
+      void this.#finishClose();
+    }
+  }
+
+  async #run(): Promise<void> {
+    if (this.#closed || this.#running || !this.#handler) {
+      return;
+    }
+
+    this.#running = true;
+    await this.#runCompilation(this.#handler);
+    this.#running = false;
+
+    if (this.#closed) {
+      await this.#finishClose();
+      return;
+    }
+
+    if (this.#invalidated) {
+      this.#invalidated = false;
+      await this.#run();
+    }
+  }
+
+  async #finishClose(): Promise<void> {
+    const callbacks = this.#closeCallbacks.splice(0);
+    const flushError = await this.#flushCache();
+    this.#onClose();
+    for (const callback of callbacks) {
+      callback(flushError);
     }
   }
 }
@@ -512,6 +690,11 @@ function normalizeSnapshotStrategy(
         : assertBoolean(strategy.timestamp, `${name}.timestamp`),
     hash: strategy.hash === undefined ? defaults.hash : assertBoolean(strategy.hash, `${name}.hash`)
   };
+}
+
+function normalizeWatchOptions(watchOptions: WatchOptions): void {
+  assertPlainObject(watchOptions, "watchOptions");
+  assertKnownKeys(watchOptions, [], "watchOptions");
 }
 
 function normalizeNativeStats(stats: NativeStatsJson | null | undefined): StatsJson {

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -1,4 +1,6 @@
 import { createRequire } from "node:module";
+import { watch as watchFileSystem } from "node:fs";
+import type { FSWatcher } from "node:fs";
 import { isAbsolute, resolve } from "node:path";
 
 export interface UnpackOptions {
@@ -52,6 +54,13 @@ export interface StatsJson {
   warnings: StatsError[];
   assets: StatsAsset[];
   outputPath: string;
+  watchDependencies: WatchDependencySets;
+}
+
+export interface WatchDependencySets {
+  files: string[];
+  contexts: string[];
+  missing: string[];
 }
 
 export interface Stats {
@@ -70,7 +79,9 @@ export interface Watching {
   invalidate(): void;
 }
 
-export interface WatchOptions {}
+export interface WatchOptions {
+  aggregateTimeout?: number;
+}
 
 export type RunCallback = (err: Error | null, stats?: Stats) => void;
 export type WatchHandler = (err: Error | null, stats?: Stats) => void;
@@ -115,12 +126,18 @@ interface NormalizedSnapshotStrategy {
   hash: boolean;
 }
 
+interface NormalizedWatchOptions {
+  aggregateTimeout: number;
+}
+
 interface NativeStatsJson {
   errors: StatsError[];
   warnings?: StatsError[];
   assets: StatsAsset[];
   outputPath?: string;
   output_path?: string;
+  watchDependencies?: WatchDependencySets;
+  watch_dependencies?: WatchDependencySets;
 }
 
 interface NativeRunResult {
@@ -218,7 +235,7 @@ class CompilerImpl implements Compiler {
   }
 
   watch(watchOptions: WatchOptions, handler: WatchHandler): Watching {
-    normalizeWatchOptions(watchOptions);
+    const normalizedWatchOptions = normalizeWatchOptions(watchOptions);
     assertFunction(handler, "handler");
 
     if (this.#closed) {
@@ -227,7 +244,8 @@ class CompilerImpl implements Compiler {
           defer(() => watchHandler(namedError("CompilerClosedError", "compiler is closed")));
         },
         () => Promise.resolve(null),
-        () => {}
+        () => {},
+        { aggregateTimeout: 20 }
       );
       watching.start(handler);
       return watching;
@@ -241,7 +259,8 @@ class CompilerImpl implements Compiler {
           );
         },
         () => Promise.resolve(null),
-        () => {}
+        () => {},
+        { aggregateTimeout: 20 }
       );
       watching.start(handler);
       return watching;
@@ -254,7 +273,8 @@ class CompilerImpl implements Compiler {
         if (this.#watching === watching) {
           this.#watching = undefined;
         }
-      }
+      },
+      normalizedWatchOptions
     );
     this.#watching = watching;
     watching.start(handler);
@@ -374,19 +394,24 @@ class WatchingImpl implements Watching {
   #running = false;
   #invalidated = false;
   #handler: WatchHandler | undefined;
+  #rebuildTimer: ReturnType<typeof setTimeout> | undefined;
+  readonly #watchers: FSWatcher[] = [];
   readonly #runCompilation: (handler: WatchHandler) => Promise<void> | void;
   readonly #flushCache: () => Promise<Error | null>;
   readonly #onClose: () => void;
+  readonly #watchOptions: NormalizedWatchOptions;
   readonly #closeCallbacks: CloseCallback[] = [];
 
   constructor(
     runCompilation: (handler: WatchHandler) => Promise<void> | void,
     flushCache: () => Promise<Error | null>,
-    onClose: () => void
+    onClose: () => void,
+    watchOptions: NormalizedWatchOptions
   ) {
     this.#runCompilation = runCompilation;
     this.#flushCache = flushCache;
     this.#onClose = onClose;
+    this.#watchOptions = watchOptions;
   }
 
   start(handler: WatchHandler): void {
@@ -398,6 +423,8 @@ class WatchingImpl implements Watching {
     if (this.#closed) {
       return;
     }
+
+    this.#clearRebuildTimer();
 
     if (this.#running) {
       this.#invalidated = true;
@@ -417,6 +444,8 @@ class WatchingImpl implements Watching {
 
     this.#closed = true;
     this.#invalidated = false;
+    this.#clearRebuildTimer();
+    this.#closeWatchers();
     this.#closeCallbacks.push(callback);
 
     if (!this.#running) {
@@ -430,8 +459,18 @@ class WatchingImpl implements Watching {
     }
 
     this.#running = true;
-    await this.#runCompilation(this.#handler);
+    let latestStats: Stats | undefined;
+    await this.#runCompilation((err, stats) => {
+      if (!err && stats) {
+        latestStats = stats;
+      }
+      this.#handler?.(err, stats);
+    });
     this.#running = false;
+
+    if (!this.#closed && latestStats) {
+      this.#replaceWatchers(latestStats.toJson().watchDependencies);
+    }
 
     if (this.#closed) {
       await this.#finishClose();
@@ -452,6 +491,47 @@ class WatchingImpl implements Watching {
       callback(flushError);
     }
   }
+
+  #replaceWatchers(dependencies: WatchDependencySets): void {
+    this.#closeWatchers();
+    for (const file of dependencies.files) {
+      try {
+        this.#watchers.push(
+          watchFileSystem(file, { persistent: false }, () => {
+            this.#queueRebuild();
+          })
+        );
+      } catch {
+        // Missing or unsupported watch targets are represented in stats but should not
+        // make an otherwise successful compilation fail.
+      }
+    }
+  }
+
+  #queueRebuild(): void {
+    if (this.#closed) {
+      return;
+    }
+
+    this.#clearRebuildTimer();
+    this.#rebuildTimer = setTimeout(() => {
+      this.#rebuildTimer = undefined;
+      this.invalidate();
+    }, this.#watchOptions.aggregateTimeout);
+  }
+
+  #clearRebuildTimer(): void {
+    if (this.#rebuildTimer !== undefined) {
+      clearTimeout(this.#rebuildTimer);
+      this.#rebuildTimer = undefined;
+    }
+  }
+
+  #closeWatchers(): void {
+    while (this.#watchers.length > 0) {
+      this.#watchers.pop()?.close();
+    }
+  }
 }
 
 class StatsImpl implements Stats {
@@ -466,7 +546,8 @@ class StatsImpl implements Stats {
       errors: this.json.errors.map(cloneStatsError),
       warnings: this.json.warnings.map(cloneStatsError),
       assets: this.json.assets.map((asset) => ({ ...asset })),
-      outputPath: this.json.outputPath
+      outputPath: this.json.outputPath,
+      watchDependencies: cloneWatchDependencies(this.json.watchDependencies)
     };
   }
 }
@@ -692,20 +773,35 @@ function normalizeSnapshotStrategy(
   };
 }
 
-function normalizeWatchOptions(watchOptions: WatchOptions): void {
+function normalizeWatchOptions(watchOptions: WatchOptions): NormalizedWatchOptions {
   assertPlainObject(watchOptions, "watchOptions");
-  assertKnownKeys(watchOptions, [], "watchOptions");
+  assertKnownKeys(watchOptions, ["aggregateTimeout"], "watchOptions");
+  return {
+    aggregateTimeout:
+      watchOptions.aggregateTimeout === undefined
+        ? 20
+        : assertNonNegativeInteger(watchOptions.aggregateTimeout, "watchOptions.aggregateTimeout")
+  };
 }
 
 function normalizeNativeStats(stats: NativeStatsJson | null | undefined): StatsJson {
   if (!stats) {
-    return { errors: [], warnings: [], assets: [], outputPath: "" };
+    return {
+      errors: [],
+      warnings: [],
+      assets: [],
+      outputPath: "",
+      watchDependencies: emptyWatchDependencies()
+    };
   }
   return {
     errors: stats.errors.map(cloneStatsError),
     warnings: (stats.warnings ?? []).map(cloneStatsError),
     assets: stats.assets.map((asset) => ({ ...asset })),
-    outputPath: stats.outputPath ?? stats.output_path ?? ""
+    outputPath: stats.outputPath ?? stats.output_path ?? "",
+    watchDependencies: cloneWatchDependencies(
+      stats.watchDependencies ?? stats.watch_dependencies ?? emptyWatchDependencies()
+    )
   };
 }
 
@@ -716,6 +812,22 @@ function cloneStatsError(error: StatsError): StatsError {
     ...(error.request === undefined ? {} : { request: error.request }),
     ...(error.issuer === undefined ? {} : { issuer: error.issuer }),
     ...(error.stack === undefined ? {} : { stack: error.stack })
+  };
+}
+
+function cloneWatchDependencies(dependencies: WatchDependencySets): WatchDependencySets {
+  return {
+    files: [...dependencies.files],
+    contexts: [...dependencies.contexts],
+    missing: [...dependencies.missing]
+  };
+}
+
+function emptyWatchDependencies(): WatchDependencySets {
+  return {
+    files: [],
+    contexts: [],
+    missing: []
   };
 }
 

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -122,8 +122,16 @@ interface NativeRunResult {
   stats?: NativeStatsJson | null;
 }
 
+interface NativeFlushResult {
+  error?: {
+    name: string;
+    message: string;
+  } | null;
+}
+
 interface NativeCompiler {
   run(): Promise<NativeRunResult>;
+  flushCache(): Promise<NativeFlushResult>;
   close(): void;
 }
 
@@ -137,10 +145,16 @@ const native = require("./unpack_node.node") as NativeBinding;
 class CompilerImpl implements Compiler {
   #closed = false;
   #running = false;
+  #idleFlushTimer: ReturnType<typeof setTimeout> | undefined;
+  #pendingCacheFlush: Promise<NativeFlushResult> | undefined;
+  readonly #filesystemCache: boolean;
+  readonly #cacheIdleTimeout: number;
   readonly #nativeCompiler: NativeCompiler;
 
   constructor(options: NormalizedOptions) {
     this.#nativeCompiler = native.createCompiler(options);
+    this.#filesystemCache = options.cache.type === "filesystem";
+    this.#cacheIdleTimeout = options.cache.idleTimeout ?? 0;
   }
 
   run(callback: RunCallback): void {
@@ -176,6 +190,7 @@ class CompilerImpl implements Compiler {
           return;
         }
 
+        this.#scheduleIdleCacheFlush();
         callback(null, new StatsImpl(normalizeNativeStats(result.stats)));
       },
       (error: unknown) => {
@@ -198,11 +213,65 @@ class CompilerImpl implements Compiler {
     }
 
     try {
-      this.#nativeCompiler.close();
-      this.#closed = true;
-      defer(() => callback(null));
+      this.#clearIdleFlushTimer();
+      this.#flushCacheNow().then((flushError) => {
+        if (flushError) {
+          callback(flushError);
+          return;
+        }
+
+        try {
+          this.#nativeCompiler.close();
+          this.#closed = true;
+          callback(null);
+        } catch (error) {
+          callback(toError(error, "InfrastructureError"));
+        }
+      });
     } catch (error) {
       defer(() => callback(toError(error, "InfrastructureError")));
+    }
+  }
+
+  #scheduleIdleCacheFlush(): void {
+    if (!this.#filesystemCache || this.#closed) {
+      return;
+    }
+
+    this.#clearIdleFlushTimer();
+    this.#idleFlushTimer = setTimeout(() => {
+      this.#idleFlushTimer = undefined;
+      void this.#flushCacheNow();
+    }, this.#cacheIdleTimeout);
+  }
+
+  #clearIdleFlushTimer(): void {
+    if (this.#idleFlushTimer !== undefined) {
+      clearTimeout(this.#idleFlushTimer);
+      this.#idleFlushTimer = undefined;
+    }
+  }
+
+  async #flushCacheNow(): Promise<Error | null> {
+    if (!this.#filesystemCache) {
+      return null;
+    }
+
+    const flush = this.#pendingCacheFlush ?? this.#nativeCompiler.flushCache();
+    this.#pendingCacheFlush = flush;
+
+    try {
+      const result = await flush;
+      if (result.error) {
+        return namedError(result.error.name, result.error.message);
+      }
+      return null;
+    } catch (error) {
+      return toError(error, "InfrastructureError");
+    } finally {
+      if (this.#pendingCacheFlush === flush) {
+        this.#pendingCacheFlush = undefined;
+      }
     }
   }
 }

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -1,6 +1,5 @@
 import { createRequire } from "node:module";
-import { watch as watchFileSystem } from "node:fs";
-import type { FSWatcher } from "node:fs";
+import { statSync, watch as watchFileSystem } from "node:fs";
 import { isAbsolute, resolve } from "node:path";
 
 export interface UnpackOptions {
@@ -81,7 +80,11 @@ export interface Watching {
 
 export interface WatchOptions {
   aggregateTimeout?: number;
+  ignored?: WatchIgnored;
+  poll?: true | number;
 }
+
+export type WatchIgnored = string | RegExp | Array<string | RegExp>;
 
 export type RunCallback = (err: Error | null, stats?: Stats) => void;
 export type WatchHandler = (err: Error | null, stats?: Stats) => void;
@@ -128,6 +131,33 @@ interface NormalizedSnapshotStrategy {
 
 interface NormalizedWatchOptions {
   aggregateTimeout: number;
+  ignored: WatchIgnoredMatcher[];
+  pollInterval: number | undefined;
+}
+
+type WatchIgnoredMatcher =
+  | {
+      type: "path";
+      value: string;
+    }
+  | {
+      type: "regexp";
+      value: RegExp;
+    };
+
+interface WatchSubscription {
+  close(): void;
+}
+
+interface WatchTarget {
+  path: string;
+  kind: "file" | "context" | "missing";
+}
+
+interface PollSnapshot {
+  exists: boolean;
+  mtimeMs: number;
+  size: number;
 }
 
 interface NativeStatsJson {
@@ -245,7 +275,7 @@ class CompilerImpl implements Compiler {
         },
         () => Promise.resolve(null),
         () => {},
-        { aggregateTimeout: 20 }
+        defaultWatchOptions()
       );
       watching.start(handler);
       return watching;
@@ -260,7 +290,7 @@ class CompilerImpl implements Compiler {
         },
         () => Promise.resolve(null),
         () => {},
-        { aggregateTimeout: 20 }
+        defaultWatchOptions()
       );
       watching.start(handler);
       return watching;
@@ -395,7 +425,7 @@ class WatchingImpl implements Watching {
   #invalidated = false;
   #handler: WatchHandler | undefined;
   #rebuildTimer: ReturnType<typeof setTimeout> | undefined;
-  readonly #watchers: FSWatcher[] = [];
+  readonly #watchers: WatchSubscription[] = [];
   readonly #runCompilation: (handler: WatchHandler) => Promise<void> | void;
   readonly #flushCache: () => Promise<Error | null>;
   readonly #onClose: () => void;
@@ -494,10 +524,28 @@ class WatchingImpl implements Watching {
 
   #replaceWatchers(dependencies: WatchDependencySets): void {
     this.#closeWatchers();
-    for (const file of dependencies.files) {
+    const targets = watchTargets(dependencies).filter(
+      (target) => !isIgnoredWatchPath(target.path, this.#watchOptions.ignored)
+    );
+
+    if (this.#watchOptions.pollInterval !== undefined) {
+      if (targets.length > 0) {
+        this.#watchers.push(this.#createPollWatcher(targets));
+      }
+      return;
+    }
+
+    for (const target of targets) {
       try {
         this.#watchers.push(
-          watchFileSystem(file, { persistent: false }, () => {
+          watchFileSystem(target.path, { persistent: false }, (_eventType, filename) => {
+            const changedPath =
+              target.kind === "context" && filename
+                ? resolve(target.path, filename.toString())
+                : target.path;
+            if (isIgnoredWatchPath(changedPath, this.#watchOptions.ignored)) {
+              return;
+            }
             this.#queueRebuild();
           })
         );
@@ -506,6 +554,33 @@ class WatchingImpl implements Watching {
         // make an otherwise successful compilation fail.
       }
     }
+  }
+
+  #createPollWatcher(targets: WatchTarget[]): WatchSubscription {
+    const snapshots = new Map(
+      targets.map((target) => [target.path, pollSnapshot(target.path)])
+    );
+    const interval = setInterval(() => {
+      let changed = false;
+      for (const target of targets) {
+        if (isIgnoredWatchPath(target.path, this.#watchOptions.ignored)) {
+          continue;
+        }
+        const previous = snapshots.get(target.path);
+        const next = pollSnapshot(target.path);
+        snapshots.set(target.path, next);
+        if (!previous || !pollSnapshotsEqual(previous, next)) {
+          changed = true;
+        }
+      }
+      if (changed) {
+        this.#queueRebuild();
+      }
+    }, this.#watchOptions.pollInterval);
+    interval.unref?.();
+    return {
+      close: () => clearInterval(interval)
+    };
   }
 
   #queueRebuild(): void {
@@ -775,13 +850,69 @@ function normalizeSnapshotStrategy(
 
 function normalizeWatchOptions(watchOptions: WatchOptions): NormalizedWatchOptions {
   assertPlainObject(watchOptions, "watchOptions");
-  assertKnownKeys(watchOptions, ["aggregateTimeout"], "watchOptions");
+  assertKnownKeys(watchOptions, ["aggregateTimeout", "ignored", "poll"], "watchOptions");
   return {
     aggregateTimeout:
       watchOptions.aggregateTimeout === undefined
         ? 20
-        : assertNonNegativeInteger(watchOptions.aggregateTimeout, "watchOptions.aggregateTimeout")
+        : assertNonNegativeInteger(watchOptions.aggregateTimeout, "watchOptions.aggregateTimeout"),
+    ignored: normalizeWatchIgnored(watchOptions.ignored, "watchOptions.ignored"),
+    pollInterval: normalizeWatchPoll(watchOptions.poll)
   };
+}
+
+function defaultWatchOptions(): NormalizedWatchOptions {
+  return {
+    aggregateTimeout: 20,
+    ignored: [],
+    pollInterval: undefined
+  };
+}
+
+function normalizeWatchIgnored(value: unknown, name: string): WatchIgnoredMatcher[] {
+  if (value === undefined) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item, index) => normalizeWatchIgnoredMatcher(item, `${name}[${index}]`));
+  }
+
+  return [normalizeWatchIgnoredMatcher(value, name)];
+}
+
+function normalizeWatchIgnoredMatcher(value: unknown, name: string): WatchIgnoredMatcher {
+  if (typeof value === "string") {
+    return {
+      type: "path",
+      value: normalizeWatchMatchPath(assertNonEmptyString(value, name))
+    };
+  }
+
+  if (value instanceof RegExp) {
+    return {
+      type: "regexp",
+      value
+    };
+  }
+
+  throw new TypeError(`${name} must be a string or RegExp`);
+}
+
+function normalizeWatchPoll(value: unknown): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === true) {
+    return 500;
+  }
+
+  if (typeof value === "number") {
+    return assertPositiveInteger(value, "watchOptions.poll");
+  }
+
+  throw new TypeError("watchOptions.poll must be true or a positive integer");
 }
 
 function normalizeNativeStats(stats: NativeStatsJson | null | undefined): StatsJson {
@@ -829,6 +960,63 @@ function emptyWatchDependencies(): WatchDependencySets {
     contexts: [],
     missing: []
   };
+}
+
+function watchTargets(dependencies: WatchDependencySets): WatchTarget[] {
+  const targets = new Map<string, WatchTarget>();
+  for (const path of dependencies.files) {
+    targets.set(path, { path, kind: "file" });
+  }
+  for (const path of dependencies.contexts) {
+    targets.set(path, { path, kind: "context" });
+  }
+  for (const path of dependencies.missing) {
+    targets.set(path, { path, kind: "missing" });
+  }
+  return [...targets.values()];
+}
+
+function isIgnoredWatchPath(path: string, ignored: WatchIgnoredMatcher[]): boolean {
+  if (ignored.length === 0) {
+    return false;
+  }
+
+  const normalizedPath = normalizeWatchMatchPath(path);
+  return ignored.some((matcher) => {
+    if (matcher.type === "path") {
+      return normalizedPath === matcher.value || normalizedPath.includes(matcher.value);
+    }
+
+    matcher.value.lastIndex = 0;
+    const matched = matcher.value.test(normalizedPath);
+    matcher.value.lastIndex = 0;
+    return matched;
+  });
+}
+
+function normalizeWatchMatchPath(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
+function pollSnapshot(path: string): PollSnapshot {
+  try {
+    const stat = statSync(path);
+    return {
+      exists: true,
+      mtimeMs: stat.mtimeMs,
+      size: stat.size
+    };
+  } catch {
+    return {
+      exists: false,
+      mtimeMs: 0,
+      size: 0
+    };
+  }
+}
+
+function pollSnapshotsEqual(left: PollSnapshot, right: PollSnapshot): boolean {
+  return left.exists === right.exists && left.mtimeMs === right.mtimeMs && left.size === right.size;
 }
 
 function assertKnownKeys(
@@ -886,6 +1074,17 @@ function assertNonNegativeInteger(value: unknown, name: string): number {
     value < 0
   ) {
     throw new TypeError(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function assertPositiveInteger(value: unknown, name: string): number {
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    value <= 0
+  ) {
+    throw new TypeError(`${name} must be a positive integer`);
   }
   return value;
 }

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -227,12 +227,14 @@ test("accepts filesystem cache option shape", async () => {
   };
 
   try {
-    const first = await runCompiler({
+    const firstCompiler = unpack({
       context: fixture,
       entry: "./src/index.js",
       cache: cacheOptions,
       snapshot
     });
+    const first = await runExistingCompiler(firstCompiler);
+    await closeCompiler(firstCompiler);
 
     assert.equal(first.err, null);
     assert.equal(first.stats?.hasErrors(), false);
@@ -242,14 +244,76 @@ test("accepts filesystem cache option shape", async () => {
     );
     assert.ok(await readFile(join(fixture, ".cache/unpack/test-cache/packs/modules.cbor")));
 
-    const second = await runCompiler({
+    const secondCompiler = unpack({
       context: fixture,
       entry: "./src/index.js",
       cache: cacheOptions,
       snapshot
     });
+    const second = await runExistingCompiler(secondCompiler);
+    await closeCompiler(secondCompiler);
     assert.equal(second.err, null);
     assert.deepEqual(second.stats?.toJson(), first.stats?.toJson());
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("filesystem cache flushes after idle timeout", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const cacheLocation = join(fixture, ".cache/unpack/idle");
+  const compiler = unpack({
+    context: fixture,
+    entry: "./src/index.js",
+    cache: {
+      type: "filesystem",
+      cacheLocation,
+      idleTimeout: 30
+    }
+  });
+
+  try {
+    const result = await runExistingCompiler(compiler);
+    assert.equal(result.err, null);
+    await assert.rejects(readFile(join(cacheLocation, "container.json"), "utf8"));
+
+    await delay(100);
+    assert.match(
+      await readFile(join(cacheLocation, "container.json"), "utf8"),
+      /UNPACK_PERSISTENT_CACHE/
+    );
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("compiler close waits for pending filesystem cache flush", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const cacheLocation = join(fixture, ".cache/unpack/close");
+  const compiler = unpack({
+    context: fixture,
+    entry: "./src/index.js",
+    cache: {
+      type: "filesystem",
+      cacheLocation,
+      idleTimeout: 60_000
+    }
+  });
+
+  try {
+    const result = await runExistingCompiler(compiler);
+    assert.equal(result.err, null);
+
+    await closeCompiler(compiler);
+    assert.match(
+      await readFile(join(cacheLocation, "container.json"), "utf8"),
+      /UNPACK_PERSISTENT_CACHE/
+    );
   } finally {
     await rm(fixture, { recursive: true, force: true });
   }
@@ -406,6 +470,12 @@ async function closeCompiler(compiler: ReturnType<typeof unpack>) {
         resolve();
       }
     });
+  });
+}
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
   });
 }
 

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -370,6 +370,93 @@ test("watch invalidate triggers rebuild", async () => {
   }
 });
 
+test("stats exposes watch dependency sets", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "import './dep'; import './missing'; export const value = dep;",
+    "src/dep.js": "export const dep = 'dep';"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+
+  try {
+    const result = await runExistingCompiler(compiler);
+    assert.equal(result.err, null);
+    const json = result.stats?.toJson();
+    const sourceRoot = await realpath(join(fixture, "src"));
+    assert.ok(json);
+    assert.equal(json.errors.length, 1);
+    assert.deepEqual(json.watchDependencies.files.sort(), [
+      join(sourceRoot, "dep.js"),
+      join(sourceRoot, "index.js")
+    ]);
+    assert.deepEqual(json.watchDependencies.contexts, []);
+    assert.deepEqual(json.watchDependencies.missing, [join(sourceRoot, "missing")]);
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("watch rebuilds when a watched dependency changes", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "import { value } from './dep'; export const result = value;",
+    "src/dep.js": "export const value = 'before';"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+  const dependency = join(fixture, "src/dep.js");
+
+  try {
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch({}, results.handler);
+    assert.equal((await first).err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /before/);
+
+    const second = results.next();
+    await writeFile(dependency, "export const value = 'after';", { encoding: "utf8" });
+    const changedTime = new Date(Date.now() + 2000);
+    await utimes(dependency, changedTime, changedTime);
+
+    assert.equal((await second).err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /after/);
+    await closeWatching(watching);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("watch aggregateTimeout coalesces rapid changes", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 'initial';"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+  const entry = join(fixture, "src/index.js");
+
+  try {
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch({ aggregateTimeout: 50 }, results.handler);
+    assert.equal((await first).err, null);
+
+    const second = results.next();
+    await writeFile(entry, "export const value = 'first';", { encoding: "utf8" });
+    const firstTime = new Date(Date.now() + 2000);
+    await utimes(entry, firstTime, firstTime);
+    await writeFile(entry, "export const value = 'second';", { encoding: "utf8" });
+    const secondTime = new Date(Date.now() + 4000);
+    await utimes(entry, secondTime, secondTime);
+
+    assert.equal((await second).err, null);
+    await delay(150);
+    assert.equal(results.calls(), 2);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /second/);
+    await closeWatching(watching);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 test("watch conflicts with run watch and compiler close", async () => {
   const fixture = await createFixture({
     "src/index.js": "export const value = 1;"
@@ -575,14 +662,17 @@ async function closeWatching(watching: ReturnType<ReturnType<typeof unpack>["wat
 
 function collectWatchResults() {
   const resolvers: Array<(result: { err: Error | null; stats?: Stats }) => void> = [];
+  let calls = 0;
   return {
     handler: (err: Error | null, stats?: Stats) => {
+      calls += 1;
       resolvers.shift()?.({ err, stats });
     },
     next: () =>
       new Promise<{ err: Error | null; stats?: Stats }>((resolve) => {
         resolvers.push(resolve);
-      })
+      }),
+    calls: () => calls
   };
 }
 

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -319,6 +319,86 @@ test("compiler close waits for pending filesystem cache flush", async () => {
   }
 });
 
+test("watch performs initial build and close keeps compiler reusable", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+
+  try {
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch({}, results.handler);
+    const result = await first;
+    assert.equal(result.err, null);
+    assert.equal(result.stats?.hasErrors(), false);
+
+    await closeWatching(watching);
+    assert.equal((await runExistingCompiler(compiler)).err, null);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("watch invalidate triggers rebuild", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 'before';"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+  const entry = join(fixture, "src/index.js");
+
+  try {
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch({}, results.handler);
+    assert.equal((await first).err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /before/);
+
+    const second = results.next();
+    await writeFile(entry, "export const value = 'after';", { encoding: "utf8" });
+    const changedTime = new Date(Date.now() + 2000);
+    await utimes(entry, changedTime, changedTime);
+    watching.invalidate();
+
+    assert.equal((await second).err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /after/);
+    await closeWatching(watching);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("watch conflicts with run watch and compiler close", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+
+  try {
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch({}, results.handler);
+    assert.equal((await first).err, null);
+
+    assert.equal((await runExistingCompiler(compiler)).err?.name, "ConcurrentRunError");
+
+    const failedWatch = collectWatchResults();
+    const failed = failedWatch.next();
+    compiler.watch({}, failedWatch.handler);
+    assert.equal((await failed).err?.name, "ConcurrentRunError");
+
+    const closeResult = await closeCompilerResult(compiler);
+    assert.equal(closeResult?.name, "CompilerRunningError");
+
+    await closeWatching(watching);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 test("run callback is asynchronous", async () => {
   const fixture = await createFixture({
     "src/index.js": "export const value = 1;"
@@ -471,6 +551,39 @@ async function closeCompiler(compiler: ReturnType<typeof unpack>) {
       }
     });
   });
+}
+
+async function closeCompilerResult(compiler: ReturnType<typeof unpack>) {
+  return new Promise<Error | null>((resolve) => {
+    compiler.close((err) => {
+      resolve(err);
+    });
+  });
+}
+
+async function closeWatching(watching: ReturnType<ReturnType<typeof unpack>["watch"]>) {
+  await new Promise<void>((resolve, reject) => {
+    watching.close((err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function collectWatchResults() {
+  const resolvers: Array<(result: { err: Error | null; stats?: Stats }) => void> = [];
+  return {
+    handler: (err: Error | null, stats?: Stats) => {
+      resolvers.shift()?.({ err, stats });
+    },
+    next: () =>
+      new Promise<{ err: Error | null; stats?: Stats }>((resolve) => {
+        resolvers.push(resolve);
+      })
+  };
 }
 
 function delay(ms: number) {

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -210,30 +210,46 @@ test("accepts filesystem cache option shape", async () => {
     "src/index.js": "export const value = 1;",
     "config/build.js": "export default {};"
   });
+  const cacheOptions = {
+    type: "filesystem" as const,
+    cacheDirectory: ".cache/unpack",
+    name: "test-cache",
+    version: "v1",
+    buildDependencies: {
+      config: ["./config/build.js"]
+    },
+    maxMemoryGenerations: 2,
+    idleTimeout: 10
+  };
+  const snapshot = {
+    module: { timestamp: true, hash: false },
+    buildDependencies: { timestamp: true, hash: true }
+  };
 
   try {
-    const { err, stats } = await runCompiler({
+    const first = await runCompiler({
       context: fixture,
       entry: "./src/index.js",
-      cache: {
-        type: "filesystem",
-        cacheDirectory: ".cache/unpack",
-        name: "test-cache",
-        version: "v1",
-        buildDependencies: {
-          config: ["./config/build.js"]
-        },
-        maxMemoryGenerations: 2,
-        idleTimeout: 10
-      },
-      snapshot: {
-        module: { timestamp: true, hash: false },
-        buildDependencies: { timestamp: true, hash: true }
-      }
+      cache: cacheOptions,
+      snapshot
     });
 
-    assert.equal(err, null);
-    assert.equal(stats?.hasErrors(), false);
+    assert.equal(first.err, null);
+    assert.equal(first.stats?.hasErrors(), false);
+    assert.match(
+      await readFile(join(fixture, ".cache/unpack/test-cache/container.json"), "utf8"),
+      /UNPACK_PERSISTENT_CACHE/
+    );
+    assert.ok(await readFile(join(fixture, ".cache/unpack/test-cache/packs/modules.cbor")));
+
+    const second = await runCompiler({
+      context: fixture,
+      entry: "./src/index.js",
+      cache: cacheOptions,
+      snapshot
+    });
+    assert.equal(second.err, null);
+    assert.deepEqual(second.stats?.toJson(), first.stats?.toJson());
   } finally {
     await rm(fixture, { recursive: true, force: true });
   }

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -457,6 +457,61 @@ test("watch aggregateTimeout coalesces rapid changes", async () => {
   }
 });
 
+test("watch ignored string prevents rebuilds from ignored files", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "import { value } from './ignored'; export const result = value;",
+    "src/ignored.js": "export const value = 'before';"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+  const ignored = join(fixture, "src/ignored.js");
+
+  try {
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch({ ignored: "ignored.js" }, results.handler);
+    assert.equal((await first).err, null);
+
+    await writeFile(ignored, "export const value = 'after';", { encoding: "utf8" });
+    const changedTime = new Date(Date.now() + 2000);
+    await utimes(ignored, changedTime, changedTime);
+    await delay(150);
+
+    assert.equal(results.calls(), 1);
+    await closeWatching(watching);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("watch poll option rebuilds through polling", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 'before';"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+  const entry = join(fixture, "src/index.js");
+
+  try {
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch({ aggregateTimeout: 0, poll: 20 }, results.handler);
+    assert.equal((await first).err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /before/);
+
+    const second = results.next();
+    await writeFile(entry, "export const value = 'after';", { encoding: "utf8" });
+    const changedTime = new Date(Date.now() + 2000);
+    await utimes(entry, changedTime, changedTime);
+
+    assert.equal((await second).err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /after/);
+    await closeWatching(watching);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 test("watch conflicts with run watch and compiler close", async () => {
   const fixture = await createFixture({
     "src/index.js": "export const value = 1;"
@@ -612,6 +667,82 @@ test("cache and snapshot option validation throws synchronously", () => {
       }),
     /options.snapshot.module.timestamp must be a boolean/
   );
+});
+
+test("watch option validation throws synchronously", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const compiler = unpack({ context: fixture, entry: "./src/index.js" });
+
+  try {
+    assert.throws(
+      () =>
+        compiler.watch(
+          {
+            // @ts-expect-error intentionally testing runtime validation
+            followSymlinks: false
+          },
+          () => {}
+        ),
+      /watchOptions contains unknown option 'followSymlinks'/
+    );
+    assert.throws(
+      () =>
+        compiler.watch(
+          {
+            // @ts-expect-error intentionally testing runtime validation
+            ignored: 1
+          },
+          () => {}
+        ),
+      /watchOptions.ignored must be a string or RegExp/
+    );
+    assert.throws(
+      () =>
+        compiler.watch(
+          {
+            // @ts-expect-error intentionally testing runtime validation
+            ignored: ["ok", 1]
+          },
+          () => {}
+        ),
+      /watchOptions.ignored\[1\] must be a string or RegExp/
+    );
+    assert.throws(
+      () =>
+        compiler.watch(
+          {
+            // @ts-expect-error intentionally testing runtime validation
+            poll: false
+          },
+          () => {}
+        ),
+      /watchOptions.poll must be true or a positive integer/
+    );
+    assert.throws(
+      () =>
+        compiler.watch(
+          {
+            poll: 0
+          },
+          () => {}
+        ),
+      /watchOptions.poll must be a positive integer/
+    );
+
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch(
+      { ignored: [/unused/, "not-used"], poll: true },
+      results.handler
+    );
+    assert.equal((await first).err, null);
+    await closeWatching(watching);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
 });
 
 async function runCompiler(options: Parameters<typeof unpack>[0]) {


### PR DESCRIPTION
## Summary
- roll up filesystem persistent cache packs and idle/close flushing onto main
- roll up compiler.watch, watch dependency subscriptions, aggregateTimeout, ignored, and poll options onto main
- keeps the previously merged stacked PR work in one main-targeted PR so the default branch receives the complete stack

## Tests
- cargo fmt --all --check
- cargo test --workspace
- pnpm --filter @unpack-js/core typecheck
- pnpm --filter @unpack-js/core test

Closes #5
Closes #6
Closes #7
Closes #8
Closes #9