### PR TITLE
Add infrastructure logging

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,6 +48,22 @@ _Avoid_: First run, clean test
 A benchmark measurement taken after a prior build in the same benchmark job while preserving benchmark-owned cache state that the tool under test can reuse.
 _Avoid_: Incremental rebuild, watch rebuild
 
+**Tracing**:
+Internal execution signals captured for Unpack developers while maintaining or debugging the bundler itself.
+_Avoid_: User logging, stats logging, telemetry
+
+**Logging**:
+User-facing build messages exposed through the JavaScript API and controlled by user configuration.
+_Avoid_: Internal tracing, Rust debug output, diagnostics
+
+**Infrastructure Logging**:
+User-facing logging for compiler infrastructure activity, configured through the JavaScript API without adding log entries to `Stats`.
+_Avoid_: Stats logging, compilation logger, tracing
+
+**Infrastructure Log Event**:
+A user-facing infrastructure logging message with a level, logger name, and message text.
+_Avoid_: Trace event, stats entry, diagnostic
+
 **Module Graph**:
 The connected set of modules reachable from one or more entry points.
 _Avoid_: Dependency tree

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,6 +1216,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1226,6 +1227,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "tokio",
+ "tracing",
  "unpack_core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ swc_experimental_ecma_parser = "0.11.0"
 tempfile = "3.23.0"
 thiserror = "2.0.17"
 tokio = { version = "1.48.0", features = ["fs", "macros", "rt", "rt-multi-thread", "sync"] }
+tracing = "0.1.44"

--- a/crates/unpack_core/Cargo.toml
+++ b/crates/unpack_core/Cargo.toml
@@ -17,6 +17,7 @@ swc_experimental_ecma_ast = { workspace = true }
 swc_experimental_ecma_parser = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 divan = { workspace = true }

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -3,11 +3,13 @@ use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
 use tokio::sync::Mutex;
 
 use crate::{
-    Asset, ChunkGraph, CompilerOptions, Error, ModuleGraph, ModuleId, Result, UnpackResolver,
+    Asset, ChunkGraph, CompilerOptions, Error, InfrastructureLogEvent, InfrastructureLogLevel,
+    ModuleGraph, ModuleId, Result, UnpackResolver,
     build_cache::BuildCache,
     code_generation,
     make::{self, MakeState},
 };
+use tracing::Instrument;
 
 #[derive(Debug, Clone)]
 pub struct Compilation {
@@ -20,6 +22,7 @@ pub struct Compilation {
     entries: Vec<ModuleId>,
     errors: Vec<Error>,
     watch_dependencies: WatchDependencies,
+    infrastructure_log_events: Vec<InfrastructureLogEvent>,
 }
 
 impl Compilation {
@@ -38,6 +41,7 @@ impl Compilation {
             entries: Vec::new(),
             errors: Vec::new(),
             watch_dependencies: WatchDependencies::default(),
+            infrastructure_log_events: Vec::new(),
         }
     }
 
@@ -69,40 +73,97 @@ impl Compilation {
         &self.watch_dependencies
     }
 
+    pub fn infrastructure_log_events(&self) -> &[InfrastructureLogEvent] {
+        &self.infrastructure_log_events
+    }
+
     pub async fn make(&mut self) -> Result<()> {
-        let state = Arc::new(Mutex::new(MakeState::default()));
-        let result = make::run(
-            &self.options,
-            self.resolver.clone(),
-            self.build_cache.clone(),
-            Arc::clone(&state),
-        )
-        .await;
+        async {
+            self.log_infrastructure(
+                InfrastructureLogLevel::Verbose,
+                "unpack.Compilation",
+                "make started",
+            );
+            let state = Arc::new(Mutex::new(MakeState::default()));
+            let result = make::run(
+                &self.options,
+                self.resolver.clone(),
+                self.build_cache.clone(),
+                Arc::clone(&state),
+            )
+            .await;
 
-        let mut state = state.lock().await;
-        self.module_graph = std::mem::take(&mut state.module_graph);
-        self.entries = std::mem::take(&mut state.entries).into_values().collect();
-        self.errors = std::mem::take(&mut state.errors);
-        self.watch_dependencies = WatchDependencies {
-            files: std::mem::take(&mut state.file_dependencies),
-            contexts: std::mem::take(&mut state.context_dependencies),
-            missing: std::mem::take(&mut state.missing_dependencies),
-        };
+            let mut state = state.lock().await;
+            self.module_graph = std::mem::take(&mut state.module_graph);
+            self.entries = std::mem::take(&mut state.entries).into_values().collect();
+            self.errors = std::mem::take(&mut state.errors);
+            self.watch_dependencies = WatchDependencies {
+                files: std::mem::take(&mut state.file_dependencies),
+                contexts: std::mem::take(&mut state.context_dependencies),
+                missing: std::mem::take(&mut state.missing_dependencies),
+            };
 
-        result
+            if result.is_ok() {
+                self.log_infrastructure(
+                    InfrastructureLogLevel::Verbose,
+                    "unpack.Compilation",
+                    "make completed",
+                );
+            }
+
+            result
+        }
+        .instrument(tracing::trace_span!("Compilation::make"))
+        .await
     }
 
     pub fn build_chunk_graph(&mut self) {
+        let span = tracing::trace_span!("Compilation::build_chunk_graph");
+        let _enter = span.enter();
+        self.log_infrastructure(
+            InfrastructureLogLevel::Verbose,
+            "unpack.Compilation",
+            "chunk graph build started",
+        );
         self.chunk_graph = ChunkGraph::build(&self.options, &self.module_graph, &self.entries);
+        self.log_infrastructure(
+            InfrastructureLogLevel::Verbose,
+            "unpack.Compilation",
+            "chunk graph build completed",
+        );
     }
 
     pub fn create_assets(&mut self) {
+        let span = tracing::trace_span!("Compilation::create_assets");
+        let _enter = span.enter();
+        self.log_infrastructure(
+            InfrastructureLogLevel::Verbose,
+            "unpack.Compilation",
+            "asset creation started",
+        );
         self.assets = code_generation::create_assets(
             &self.options,
             &self.module_graph,
             &self.chunk_graph,
             &self.entries,
         );
+        self.log_infrastructure(
+            InfrastructureLogLevel::Verbose,
+            "unpack.Compilation",
+            "asset creation completed",
+        );
+    }
+
+    fn log_infrastructure(
+        &mut self,
+        level: InfrastructureLogLevel,
+        name: impl Into<String>,
+        message: impl Into<String>,
+    ) {
+        if self.options.infrastructure_logging.enabled(level) {
+            self.infrastructure_log_events
+                .push(InfrastructureLogEvent::new(level, name, message));
+        }
     }
 }
 

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -1,9 +1,10 @@
 use std::path::PathBuf;
 
 use crate::{
-    CacheOptions, Compilation, ResolveOptions, Result, SnapshotOptions, UnpackResolver,
-    build_cache::BuildCache,
+    CacheOptions, Compilation, InfrastructureLoggingOptions, ResolveOptions, Result,
+    SnapshotOptions, UnpackResolver, build_cache::BuildCache,
 };
+use tracing::Instrument;
 
 pub const DEFAULT_EXTENSIONS: &[&str] = &[".ts", ".tsx", ".js", ".jsx"];
 
@@ -29,6 +30,7 @@ pub struct CompilerOptions {
     pub cache: CacheOptions,
     pub resolve: ResolveOptions,
     pub snapshot: SnapshotOptions,
+    pub infrastructure_logging: InfrastructureLoggingOptions,
     pub parallelism: usize,
 }
 
@@ -40,6 +42,7 @@ impl CompilerOptions {
             cache: CacheOptions::default(),
             resolve: default_resolve_options(),
             snapshot: SnapshotOptions::default(),
+            infrastructure_logging: InfrastructureLoggingOptions::disabled(),
             parallelism: 100,
         }
     }
@@ -77,14 +80,20 @@ impl Compiler {
     }
 
     pub async fn run(&self) -> Result<Compilation> {
-        let mut compilation = self.create_compilation();
-        compilation.make().await?;
-        compilation.build_chunk_graph();
-        compilation.create_assets();
-        Ok(compilation)
+        async {
+            let mut compilation = self.create_compilation();
+            compilation.make().await?;
+            compilation.build_chunk_graph();
+            compilation.create_assets();
+            Ok(compilation)
+        }
+        .instrument(tracing::trace_span!("Compiler::run"))
+        .await
     }
 
     pub fn flush_cache(&self) -> std::result::Result<(), String> {
+        let span = tracing::trace_span!("Compiler::flush_cache");
+        let _enter = span.enter();
         self.build_cache
             .flush_to_filesystem()
             .map_err(|error| error.to_string())

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -6,6 +6,7 @@ mod compiler;
 mod dependency;
 mod error;
 mod exports_info;
+mod logging;
 mod make;
 mod module;
 mod module_graph;
@@ -30,6 +31,7 @@ pub use dependency::{
 };
 pub use error::{Error, Result};
 pub use exports_info::ExportsInfo;
+pub use logging::{InfrastructureLogEvent, InfrastructureLogLevel, InfrastructureLoggingOptions};
 pub use module::{Module, ModuleId, ModuleIdentity, ModuleType};
 pub use module_graph::{ModuleGraph, ModuleGraphConnection};
 pub use normal_module_factory::{FactorizedModule, NormalModuleFactory};

--- a/crates/unpack_core/src/logging.rs
+++ b/crates/unpack_core/src/logging.rs
@@ -1,0 +1,68 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InfrastructureLogLevel {
+    Error,
+    Warn,
+    Info,
+    Log,
+    Verbose,
+}
+
+impl InfrastructureLogLevel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warn => "warn",
+            Self::Info => "info",
+            Self::Log => "log",
+            Self::Verbose => "verbose",
+        }
+    }
+
+    fn rank(self) -> u8 {
+        match self {
+            Self::Error => 0,
+            Self::Warn => 1,
+            Self::Info => 2,
+            Self::Log => 3,
+            Self::Verbose => 4,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InfrastructureLogEvent {
+    pub level: InfrastructureLogLevel,
+    pub name: String,
+    pub message: String,
+}
+
+impl InfrastructureLogEvent {
+    pub(crate) fn new(
+        level: InfrastructureLogLevel,
+        name: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            level,
+            name: name.into(),
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct InfrastructureLoggingOptions {
+    pub level: Option<InfrastructureLogLevel>,
+}
+
+impl InfrastructureLoggingOptions {
+    pub fn disabled() -> Self {
+        Self { level: None }
+    }
+
+    pub fn enabled(self, level: InfrastructureLogLevel) -> bool {
+        self.level
+            .map(|configured| level.rank() <= configured.rank())
+            .unwrap_or(false)
+    }
+}

--- a/crates/unpack_node/Cargo.toml
+++ b/crates/unpack_node/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 napi = { workspace = true }
 napi-derive = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 unpack_core = { path = "../unpack_core" }
 
 [build-dependencies]

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -8,7 +8,8 @@ use napi::{Env, Result, Task, bindgen_prelude::AsyncTask};
 use napi_derive::napi;
 use unpack_core::{
     Asset, BuildDependency, CacheOptions, Compiler, CompilerOptions, Entry, Error as CoreError,
-    SnapshotOptions, SnapshotStrategy,
+    InfrastructureLogEvent, InfrastructureLogLevel, InfrastructureLoggingOptions, SnapshotOptions,
+    SnapshotStrategy,
 };
 
 #[napi(object)]
@@ -25,6 +26,8 @@ pub struct NativeCompilerOptions {
     pub output_path: String,
     pub cache: NativeCacheOptions,
     pub snapshot: NativeSnapshotOptions,
+    #[napi(js_name = "infrastructureLogging")]
+    pub infrastructure_logging: NativeInfrastructureLoggingOptions,
 }
 
 #[napi(object)]
@@ -63,6 +66,11 @@ pub struct NativeSnapshotOptions {
 pub struct NativeSnapshotStrategy {
     pub timestamp: bool,
     pub hash: bool,
+}
+
+#[napi(object)]
+pub struct NativeInfrastructureLoggingOptions {
+    pub level: String,
 }
 
 #[napi(object)]
@@ -105,9 +113,17 @@ pub struct NativeInfrastructureError {
 }
 
 #[napi(object)]
+pub struct NativeInfrastructureLogEvent {
+    pub level: String,
+    pub name: String,
+    pub message: String,
+}
+
+#[napi(object)]
 pub struct NativeRunResult {
     pub error: Option<NativeInfrastructureError>,
     pub stats: Option<NativeStatsJson>,
+    pub logs: Vec<NativeInfrastructureLogEvent>,
 }
 
 #[napi(object)]
@@ -161,6 +177,8 @@ impl NativeCompiler {
         let mut compiler_options = CompilerOptions::new(context, entries);
         compiler_options.cache = cache_options_from_native(options.cache);
         compiler_options.snapshot = snapshot_options_from_native(options.snapshot);
+        compiler_options.infrastructure_logging =
+            infrastructure_logging_options_from_native(options.infrastructure_logging);
         let compiler = Compiler::new(compiler_options);
 
         Self {
@@ -205,6 +223,21 @@ fn snapshot_strategy_from_native(strategy: NativeSnapshotStrategy) -> SnapshotSt
     SnapshotStrategy {
         timestamp: strategy.timestamp,
         hash: strategy.hash,
+    }
+}
+
+fn infrastructure_logging_options_from_native(
+    options: NativeInfrastructureLoggingOptions,
+) -> InfrastructureLoggingOptions {
+    InfrastructureLoggingOptions {
+        level: match options.level.as_str() {
+            "error" => Some(InfrastructureLogLevel::Error),
+            "warn" => Some(InfrastructureLogLevel::Warn),
+            "info" => Some(InfrastructureLogLevel::Info),
+            "log" => Some(InfrastructureLogLevel::Log),
+            "verbose" => Some(InfrastructureLogLevel::Verbose),
+            _ => None,
+        },
     }
 }
 
@@ -284,8 +317,9 @@ fn run_compiler_inner(compiler: Option<&Compiler>, output_path: &Path) -> Native
         }
     };
 
+    let logs = infrastructure_log_events(compilation.infrastructure_log_events());
     if let Err(error) = emit_assets(output_path, compilation.assets()) {
-        return infrastructure_error("OutputWriteError", error);
+        return infrastructure_error_with_logs("OutputWriteError", error, logs);
     }
 
     NativeRunResult {
@@ -297,10 +331,13 @@ fn run_compiler_inner(compiler: Option<&Compiler>, output_path: &Path) -> Native
             output_path: output_path.to_string_lossy().into_owned(),
             watch_dependencies: watch_dependencies(compilation.watch_dependencies()),
         }),
+        logs,
     }
 }
 
 fn emit_assets(output_path: &Path, assets: &[Asset]) -> std::result::Result<(), String> {
+    let span = tracing::trace_span!("unpack_node::emit_assets");
+    let _enter = span.enter();
     fs::create_dir_all(output_path).map_err(|error| {
         format!(
             "failed to create output path {}: {error}",
@@ -326,12 +363,21 @@ fn emit_assets(output_path: &Path, assets: &[Asset]) -> std::result::Result<(), 
 }
 
 fn infrastructure_error(name: impl Into<String>, message: impl Into<String>) -> NativeRunResult {
+    infrastructure_error_with_logs(name, message, Vec::new())
+}
+
+fn infrastructure_error_with_logs(
+    name: impl Into<String>,
+    message: impl Into<String>,
+    logs: Vec<NativeInfrastructureLogEvent>,
+) -> NativeRunResult {
     NativeRunResult {
         error: Some(NativeInfrastructureError {
             name: name.into(),
             message: message.into(),
         }),
         stats: None,
+        logs,
     }
 }
 
@@ -380,6 +426,19 @@ fn asset_stats(asset: &Asset) -> NativeAsset {
         name: asset.filename.clone(),
         size: asset.source.len().try_into().unwrap_or(u32::MAX),
     }
+}
+
+fn infrastructure_log_events(
+    events: &[InfrastructureLogEvent],
+) -> Vec<NativeInfrastructureLogEvent> {
+    events
+        .iter()
+        .map(|event| NativeInfrastructureLogEvent {
+            level: event.level.as_str().to_string(),
+            name: event.name.clone(),
+            message: event.message.clone(),
+        })
+        .collect()
 }
 
 fn watch_dependencies(dependencies: &unpack_core::WatchDependencies) -> NativeWatchDependencies {

--- a/docs/adr/0083-start-user-logging-with-infrastructure-logging.md
+++ b/docs/adr/0083-start-user-logging-with-infrastructure-logging.md
@@ -1,0 +1,11 @@
+# Start user logging with infrastructure logging
+
+Unpack's first user-facing logging surface will use an `infrastructureLogging` JavaScript option and follow webpack's infrastructure logging shape rather than adding logs to `Stats`. The first option subset will expose only `infrastructureLogging.level`, keeping output targets, logger-name filtering, colors, and append-only console behavior out of the first API. Unlike webpack's `info` default, Unpack's JavaScript API will default infrastructure logging to `none` so library usage remains quiet unless the caller opts into output.
+
+Rust will report infrastructure log events through the native run result, and the TypeScript wrapper will write enabled events through Node's `console` at JavaScript compiler lifecycle points and when replaying native events after each run or watch compilation completes. Each infrastructure log event will carry only a level, logger name, and message text in the first API. This avoids making the Rust core own user output policy, keeps cross-thread JavaScript callbacks out of the first implementation, and leaves webpack-style custom `console` support as a future extension.
+
+`none` is a configuration value rather than an event level. The enabled levels are cumulative: `error` enables errors only, `warn` enables errors and warnings, `info` adds informational messages, `log` adds normal log messages, and `verbose` enables every infrastructure log event.
+
+The first event set will stay at compiler and phase granularity. `info` will cover run or watch compilation start and completion plus cache flush start and completion. `warn` and `error` will cover infrastructure failures that are also represented through the existing callback error path. `verbose` may include make, chunk graph, asset creation, and cache summary phase messages, but it will not emit per-module resolve or build messages in the first implementation.
+
+This keeps `Stats` aligned with its deliberately small report surface while giving JavaScript API users a way to control compiler infrastructure messages before Unpack has a plugin or loader lifecycle that would justify a compilation logger surface. A future CLI can choose a noisier default without making the package API write to stdout or stderr by default.

--- a/docs/adr/0084-separate-internal-tracing-from-user-logging.md
+++ b/docs/adr/0084-separate-internal-tracing-from-user-logging.md
@@ -1,0 +1,7 @@
+# Separate internal tracing from user logging
+
+Unpack will keep developer-facing tracing separate from user-facing infrastructure logging. Rust `tracing` spans and events may be added around coarse compiler phase boundaries for Unpack developers without adding JavaScript API options, while infrastructure log events remain a deliberate JavaScript API surface for users. The same compiler operation may emit both signals, but internal span names, fields, and event frequency must not become the contract for user-visible logging.
+
+Tracing must not become a meaningful cost on normal builds. The first implementation will avoid per-module and per-dependency tracing, avoid collecting trace data when no subscriber is installed, and keep expensive field formatting out of hot paths.
+
+The first span set will be limited to `Compiler::run`, `Compilation::make`, `Compilation::build_chunk_graph`, `Compilation::create_assets`, `unpack_node::emit_assets`, and `Compiler::flush_cache`.

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -10,6 +10,7 @@ export interface UnpackOptions {
   };
   cache?: CacheOptions;
   snapshot?: SnapshotOptions;
+  infrastructureLogging?: InfrastructureLoggingOptions;
 }
 
 export type CacheOptions =
@@ -35,6 +36,18 @@ export interface SnapshotStrategyOptions {
   timestamp?: boolean;
   hash?: boolean;
 }
+
+export interface InfrastructureLoggingOptions {
+  level?: InfrastructureLoggingLevel;
+}
+
+export type InfrastructureLoggingLevel =
+  | "none"
+  | "error"
+  | "warn"
+  | "info"
+  | "log"
+  | "verbose";
 
 export interface StatsError {
   message: string;
@@ -102,6 +115,7 @@ interface NormalizedOptions {
   outputPath: string;
   cache: NormalizedCacheOptions;
   snapshot: NormalizedSnapshotOptions;
+  infrastructureLogging: NormalizedInfrastructureLoggingOptions;
 }
 
 interface NormalizedCacheOptions {
@@ -129,6 +143,18 @@ interface NormalizedSnapshotOptions {
 interface NormalizedSnapshotStrategy {
   timestamp: boolean;
   hash: boolean;
+}
+
+interface NormalizedInfrastructureLoggingOptions {
+  level: InfrastructureLoggingLevel;
+}
+
+type InfrastructureLogEventLevel = Exclude<InfrastructureLoggingLevel, "none">;
+
+interface InfrastructureLogEvent {
+  level: InfrastructureLogEventLevel;
+  name: string;
+  message: string;
 }
 
 interface NormalizedWatchOptions {
@@ -178,6 +204,7 @@ interface NativeRunResult {
     message: string;
   } | null;
   stats?: NativeStatsJson | null;
+  logs?: InfrastructureLogEvent[] | null;
 }
 
 interface NativeFlushResult {
@@ -208,60 +235,73 @@ class CompilerImpl implements Compiler {
   #pendingCacheFlush: Promise<NativeFlushResult> | undefined;
   readonly #filesystemCache: boolean;
   readonly #cacheIdleTimeout: number;
+  readonly #infrastructureLoggingLevel: InfrastructureLoggingLevel;
   readonly #nativeCompiler: NativeCompiler;
 
   constructor(options: NormalizedOptions) {
     this.#nativeCompiler = native.createCompiler(options);
     this.#filesystemCache = options.cache.type === "filesystem";
     this.#cacheIdleTimeout = options.cache.idleTimeout ?? 0;
+    this.#infrastructureLoggingLevel = options.infrastructureLogging.level;
   }
 
   run(callback: RunCallback): void {
     assertFunction(callback, "callback");
 
     if (this.#closed) {
-      defer(() => callback(namedError("CompilerClosedError", "compiler is closed")));
+      const error = namedError("CompilerClosedError", "compiler is closed");
+      this.#emitInfrastructureLog("error", "unpack.Compiler", error.message);
+      defer(() => callback(error));
       return;
     }
 
     if (this.#running) {
-      defer(() =>
-        callback(namedError("ConcurrentRunError", "compiler is already running"))
-      );
+      const error = namedError("ConcurrentRunError", "compiler is already running");
+      this.#emitInfrastructureLog("error", "unpack.Compiler", error.message);
+      defer(() => callback(error));
       return;
     }
 
     if (this.#watching) {
-      defer(() =>
-        callback(namedError("ConcurrentRunError", "compiler is already watching"))
-      );
+      const error = namedError("ConcurrentRunError", "compiler is already watching");
+      this.#emitInfrastructureLog("error", "unpack.Compiler", error.message);
+      defer(() => callback(error));
       return;
     }
 
     this.#running = true;
     let run: Promise<NativeRunResult>;
     try {
+      this.#emitInfrastructureLog("info", "unpack.Compiler", "run started");
       run = this.#nativeCompiler.run();
     } catch (error) {
       this.#running = false;
-      defer(() => callback(toError(error, "InfrastructureError")));
+      const infrastructureError = toError(error, "InfrastructureError");
+      this.#emitInfrastructureLog("error", "unpack.Compiler", infrastructureError.message);
+      defer(() => callback(infrastructureError));
       return;
     }
 
     run.then(
       (result) => {
         this.#running = false;
+        this.#emitInfrastructureLogs(result.logs);
         if (result.error) {
-          callback(namedError(result.error.name, result.error.message));
+          const error = namedError(result.error.name, result.error.message);
+          this.#emitInfrastructureLog("error", "unpack.Compiler", error.message);
+          callback(error);
           return;
         }
 
         this.#scheduleIdleCacheFlush();
+        this.#emitInfrastructureLog("info", "unpack.Compiler", "run completed");
         callback(null, new StatsImpl(normalizeNativeStats(result.stats)));
       },
       (error: unknown) => {
         this.#running = false;
-        callback(toError(error, "InfrastructureError"));
+        const infrastructureError = toError(error, "InfrastructureError");
+        this.#emitInfrastructureLog("error", "unpack.Compiler", infrastructureError.message);
+        callback(infrastructureError);
       }
     );
   }
@@ -271,9 +311,11 @@ class CompilerImpl implements Compiler {
     assertFunction(handler, "handler");
 
     if (this.#closed) {
+      const error = namedError("CompilerClosedError", "compiler is closed");
+      this.#emitInfrastructureLog("error", "unpack.Watch", error.message);
       const watching = new WatchingImpl(
         (watchHandler) => {
-          defer(() => watchHandler(namedError("CompilerClosedError", "compiler is closed")));
+          defer(() => watchHandler(error));
         },
         () => Promise.resolve(null),
         () => {},
@@ -284,11 +326,11 @@ class CompilerImpl implements Compiler {
     }
 
     if (this.#running || this.#watching) {
+      const error = namedError("ConcurrentRunError", "compiler is already running");
+      this.#emitInfrastructureLog("error", "unpack.Watch", error.message);
       const watching = new WatchingImpl(
         (watchHandler) => {
-          defer(() =>
-            watchHandler(namedError("ConcurrentRunError", "compiler is already running"))
-          );
+          defer(() => watchHandler(error));
         },
         () => Promise.resolve(null),
         () => {},
@@ -317,20 +359,22 @@ class CompilerImpl implements Compiler {
     assertFunction(callback, "callback");
 
     if (this.#running) {
-      defer(() =>
-        callback(
-          namedError("CompilerRunningError", "compiler cannot close while running")
-        )
+      const error = namedError(
+        "CompilerRunningError",
+        "compiler cannot close while running"
       );
+      this.#emitInfrastructureLog("error", "unpack.Compiler", error.message);
+      defer(() => callback(error));
       return;
     }
 
     if (this.#watching) {
-      defer(() =>
-        callback(
-          namedError("CompilerRunningError", "compiler cannot close while watching")
-        )
+      const error = namedError(
+        "CompilerRunningError",
+        "compiler cannot close while watching"
       );
+      this.#emitInfrastructureLog("error", "unpack.Compiler", error.message);
+      defer(() => callback(error));
       return;
     }
 
@@ -347,34 +391,47 @@ class CompilerImpl implements Compiler {
           this.#closed = true;
           callback(null);
         } catch (error) {
-          callback(toError(error, "InfrastructureError"));
+          const infrastructureError = toError(error, "InfrastructureError");
+          this.#emitInfrastructureLog("error", "unpack.Compiler", infrastructureError.message);
+          callback(infrastructureError);
         }
       });
     } catch (error) {
-      defer(() => callback(toError(error, "InfrastructureError")));
+      const infrastructureError = toError(error, "InfrastructureError");
+      this.#emitInfrastructureLog("error", "unpack.Compiler", infrastructureError.message);
+      defer(() => callback(infrastructureError));
     }
   }
 
   async #runWatchCompilation(handler: WatchHandler): Promise<void> {
     let run: Promise<NativeRunResult>;
     try {
+      this.#emitInfrastructureLog("info", "unpack.Watch", "watch compilation started");
       run = this.#nativeCompiler.run();
     } catch (error) {
-      handler(toError(error, "InfrastructureError"));
+      const infrastructureError = toError(error, "InfrastructureError");
+      this.#emitInfrastructureLog("error", "unpack.Watch", infrastructureError.message);
+      handler(infrastructureError);
       return;
     }
 
     try {
       const result = await run;
+      this.#emitInfrastructureLogs(result.logs);
       if (result.error) {
-        handler(namedError(result.error.name, result.error.message));
+        const error = namedError(result.error.name, result.error.message);
+        this.#emitInfrastructureLog("error", "unpack.Watch", error.message);
+        handler(error);
         return;
       }
 
       this.#scheduleIdleCacheFlush();
+      this.#emitInfrastructureLog("info", "unpack.Watch", "watch compilation completed");
       handler(null, new StatsImpl(normalizeNativeStats(result.stats)));
     } catch (error) {
-      handler(toError(error, "InfrastructureError"));
+      const infrastructureError = toError(error, "InfrastructureError");
+      this.#emitInfrastructureLog("error", "unpack.Watch", infrastructureError.message);
+      handler(infrastructureError);
     }
   }
 
@@ -402,21 +459,56 @@ class CompilerImpl implements Compiler {
       return null;
     }
 
+    const startsFlush = this.#pendingCacheFlush === undefined;
+    if (startsFlush) {
+      this.#emitInfrastructureLog("info", "unpack.Cache", "cache flush started");
+    }
     const flush = this.#pendingCacheFlush ?? this.#nativeCompiler.flushCache();
     this.#pendingCacheFlush = flush;
 
     try {
       const result = await flush;
       if (result.error) {
-        return namedError(result.error.name, result.error.message);
+        const error = namedError(result.error.name, result.error.message);
+        if (startsFlush) {
+          this.#emitInfrastructureLog("warn", "unpack.Cache", error.message);
+        }
+        return error;
+      }
+      if (startsFlush) {
+        this.#emitInfrastructureLog("info", "unpack.Cache", "cache flush completed");
       }
       return null;
     } catch (error) {
-      return toError(error, "InfrastructureError");
+      const infrastructureError = toError(error, "InfrastructureError");
+      if (startsFlush) {
+        this.#emitInfrastructureLog("error", "unpack.Cache", infrastructureError.message);
+      }
+      return infrastructureError;
     } finally {
       if (this.#pendingCacheFlush === flush) {
         this.#pendingCacheFlush = undefined;
       }
+    }
+  }
+
+  #emitInfrastructureLog(
+    level: InfrastructureLogEventLevel,
+    name: string,
+    message: string
+  ): void {
+    emitInfrastructureLog(
+      { level, name, message },
+      this.#infrastructureLoggingLevel
+    );
+  }
+
+  #emitInfrastructureLogs(logs: InfrastructureLogEvent[] | null | undefined): void {
+    if (!logs) {
+      return;
+    }
+    for (const log of logs) {
+      emitInfrastructureLog(log, this.#infrastructureLoggingLevel);
     }
   }
 }
@@ -650,7 +742,11 @@ export default function unpack(
 
 function normalizeOptions(options: UnpackOptions): NormalizedOptions {
   assertPlainObject(options, "options");
-  assertKnownKeys(options, ["context", "entry", "output", "cache", "snapshot"], "options");
+  assertKnownKeys(
+    options,
+    ["context", "entry", "output", "cache", "snapshot", "infrastructureLogging"],
+    "options"
+  );
 
   const context =
     options.context === undefined
@@ -674,7 +770,8 @@ function normalizeOptions(options: UnpackOptions): NormalizedOptions {
     entries: normalizeEntry(options.entry),
     outputPath,
     cache: normalizeCacheOptions(options.cache, normalizedContext),
-    snapshot: normalizeSnapshotOptions(options.snapshot)
+    snapshot: normalizeSnapshotOptions(options.snapshot),
+    infrastructureLogging: normalizeInfrastructureLoggingOptions(options.infrastructureLogging)
   };
 }
 
@@ -855,6 +952,39 @@ function normalizeSnapshotStrategy(
   };
 }
 
+function normalizeInfrastructureLoggingOptions(
+  infrastructureLogging: InfrastructureLoggingOptions | undefined
+): NormalizedInfrastructureLoggingOptions {
+  if (infrastructureLogging === undefined) {
+    return { level: "none" };
+  }
+
+  assertPlainObject(infrastructureLogging, "options.infrastructureLogging");
+  assertKnownKeys(infrastructureLogging, ["level"], "options.infrastructureLogging");
+  return {
+    level:
+      infrastructureLogging.level === undefined
+        ? "none"
+        : assertInfrastructureLoggingLevel(infrastructureLogging.level)
+  };
+}
+
+function assertInfrastructureLoggingLevel(value: unknown): InfrastructureLoggingLevel {
+  if (
+    value !== "none" &&
+    value !== "error" &&
+    value !== "warn" &&
+    value !== "info" &&
+    value !== "log" &&
+    value !== "verbose"
+  ) {
+    throw new TypeError(
+      "options.infrastructureLogging.level must be 'none', 'error', 'warn', 'info', 'log', or 'verbose'"
+    );
+  }
+  return value;
+}
+
 function normalizeWatchOptions(watchOptions: WatchOptions): NormalizedWatchOptions {
   assertPlainObject(watchOptions, "watchOptions");
   assertKnownKeys(watchOptions, ["aggregateTimeout", "ignored", "poll"], "watchOptions");
@@ -967,6 +1097,60 @@ function emptyWatchDependencies(): WatchDependencySets {
     contexts: [],
     missing: []
   };
+}
+
+function emitInfrastructureLog(
+  event: InfrastructureLogEvent,
+  configuredLevel: InfrastructureLoggingLevel
+): void {
+  if (!isInfrastructureLogEnabled(event.level, configuredLevel)) {
+    return;
+  }
+
+  const message = `[${event.name}] ${event.message}`;
+  switch (event.level) {
+    case "error":
+      console.error(message);
+      return;
+    case "warn":
+      console.warn(message);
+      return;
+    case "info":
+      console.info(message);
+      return;
+    case "log":
+    case "verbose":
+      console.log(message);
+      return;
+  }
+}
+
+function isInfrastructureLogEnabled(
+  eventLevel: InfrastructureLogEventLevel,
+  configuredLevel: InfrastructureLoggingLevel
+): boolean {
+  if (configuredLevel === "none") {
+    return false;
+  }
+  return (
+    infrastructureLogLevelRank(eventLevel) <=
+    infrastructureLogLevelRank(configuredLevel)
+  );
+}
+
+function infrastructureLogLevelRank(level: InfrastructureLogEventLevel): number {
+  switch (level) {
+    case "error":
+      return 0;
+    case "warn":
+      return 1;
+    case "info":
+      return 2;
+    case "log":
+      return 3;
+    case "verbose":
+      return 4;
+  }
 }
 
 function watchTargets(dependencies: WatchDependencySets): WatchTarget[] {

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -603,6 +603,85 @@ test("compilation errors are reported in stats and still emit assets", async () 
   }
 });
 
+test("infrastructure logging is quiet by default", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const captured = captureConsole();
+
+  try {
+    const result = await runCompiler({
+      context: fixture,
+      entry: "./src/index.js"
+    });
+
+    assert.equal(result.err, null);
+    assert.deepEqual(captured.all(), []);
+  } finally {
+    captured.restore();
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("infrastructure logging level info reports compiler runs outside stats", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const captured = captureConsole();
+
+  try {
+    const result = await runCompiler({
+      context: fixture,
+      entry: "./src/index.js",
+      infrastructureLogging: {
+        level: "info"
+      }
+    });
+
+    assert.equal(result.err, null);
+    assert.ok(result.stats);
+    assert.equal("logs" in result.stats.toJson(), false);
+    assert.deepEqual(captured.calls.info, [
+      "[unpack.Compiler] run started",
+      "[unpack.Compiler] run completed"
+    ]);
+    assert.deepEqual(captured.calls.log, []);
+  } finally {
+    captured.restore();
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("infrastructure logging level verbose reports compilation phases", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const captured = captureConsole();
+
+  try {
+    const result = await runCompiler({
+      context: fixture,
+      entry: "./src/index.js",
+      infrastructureLogging: {
+        level: "verbose"
+      }
+    });
+
+    assert.equal(result.err, null);
+    assert.deepEqual(captured.calls.log, [
+      "[unpack.Compilation] make started",
+      "[unpack.Compilation] make completed",
+      "[unpack.Compilation] chunk graph build started",
+      "[unpack.Compilation] chunk graph build completed",
+      "[unpack.Compilation] asset creation started",
+      "[unpack.Compilation] asset creation completed"
+    ]);
+  } finally {
+    captured.restore();
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 test("top-level option validation throws synchronously", () => {
   assert.throws(
     () =>
@@ -620,6 +699,31 @@ test("top-level option validation throws synchronously", () => {
         null
       ),
     /options must be an object/
+  );
+});
+
+test("infrastructure logging option validation throws synchronously", () => {
+  assert.throws(
+    () =>
+      unpack({
+        entry: "./src/index.js",
+        infrastructureLogging: {
+          // @ts-expect-error intentionally testing runtime validation
+          debug: true
+        }
+      }),
+    /options.infrastructureLogging contains unknown option 'debug'/
+  );
+  assert.throws(
+    () =>
+      unpack({
+        entry: "./src/index.js",
+        infrastructureLogging: {
+          // @ts-expect-error intentionally testing runtime validation
+          level: "debug"
+        }
+      }),
+    /options.infrastructureLogging.level must be/
   );
 });
 
@@ -826,6 +930,37 @@ function delay(ms: number) {
   return new Promise<void>((resolve) => {
     setTimeout(resolve, ms);
   });
+}
+
+type ConsoleMethod = "error" | "warn" | "info" | "log";
+
+function captureConsole() {
+  const methods: ConsoleMethod[] = ["error", "warn", "info", "log"];
+  const original = Object.fromEntries(
+    methods.map((method) => [method, console[method]])
+  ) as Record<ConsoleMethod, (...data: unknown[]) => void>;
+  const calls: Record<ConsoleMethod, string[]> = {
+    error: [],
+    warn: [],
+    info: [],
+    log: []
+  };
+
+  for (const method of methods) {
+    console[method] = (...data: unknown[]) => {
+      calls[method].push(data.map(String).join(" "));
+    };
+  }
+
+  return {
+    calls,
+    all: () => methods.flatMap((method) => calls[method]),
+    restore: () => {
+      for (const method of methods) {
+        console[method] = original[method];
+      }
+    }
+  };
 }
 
 async function createFixture(files: Record<string, string>) {


### PR DESCRIPTION
## Summary

- Add a quiet-by-default `infrastructureLogging.level` JavaScript API option with webpack-shaped cumulative log levels.
- Carry infrastructure log events from Rust through the native result and emit enabled messages through the TypeScript wrapper without adding logs to `Stats`.
- Add coarse Rust `tracing` spans around compiler phases and document the separation between tracing and user-facing logging.

## Validation

- `pnpm test`