### PR TITLE
Add CI cross-bundler benchmark

### DIFF
--- a/.github/workflows/cross-bundler-benchmark.yml
+++ b/.github/workflows/cross-bundler-benchmark.yml
@@ -1,0 +1,83 @@
+name: Cross-Bundler Benchmarks
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  TURBOPACK_NEXT_COMMIT: a88f25caf0070b582a8ed83b1ae9e7135d7fd3bc
+
+jobs:
+  cross-bundler-benchmarks:
+    name: Run cross-bundler benchmarks
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: moonrepo/setup-rust@v0
+        with:
+          channel: stable
+          cache-target: release
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.7.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install JavaScript dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Unpack JavaScript API
+        run: pnpm --filter @unpack-js/core build
+
+      - name: Checkout fixed Turbopack source
+        run: |
+          mkdir -p .benchmark-tools/next.js
+          git -C .benchmark-tools/next.js init
+          git -C .benchmark-tools/next.js remote add origin https://github.com/vercel/next.js.git
+          git -C .benchmark-tools/next.js fetch --depth=1 --filter=blob:none origin "$TURBOPACK_NEXT_COMMIT"
+          git -C .benchmark-tools/next.js checkout --detach FETCH_HEAD
+
+      - name: Run cross-bundler benchmark
+        id: benchmark
+        continue-on-error: true
+        run: |
+          pnpm --filter @unpack-js/benchmarks bench -- \
+            --workspace .benchmark-work/ci \
+            --output-json .benchmark-work/ci/results.json \
+            --summary-md .benchmark-work/ci/summary.md \
+            --turbopack-repo .benchmark-tools/next.js \
+            --turbopack-commit "$TURBOPACK_NEXT_COMMIT"
+
+      - name: Publish benchmark summary
+        if: always()
+        run: |
+          if [ -f .benchmark-work/ci/summary.md ]; then
+            cat .benchmark-work/ci/summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Cross-Bundler Benchmarks"
+              echo
+              echo "The benchmark did not produce a summary. Check the workflow logs for setup or runner failures."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cross-bundler-benchmark-results
+          path: |
+            .benchmark-work/ci/results.json
+            .benchmark-work/ci/summary.md
+          if-no-files-found: warn

--- a/.github/workflows/cross-bundler-benchmark.yml
+++ b/.github/workflows/cross-bundler-benchmark.yml
@@ -14,6 +14,8 @@ jobs:
     continue-on-error: true
     permissions:
       contents: read
+      issues: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v5
 
@@ -70,6 +72,47 @@ jobs:
               echo
               echo "The benchmark did not produce a summary. Check the workflow logs for setup or runner failures."
             } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Comment benchmark summary on PR
+        if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          marker="<!-- unpack-cross-bundler-benchmark -->"
+          comment_file=".benchmark-work/ci/pr-comment.md"
+          mkdir -p "$(dirname "$comment_file")"
+
+          {
+            echo "$marker"
+            echo "## Cross-Bundler Benchmark"
+            echo
+            if [ -f .benchmark-work/ci/summary.md ]; then
+              cat .benchmark-work/ci/summary.md
+            else
+              echo "The benchmark did not produce a summary. Check the workflow logs for setup or runner failures."
+            fi
+            echo
+            echo "[Workflow run]($RUN_URL)"
+            echo
+            echo "Raw JSON results are uploaded as the \`cross-bundler-benchmark-results\` workflow artifact."
+          } > "$comment_file"
+
+          comment_id="$(
+            gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --paginate \
+              --jq ".[] | select(.user.type == \"Bot\" and (.body | contains(\"$marker\"))) | .id" \
+              | head -n 1
+          )"
+
+          if [ -n "$comment_id" ]; then
+            gh api --method PATCH "repos/${{ github.repository }}/issues/comments/$comment_id" \
+              -f body="$(cat "$comment_file")"
+          else
+            gh api --method POST "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+              -f body="$(cat "$comment_file")"
           fi
 
       - name: Upload benchmark results

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 /target/
+.benchmark-tools/
+.benchmark-work/
 node_modules/
 packages/*/dist/
 packages/*/dist-test/
+packages/*/.benchmark-work/
 packages/*/node_modules/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,6 +32,22 @@ _Avoid_: Rust API, webpack-compatible API
 A test authored from the JavaScript side that exercises Unpack through the public JavaScript API boundary.
 _Avoid_: Rust core test, internal facade test
 
+**Cross-Bundler Benchmark**:
+A performance comparison that runs the same benchmark fixture through Unpack and selected external bundlers. Its results are diagnostic signals, not merge gates or compatibility claims.
+_Avoid_: Compatibility benchmark, conformance benchmark, release gate
+
+**Benchmark Fixture**:
+A generated application module graph constrained to JavaScript features the compared bundlers are expected to compile. It exists to produce comparable bundle work, not to model a real application.
+_Avoid_: Sample app, real-world app, compatibility fixture
+
+**Cold Build Measurement**:
+A benchmark measurement taken after clearing the output path and benchmark-owned cache state for the tool under test.
+_Avoid_: First run, clean test
+
+**Warm Build Measurement**:
+A benchmark measurement taken after a prior build in the same benchmark job while preserving benchmark-owned cache state that the tool under test can reuse.
+_Avoid_: Incremental rebuild, watch rebuild
+
 **Module Graph**:
 The connected set of modules reachable from one or more entry points.
 _Avoid_: Dependency tree

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -45,6 +45,6 @@ Runtime verification is separate from build timing. A Bundle that builds but doe
 
 ## CI
 
-The `Cross-Bundler Benchmarks` workflow runs on pull requests and manual dispatch. It writes the table to the GitHub Actions job summary and uploads the JSON report as an artifact.
+The `Cross-Bundler Benchmarks` workflow runs on pull requests and manual dispatch. It writes the table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, and uploads the JSON report as an artifact.
 
 The workflow is intentionally non-blocking. Benchmark setup failures, external toolchain failures, or runtime verification failures should be visible in the workflow output without blocking unrelated code from merging.

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -1,0 +1,50 @@
+# Cross-Bundler Benchmark
+
+The Cross-Bundler Benchmark compares Unpack with webpack, Rspack, Rolldown, and Turbopack on generated Benchmark Fixtures. The results are diagnostic signals for maintainers; they are not merge gates and they are not compatibility claims.
+
+## Local Run
+
+Build the Unpack JavaScript API and run the benchmark:
+
+```sh
+pnpm benchmark:bundlers -- --workspace .benchmark-work/local
+```
+
+To run only the fast local smoke subset:
+
+```sh
+pnpm --filter @unpack-js/benchmarks bench -- --fixtures small --bundlers unpack,webpack,rspack,rolldown
+```
+
+Turbopack requires a fixed Next.js checkout:
+
+```sh
+git init .benchmark-tools/next.js
+git -C .benchmark-tools/next.js remote add origin https://github.com/vercel/next.js.git
+git -C .benchmark-tools/next.js fetch --depth=1 --filter=blob:none origin a88f25caf0070b582a8ed83b1ae9e7135d7fd3bc
+git -C .benchmark-tools/next.js checkout --detach FETCH_HEAD
+
+pnpm --filter @unpack-js/benchmarks bench -- \
+  --turbopack-repo .benchmark-tools/next.js \
+  --turbopack-commit a88f25caf0070b582a8ed83b1ae9e7135d7fd3bc
+```
+
+## Result Shape
+
+The runner emits a Markdown summary and can write the raw JSON report with `--output-json`.
+
+Important fields:
+
+- `cold_build_ms`: build time after clearing benchmark-owned output and cache state.
+- `warm_build_ms`: build time for the second run in the same job while preserving benchmark-owned cache state.
+- `output_bytes`: bytes emitted under the benchmark output path, excluding runner metadata.
+- `version_source`: the npm package version or fixed source commit used for the bundler.
+- `status`: `success`, `unsupported`, `setup_failed`, `build_failed`, `runtime_failed`, or a warm-build variant.
+
+Runtime verification is separate from build timing. A Bundle that builds but does not export the expected checksum is marked `runtime_failed` and should not be treated as a valid performance result.
+
+## CI
+
+The `Cross-Bundler Benchmarks` workflow runs on pull requests and manual dispatch. It writes the table to the GitHub Actions job summary and uploads the JSON report as an artifact.
+
+The workflow is intentionally non-blocking. Benchmark setup failures, external toolchain failures, or runtime verification failures should be visible in the workflow output without blocking unrelated code from merging.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "scripts": {
-    "test": "cargo test --workspace && pnpm --filter @unpack-js/core test"
+    "benchmark:bundlers": "pnpm --filter @unpack-js/core build && pnpm --filter @unpack-js/benchmarks bench",
+    "test": "cargo test --workspace && pnpm --filter @unpack-js/core test && pnpm --filter @unpack-js/benchmarks test"
   }
 }

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@unpack-js/benchmarks",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "bench": "node src/run.mjs",
+    "test": "node --test test/*.test.mjs"
+  },
+  "dependencies": {
+    "@rspack/core": "2.1.1",
+    "@unpack-js/core": "workspace:*",
+    "rolldown": "1.1.3",
+    "webpack": "5.108.1"
+  }
+}

--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -1,0 +1,313 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+import { promisify } from "node:util";
+
+import { DEFAULT_TURBOPACK_COMMIT } from "./runner.mjs";
+
+const execFile = promisify(execFileCallback);
+const require = createRequire(import.meta.url);
+const preparedTurbopackBuilds = new Set();
+
+export const adapters = {
+  unpack: {
+    name: "unpack",
+    versionSource: () => `@unpack-js/core@${packageVersion("@unpack-js/core")}`,
+    async build({ fixture, outputDir, cacheDir }) {
+      const { default: unpack } = await import("@unpack-js/core");
+      const compiler = unpack({
+        context: fixture.context,
+        entry: fixture.entry,
+        output: { path: outputDir },
+        cache: {
+          type: "filesystem",
+          cacheLocation: cacheDir,
+          idleTimeout: 0
+        }
+      });
+
+      try {
+        const { err, stats } = await runUnpackCompiler(compiler);
+        if (err) {
+          throw err;
+        }
+        if (stats?.hasErrors()) {
+          const errors = stats.toJson().errors.map((error) => error.message).join("\n");
+          throw new Error(errors || "Unpack reported compilation errors");
+        }
+      } finally {
+        await closeUnpackCompiler(compiler);
+      }
+
+      return { entryFile: join(outputDir, "main.js") };
+    }
+  },
+
+  webpack: {
+    name: "webpack",
+    versionSource: () => `webpack@${packageVersion("webpack")}`,
+    async build({ fixture, outputDir, cacheDir }) {
+      const webpackModule = await import("webpack");
+      const webpack = webpackModule.default ?? webpackModule;
+      const compiler = webpack({
+        ...webpackLikeConfig({ fixture, outputDir }),
+        cache: {
+          type: "filesystem",
+          cacheDirectory: cacheDir
+        }
+      });
+
+      try {
+        const stats = await runWebpackCompiler(compiler);
+        assertWebpackStats(stats, "webpack");
+      } finally {
+        await closeWebpackCompiler(compiler);
+      }
+
+      return { entryFile: join(outputDir, "main.js") };
+    }
+  },
+
+  rspack: {
+    name: "rspack",
+    versionSource: () => `@rspack/core@${packageVersion("@rspack/core")}`,
+    async build({ fixture, outputDir, cacheDir }) {
+      const rspackModule = await import("@rspack/core");
+      const rspack = rspackModule.rspack ?? rspackModule.default;
+      const compiler = rspack({
+        ...webpackLikeConfig({ fixture, outputDir }),
+        cache: {
+          type: "persistent",
+          storage: {
+            type: "filesystem",
+            directory: cacheDir
+          }
+        }
+      });
+
+      try {
+        const stats = await runWebpackCompiler(compiler);
+        assertWebpackStats(stats, "Rspack");
+      } finally {
+        await closeWebpackCompiler(compiler);
+      }
+
+      return { entryFile: join(outputDir, "main.js") };
+    }
+  },
+
+  rolldown: {
+    name: "rolldown",
+    versionSource: () => `rolldown@${packageVersion("rolldown")}`,
+    async build({ fixture, outputDir }) {
+      const { rolldown } = await import("rolldown");
+      const bundle = await rolldown({
+        input: resolve(fixture.context, fixture.entry),
+        treeshake: true
+      });
+
+      try {
+        await bundle.write({
+          dir: outputDir,
+          format: "cjs",
+          entryFileNames: "main.js",
+          chunkFileNames: "[name].js",
+          exports: "named",
+          sourcemap: false
+        });
+      } finally {
+        await bundle.close?.();
+      }
+
+      return { entryFile: join(outputDir, "main.js") };
+    }
+  },
+
+  turbopack: {
+    name: "turbopack",
+    outputDir: ({ fixture }) => join(fixture.context, "dist"),
+    versionSource: ({ options }) =>
+      `vercel/next.js@${options.turbopackCommit ?? DEFAULT_TURBOPACK_COMMIT}`,
+    async prepare({ options }) {
+      const repo = options.turbopackRepo;
+      if (!repo) {
+        throw unsupported("Turbopack requires --turbopack-repo pointing at a fixed Next.js checkout");
+      }
+
+      const profile = options.turbopackProfile ?? "release";
+      const prepareKey = `${repo}:${profile}`;
+      if (preparedTurbopackBuilds.has(prepareKey)) {
+        return;
+      }
+
+      const args = ["build", "--package", "turbopack-cli", "--bin", "turbopack-cli"];
+      if (profile === "release") {
+        args.push("--release");
+      } else if (profile !== "dev") {
+        args.push("--profile", profile);
+      }
+
+      await execFile("cargo", args, {
+        cwd: repo,
+        timeout: 60 * 60 * 1000,
+        maxBuffer: 1024 * 1024 * 20
+      });
+      preparedTurbopackBuilds.add(prepareKey);
+    },
+    async build({ fixture, cacheDir, options }) {
+      const repo = options.turbopackRepo;
+      if (!repo) {
+        throw unsupported("Turbopack requires --turbopack-repo pointing at a fixed Next.js checkout");
+      }
+
+      const profile = options.turbopackProfile ?? "release";
+      const binary = join(
+        repo,
+        "target",
+        profile === "dev" ? "debug" : profile,
+        "turbopack-cli"
+      );
+
+      await execFile(
+        binary,
+        [
+          "build",
+          "--dir",
+          fixture.context,
+          "--root",
+          fixture.context,
+          "--target",
+          "node",
+          "--no-minify",
+          "--no-sourcemap",
+          "--no-scope-hoist",
+          "--persistent-caching",
+          "--cache-dir",
+          cacheDir,
+          fixture.entry
+        ],
+        {
+          cwd: repo,
+          env: { ...process.env, CI: process.env.CI ?? "1" },
+          timeout: 10 * 60 * 1000,
+          maxBuffer: 1024 * 1024 * 20
+        }
+      );
+
+      return { entryFile: join(fixture.context, "dist/index.entry.js") };
+    }
+  }
+};
+
+function webpackLikeConfig({ fixture, outputDir }) {
+  return {
+    mode: "none",
+    target: "node",
+    context: fixture.context,
+    entry: {
+      main: resolve(fixture.context, fixture.entry)
+    },
+    output: {
+      path: outputDir,
+      filename: "main.js",
+      chunkFilename: "[name].js",
+      library: {
+        type: "commonjs2"
+      },
+      clean: false
+    },
+    devtool: false,
+    optimization: {
+      minimize: false
+    },
+    stats: "errors-warnings"
+  };
+}
+
+function runUnpackCompiler(compiler) {
+  return new Promise((resolve) => {
+    compiler.run((err, stats) => resolve({ err, stats }));
+  });
+}
+
+function closeUnpackCompiler(compiler) {
+  return new Promise((resolve, reject) => {
+    compiler.close((err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function runWebpackCompiler(compiler) {
+  return new Promise((resolve, reject) => {
+    compiler.run((err, stats) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(stats);
+    });
+  });
+}
+
+function closeWebpackCompiler(compiler) {
+  return new Promise((resolve, reject) => {
+    compiler.close((err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function assertWebpackStats(stats, label) {
+  if (!stats?.hasErrors?.()) {
+    return;
+  }
+
+  const info = stats.toJson({
+    all: false,
+    errors: true
+  });
+  const message =
+    info.errors?.map((error) => error.message || String(error)).join("\n") ||
+    `${label} reported compilation errors`;
+  throw new Error(message);
+}
+
+function packageVersion(packageName) {
+  try {
+    return require(`${packageName}/package.json`).version;
+  } catch {
+    return packageVersionFromResolvedEntry(packageName);
+  }
+}
+
+function packageVersionFromResolvedEntry(packageName) {
+  let current = dirname(require.resolve(packageName));
+  while (current !== dirname(current)) {
+    const packageJson = join(current, "package.json");
+    try {
+      const parsed = JSON.parse(require("node:fs").readFileSync(packageJson, "utf8"));
+      if (parsed.name === packageName) {
+        return parsed.version;
+      }
+    } catch {
+      // Keep walking upward until the package root is found.
+    }
+    current = dirname(current);
+  }
+  return "unknown";
+}
+
+function unsupported(message) {
+  const error = new Error(message);
+  error.code = "UNSUPPORTED_BUNDLER";
+  return error;
+}

--- a/packages/benchmarks/src/fixture.mjs
+++ b/packages/benchmarks/src/fixture.mjs
@@ -1,0 +1,147 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export const FIXTURE_SHAPES = {
+  small: {
+    name: "small",
+    featureModules: 10,
+    sharedModules: 5,
+    importsPerFeature: 3
+  },
+  medium: {
+    name: "medium",
+    featureModules: 100,
+    sharedModules: 20,
+    importsPerFeature: 4
+  },
+  large: {
+    name: "large",
+    featureModules: 500,
+    sharedModules: 50,
+    importsPerFeature: 5
+  }
+};
+
+export async function createBenchmarkFixture(rootDir, shape) {
+  const context = join(rootDir, shape.name);
+  await rm(context, { recursive: true, force: true });
+  await mkdir(context, { recursive: true });
+  await writeJson(join(context, "package.json"), {
+    private: true,
+    type: "module"
+  });
+
+  await writeSource(join(context, "src/index.js"), entrySource(shape));
+
+  for (let shared = 0; shared < shape.sharedModules; shared += 1) {
+    await writeSource(
+      join(context, `src/shared/shared${shared}.js`),
+      sharedSource(shared)
+    );
+  }
+
+  for (let feature = 0; feature < shape.featureModules; feature += 1) {
+    await writeSource(
+      join(context, `src/features/feature${feature}.js`),
+      featureSource(shape, feature)
+    );
+    await writeSource(
+      join(context, `src/features/leaf${feature}.js`),
+      leafSource(feature)
+    );
+    await writeSource(
+      join(context, `src/features/reexport${feature}.js`),
+      reexportSource(feature)
+    );
+  }
+
+  return {
+    name: shape.name,
+    context,
+    entry: "./src/index.js",
+    expectedChecksum: expectedChecksum(shape)
+  };
+}
+
+function entrySource(shape) {
+  const source = [];
+  for (let feature = 0; feature < shape.featureModules; feature += 1) {
+    source.push(
+      `import { feature${feature}, reexport${feature} } from "./features/feature${feature}.js";`
+    );
+  }
+
+  source.push("const values = [");
+  for (let feature = 0; feature < shape.featureModules; feature += 1) {
+    source.push(`  feature${feature}, reexport${feature},`);
+  }
+  source.push("];");
+  source.push(
+    "export const checksum = values.reduce((total, value) => total + value, 0);"
+  );
+  source.push("export default checksum;");
+  return `${source.join("\n")}\n`;
+}
+
+function featureSource(shape, feature) {
+  const sharedImports = sharedImportsFor(shape, feature);
+  const source = [];
+  for (const shared of sharedImports) {
+    source.push(
+      `import { shared${shared} } from "../shared/shared${shared}.js";`
+    );
+  }
+  source.push(`import { leaf${feature} } from "./leaf${feature}.js";`);
+  source.push(
+    `export { leaf${feature} as reexport${feature} } from "./reexport${feature}.js";`
+  );
+  source.push(`export * from "../shared/shared${feature % shape.sharedModules}.js";`);
+  source.push(
+    `export const feature${feature} = leaf${feature}${sharedImports
+      .map((shared) => ` + shared${shared}`)
+      .join("")};`
+  );
+  return `${source.join("\n")}\n`;
+}
+
+function sharedImportsFor(shape, feature) {
+  return Array.from(
+    { length: shape.importsPerFeature },
+    (_unused, offset) => (feature + offset) % shape.sharedModules
+  );
+}
+
+function sharedSource(shared) {
+  return `export const shared${shared} = ${shared + 1};\nexport const sharedValue${shared} = shared${shared} * 2;\n`;
+}
+
+function leafSource(feature) {
+  return `export const leaf${feature} = ${feature + 1};\n`;
+}
+
+function reexportSource(feature) {
+  return `export { leaf${feature} } from "./leaf${feature}.js";\n`;
+}
+
+function expectedChecksum(shape) {
+  let checksum = 0;
+  for (let feature = 0; feature < shape.featureModules; feature += 1) {
+    const leaf = feature + 1;
+    const sharedTotal = sharedImportsFor(shape, feature).reduce(
+      (total, shared) => total + shared + 1,
+      0
+    );
+    checksum += leaf + sharedTotal + leaf;
+  }
+  return checksum;
+}
+
+async function writeSource(path, source) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, source, "utf8");
+}
+
+async function writeJson(path, value) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}

--- a/packages/benchmarks/src/run.mjs
+++ b/packages/benchmarks/src/run.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+import {
+  DEFAULT_BUNDLERS,
+  DEFAULT_TURBOPACK_COMMIT,
+  runBenchmark,
+  toSummaryMarkdown
+} from "./runner.mjs";
+
+const invocationCwd = process.env.INIT_CWD ?? process.cwd();
+const options = parseArgs(process.argv.slice(2));
+const report = await runBenchmark(options);
+const summary = toSummaryMarkdown(report);
+
+if (options.outputJson) {
+  await writeOutput(options.outputJson, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+if (options.summaryMd) {
+  await writeOutput(options.summaryMd, summary);
+}
+
+process.stdout.write(summary);
+
+function parseArgs(args) {
+  const parsed = {
+    workspaceDir: resolve(invocationCwd, ".benchmark-work"),
+    fixtures: ["small", "medium", "large"],
+    bundlers: DEFAULT_BUNDLERS,
+    turbopackCommit: DEFAULT_TURBOPACK_COMMIT,
+    turbopackProfile: "release"
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const value = () => {
+      index += 1;
+      if (index >= args.length) {
+        throw new Error(`${arg} requires a value`);
+      }
+      return args[index];
+    };
+
+    switch (arg) {
+      case "--":
+        break;
+      case "--workspace":
+        parsed.workspaceDir = resolve(invocationCwd, value());
+        break;
+      case "--fixtures":
+        parsed.fixtures = splitList(value());
+        break;
+      case "--bundlers":
+        parsed.bundlers = splitList(value());
+        break;
+      case "--output-json":
+        parsed.outputJson = resolve(invocationCwd, value());
+        break;
+      case "--summary-md":
+        parsed.summaryMd = resolve(invocationCwd, value());
+        break;
+      case "--turbopack-repo":
+        parsed.turbopackRepo = resolve(invocationCwd, value());
+        break;
+      case "--turbopack-commit":
+        parsed.turbopackCommit = value();
+        break;
+      case "--turbopack-profile":
+        parsed.turbopackProfile = value();
+        break;
+      case "--help":
+        printHelp();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`unknown argument '${arg}'`);
+    }
+  }
+
+  return parsed;
+}
+
+function splitList(value) {
+  return value.split(",").map((item) => item.trim()).filter(Boolean);
+}
+
+async function writeOutput(path, contents) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, contents, "utf8");
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: pnpm --filter @unpack-js/benchmarks bench -- [options]
+
+Options:
+  --workspace <path>            Benchmark-owned workspace directory
+  --fixtures <list>             Comma-separated fixture list
+  --bundlers <list>             Comma-separated bundler list
+  --output-json <path>          Write raw JSON report
+  --summary-md <path>           Write Markdown summary table
+  --turbopack-repo <path>       Fixed Next.js checkout containing turbopack/
+  --turbopack-commit <sha>      Commit shown for Turbopack results
+  --turbopack-profile <name>    Cargo profile for turbopack-cli (default: release)
+`);
+}

--- a/packages/benchmarks/src/runner.mjs
+++ b/packages/benchmarks/src/runner.mjs
@@ -1,0 +1,337 @@
+import { createRequire } from "node:module";
+import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { performance } from "node:perf_hooks";
+import { dirname, join, resolve, sep } from "node:path";
+
+import { createBenchmarkFixture, FIXTURE_SHAPES } from "./fixture.mjs";
+
+const require = createRequire(import.meta.url);
+
+export const DEFAULT_BUNDLERS = [
+  "unpack",
+  "webpack",
+  "rspack",
+  "rolldown",
+  "turbopack"
+];
+
+export const DEFAULT_TURBOPACK_COMMIT =
+  "a88f25caf0070b582a8ed83b1ae9e7135d7fd3bc";
+
+export async function runBenchmark(options = {}) {
+  const workspaceDir = resolve(options.workspaceDir ?? ".benchmark-work");
+  const fixtureNames = options.fixtures ?? ["small", "medium", "large"];
+  const bundlerNames = options.bundlers ?? DEFAULT_BUNDLERS;
+  const adapters = options.adapters ?? (await defaultAdapters());
+  const shapes = fixtureNames.map((name) => {
+    const shape = FIXTURE_SHAPES[name];
+    if (!shape) {
+      throw new Error(`unknown benchmark fixture '${name}'`);
+    }
+    return shape;
+  });
+
+  await mkdir(workspaceDir, { recursive: true });
+  const fixtureRoot = join(workspaceDir, "fixtures");
+  const results = [];
+
+  for (const shape of shapes) {
+    const fixture = await createBenchmarkFixture(fixtureRoot, shape);
+    for (const bundler of bundlerNames) {
+      const adapter = adapters[bundler];
+      results.push(
+        await runBundlerBenchmark({
+          adapter,
+          bundler,
+          fixture,
+          workspaceDir,
+          options
+        })
+      );
+    }
+  }
+
+  return {
+    schema_version: 1,
+    generated_at: new Date().toISOString(),
+    results
+  };
+}
+
+export function toSummaryMarkdown(report) {
+  const lines = [
+    "| fixture | bundler | version/source | cold_build_ms | warm_build_ms | output_bytes | status |",
+    "| --- | --- | --- | ---: | ---: | ---: | --- |"
+  ];
+
+  for (const result of report.results) {
+    lines.push(
+      [
+        result.fixture,
+        result.bundler,
+        result.version_source ?? "",
+        formatNumber(result.cold_build_ms),
+        formatNumber(result.warm_build_ms),
+        formatNumber(result.output_bytes, 0),
+        result.status
+      ].join(" | ").replace(/^/, "| ").replace(/$/, " |")
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+async function runBundlerBenchmark({ adapter, bundler, fixture, workspaceDir, options }) {
+  const versionSource = await adapterVersion(adapter, options);
+  const baseDir = join(workspaceDir, "runs", fixture.name, bundler);
+  const outputDir = adapter?.outputDir
+    ? adapter.outputDir({ fixture, baseDir, options })
+    : join(baseDir, "output");
+  const cacheDir = join(baseDir, "cache");
+
+  if (!adapter) {
+    return emptyResult({
+      fixture,
+      bundler,
+      versionSource: "not_configured",
+      status: "unsupported",
+      message: "no adapter configured"
+    });
+  }
+
+  try {
+    await adapter.prepare?.({ options });
+  } catch (error) {
+    return emptyResult({
+      fixture,
+      bundler,
+      versionSource,
+      status: isUnsupported(error) ? "unsupported" : "setup_failed",
+      message: errorMessage(error)
+    });
+  }
+
+  const cold = await timedBuild({
+    adapter,
+    phase: "cold",
+    fixture,
+    outputDir,
+    cacheDir,
+    options
+  });
+  if (cold.status !== "success") {
+    return resultFromPhases({ fixture, bundler, versionSource, cold });
+  }
+
+  const warm = await timedBuild({
+    adapter,
+    phase: "warm",
+    fixture,
+    outputDir,
+    cacheDir,
+    options
+  });
+
+  return resultFromPhases({ fixture, bundler, versionSource, cold, warm });
+}
+
+async function timedBuild({ adapter, phase, fixture, outputDir, cacheDir, options }) {
+  if (phase === "cold") {
+    await rm(outputDir, { recursive: true, force: true });
+    await rm(cacheDir, { recursive: true, force: true });
+  }
+  await mkdir(outputDir, { recursive: true });
+  await mkdir(cacheDir, { recursive: true });
+
+  let buildResult;
+  const started = performance.now();
+  try {
+    buildResult = await adapter.build({
+      fixture,
+      outputDir,
+      cacheDir,
+      phase,
+      options
+    });
+  } catch (error) {
+    return {
+      status: isUnsupported(error) ? "unsupported" : "build_failed",
+      build_ms: elapsed(started),
+      output_bytes: null,
+      verify_ms: null,
+      message: errorMessage(error)
+    };
+  }
+
+  const buildMs = elapsed(started);
+  const entryFile = buildResult?.entryFile;
+  if (!entryFile) {
+    return {
+      status: "build_failed",
+      build_ms: buildMs,
+      output_bytes: await outputBytes(outputDir),
+      verify_ms: null,
+      message: "adapter did not return an entry file"
+    };
+  }
+
+  const verifyStarted = performance.now();
+  try {
+    await verifyBundle({
+      entryFile,
+      outputDir,
+      expectedChecksum: fixture.expectedChecksum
+    });
+  } catch (error) {
+    return {
+      status: "runtime_failed",
+      build_ms: buildMs,
+      output_bytes: await outputBytes(outputDir),
+      verify_ms: elapsed(verifyStarted),
+      message: errorMessage(error)
+    };
+  }
+
+  return {
+    status: "success",
+    build_ms: buildMs,
+    output_bytes: await outputBytes(outputDir),
+    verify_ms: elapsed(verifyStarted),
+    message: null
+  };
+}
+
+async function verifyBundle({ entryFile, outputDir, expectedChecksum }) {
+  await writeFile(
+    join(outputDir, "package.json"),
+    `${JSON.stringify({ type: "commonjs" }, null, 2)}\n`,
+    "utf8"
+  );
+
+  clearRequireCache(outputDir);
+  const resolvedEntry = require.resolve(entryFile);
+  delete require.cache[resolvedEntry];
+  const exports = require(resolvedEntry);
+  const checksum = exports?.checksum ?? exports?.default?.checksum;
+
+  if (checksum !== expectedChecksum) {
+    throw new Error(
+      `expected bundle checksum ${expectedChecksum}, received ${String(checksum)}`
+    );
+  }
+}
+
+function resultFromPhases({ fixture, bundler, versionSource, cold, warm }) {
+  const status =
+    cold.status !== "success"
+      ? cold.status
+      : warm && warm.status !== "success"
+        ? `warm_${warm.status}`
+        : "success";
+  const message =
+    cold.status !== "success" ? cold.message : warm?.status !== "success" ? warm.message : null;
+
+  return {
+    fixture: fixture.name,
+    bundler,
+    version_source: versionSource,
+    cold_build_ms: cold.status === "success" ? cold.build_ms : null,
+    warm_build_ms: warm?.status === "success" ? warm.build_ms : null,
+    output_bytes: warm?.output_bytes ?? cold.output_bytes,
+    cold_status: cold.status,
+    warm_status: warm?.status ?? "not_run",
+    verify_status:
+      cold.status === "runtime_failed" || warm?.status === "runtime_failed"
+        ? "runtime_failed"
+        : cold.status === "success" && (!warm || warm.status === "success")
+          ? "success"
+          : "not_run",
+    status,
+    error: message
+  };
+}
+
+function emptyResult({ fixture, bundler, versionSource, status, message }) {
+  return {
+    fixture: fixture.name,
+    bundler,
+    version_source: versionSource,
+    cold_build_ms: null,
+    warm_build_ms: null,
+    output_bytes: null,
+    cold_status: "not_run",
+    warm_status: "not_run",
+    verify_status: "not_run",
+    status,
+    error: message
+  };
+}
+
+async function adapterVersion(adapter, options) {
+  if (!adapter) {
+    return "not_configured";
+  }
+  if (adapter.versionSource) {
+    return adapter.versionSource({ options });
+  }
+  return adapter.name;
+}
+
+export async function outputBytes(outputDir) {
+  let total = 0;
+  let entries;
+  try {
+    entries = await readdir(outputDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  for (const entry of entries) {
+    if (entry.name === "package.json") {
+      continue;
+    }
+    const path = join(outputDir, entry.name);
+    if (entry.isDirectory()) {
+      total += (await outputBytes(path)) ?? 0;
+    } else if (entry.isFile()) {
+      total += (await stat(path)).size;
+    }
+  }
+  return total;
+}
+
+function clearRequireCache(outputDir) {
+  const normalizedOutputDir = `${resolve(outputDir)}${sep}`;
+  for (const cacheKey of Object.keys(require.cache)) {
+    if (cacheKey === resolve(outputDir) || cacheKey.startsWith(normalizedOutputDir)) {
+      delete require.cache[cacheKey];
+    }
+  }
+}
+
+function elapsed(started) {
+  return Number((performance.now() - started).toFixed(3));
+}
+
+function formatNumber(value, digits = 3) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return Number(value).toFixed(digits);
+}
+
+function isUnsupported(error) {
+  return error && typeof error === "object" && error.code === "UNSUPPORTED_BUNDLER";
+}
+
+function errorMessage(error) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+async function defaultAdapters() {
+  const { adapters } = await import("./adapters.mjs");
+  return adapters;
+}

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import { runBenchmark, toSummaryMarkdown } from "../src/runner.mjs";
+
+const execFileAsync = promisify(execFile);
+
+test("runner emits cold and warm measurements for a verified bundle", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
+
+  try {
+    const report = await runBenchmark({
+      workspaceDir: workspace,
+      fixtures: ["small"],
+      bundlers: ["fake"],
+      adapters: {
+        fake: fakeAdapter()
+      }
+    });
+
+    assert.equal(report.schema_version, 1);
+    assert.equal(report.results.length, 1);
+    assert.equal(report.results[0].fixture, "small");
+    assert.equal(report.results[0].bundler, "fake");
+    assert.equal(report.results[0].status, "success");
+    assert.equal(report.results[0].cold_status, "success");
+    assert.equal(report.results[0].warm_status, "success");
+    assert.equal(report.results[0].verify_status, "success");
+    assert.equal(typeof report.results[0].cold_build_ms, "number");
+    assert.equal(typeof report.results[0].warm_build_ms, "number");
+    assert.ok(report.results[0].output_bytes > 0);
+    assert.match(toSummaryMarkdown(report), /\\| small \\| fake \\| fake@1\\.0\\.0 \\|/);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("runner marks a built bundle with the wrong checksum as runtime_failed", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
+
+  try {
+    const report = await runBenchmark({
+      workspaceDir: workspace,
+      fixtures: ["small"],
+      bundlers: ["fake"],
+      adapters: {
+        fake: fakeAdapter({ checksumOffset: 1 })
+      }
+    });
+
+    assert.equal(report.results[0].status, "runtime_failed");
+    assert.equal(report.results[0].cold_status, "runtime_failed");
+    assert.equal(report.results[0].warm_status, "not_run");
+    assert.equal(report.results[0].warm_build_ms, null);
+    assert.match(report.results[0].error, /expected bundle checksum/);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("runner reports unsupported adapters explicitly", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
+
+  try {
+    const error = new Error("not available in this environment");
+    error.code = "UNSUPPORTED_BUNDLER";
+    const report = await runBenchmark({
+      workspaceDir: workspace,
+      fixtures: ["small"],
+      bundlers: ["fake"],
+      adapters: {
+        fake: fakeAdapter({ error })
+      }
+    });
+
+    assert.equal(report.results[0].status, "unsupported");
+    assert.equal(report.results[0].cold_build_ms, null);
+    assert.equal(report.results[0].warm_build_ms, null);
+    assert.match(report.results[0].error, /not available/);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("CLI accepts pnpm-style -- separator and writes JSON output", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
+  const outputJson = join(workspace, "results.json");
+
+  try {
+    await execFileAsync(
+      process.execPath,
+      [
+        "src/run.mjs",
+        "--",
+        "--fixtures",
+        "small",
+        "--bundlers",
+        "turbopack",
+        "--workspace",
+        join(workspace, "run"),
+        "--output-json",
+        outputJson
+      ],
+      {
+        cwd: join(import.meta.dirname, "..")
+      }
+    );
+
+    const report = JSON.parse(await readFile(outputJson, "utf8"));
+    assert.equal(report.results[0].bundler, "turbopack");
+    assert.equal(report.results[0].status, "unsupported");
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+function fakeAdapter({ checksumOffset = 0, error } = {}) {
+  return {
+    name: "fake",
+    versionSource: () => "fake@1.0.0",
+    async build({ fixture, outputDir }) {
+      if (error) {
+        throw error;
+      }
+      const entryFile = join(outputDir, "main.js");
+      await writeFile(
+        entryFile,
+        `exports.checksum = ${fixture.expectedChecksum + checksumOffset};\n`,
+        "utf8"
+      );
+      return { entryFile };
+    }
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,21 @@ importers:
 
   .: {}
 
+  packages/benchmarks:
+    dependencies:
+      '@rspack/core':
+        specifier: 2.1.1
+        version: 2.1.1
+      '@unpack-js/core':
+        specifier: workspace:*
+        version: link:../unpack
+      rolldown:
+        specifier: 1.1.3
+        version: 1.1.3
+      webpack:
+        specifier: 5.108.1
+        version: 5.108.1
+
   packages/unpack:
     devDependencies:
       '@types/node':
@@ -19,8 +34,490 @@ importers:
 
 packages:
 
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.137.0':
+    resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
+
+  '@rolldown/binding-android-arm64@1.1.3':
+    resolution: {integrity: sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.3':
+    resolution: {integrity: sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.3':
+    resolution: {integrity: sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.3':
+    resolution: {integrity: sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.3':
+    resolution: {integrity: sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.3':
+    resolution: {integrity: sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.3':
+    resolution: {integrity: sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.3':
+    resolution: {integrity: sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.3':
+    resolution: {integrity: sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.3':
+    resolution: {integrity: sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.1.3':
+    resolution: {integrity: sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.1.3':
+    resolution: {integrity: sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.3':
+    resolution: {integrity: sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.3':
+    resolution: {integrity: sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.3':
+    resolution: {integrity: sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@rspack/binding-darwin-arm64@2.1.1':
+    resolution: {integrity: sha512-6K8jA3pZphBwLt5DU78wl0IzY1myHrqNSvFVCd9CHa+szlOwv2iMQpZdYdpupIBxwiZ39rrDyQKtoZw7lsAG8w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@2.1.1':
+    resolution: {integrity: sha512-RdqtEfIbSe5ucLNVvMac1k88UwmL4Gil8uXqlEFcSZ3VC2jTOkecadd+B0RYqJ+PirSInrRmKm1cr0740zppOA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-linux-arm64-gnu@2.1.1':
+    resolution: {integrity: sha512-ROKtqXoLpbZO1vYEcNxQg6COvRhdlJcoib1Z4pzG1nIyctEAUuFmnD7pIvJiVe6M7YuJNXW+1p0BhpptT2XEUQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-musl@2.1.1':
+    resolution: {integrity: sha512-QdQpG9dK0GfPASjBd/8rUwDNW0ShfFfYJfcoGLNTM6A8EqmgvWwklXDiCVF5dXALbZIksAuRznIKnLDsUoXi9Q==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.1':
+    resolution: {integrity: sha512-LGdYCAvblZp2qtHk9UseYftIRyaBzSWqEzd1toaS08sYESXERm+YBbrYKKiyq1yXiU1L7BkhMUxiWc3GCYmKcA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-riscv64-musl@2.1.1':
+    resolution: {integrity: sha512-87phiiPGFT1p4gy3Oz6YdNijCPXdjJy43LFdE8AFiZsV4ChFXQPqnVCF2aMRLybYa51A+9wGYlTvxt09yUQUww==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-x64-gnu@2.1.1':
+    resolution: {integrity: sha512-om0/PvZzxISsnyz3hdmI3xBi3Qsn6faRGrfp6WJpGHa5JYYaRVWz1MJ9fe+/cQE9ON9r32HpMOeuataCLv+Owg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-musl@2.1.1':
+    resolution: {integrity: sha512-YgAyTOM5ZWvWT0Exwcg7QkGUv9PsHT4yIsEyJbH+a99uAKliGMwkHIOP/aJgrCF8G+lTfigY2wyl9cWo4TA4aw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-wasm32-wasi@2.1.1':
+    resolution: {integrity: sha512-OicgaB3Dcd+KXsH/I3DkJG7XQyREJScg/jLkCtycFn9BhT0IVJvgi37F8QNJKl8Bp9YZIGehsqK9HpQWav6SLw==}
+    cpu: [wasm32]
+
+  '@rspack/binding-win32-arm64-msvc@2.1.1':
+    resolution: {integrity: sha512-fwL4P3SsC0r/vVGgnmexnc4vkvf+9vWMcGw5fdlPBJNR/zWlZRSXR5V6eXcHrpYVLhBsLYvZYE3NZa9paIUGxw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-ia32-msvc@2.1.1':
+    resolution: {integrity: sha512-j3BISXbjPyI57HeHxW9Jx+UP7RebNQ4t62uCbRP29caf9aghYJP+ZA5nJ2X7pol7N5Je2/V6WNahuNd0zQFDOA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@2.1.1':
+    resolution: {integrity: sha512-aPNNFuZT5iBM8+S9J4P5ywJbf3tUvZN3Ppe6mXJ8/jTVDUDhe0YVj3AgD/AuxnUvl+yHrLfQkN1nNwUfIcomfA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding@2.1.1':
+    resolution: {integrity: sha512-6062hZP33fn1w51ClpQnum19GGXl/3eS754xrRYbQ7wwBNZk94HVwfSyiqcNCtY/pB1lsFjnaTKiW/Q+jv0axQ==}
+
+  '@rspack/core@2.1.1':
+    resolution: {integrity: sha512-Rgz6xZcD0rm7ejZhYNi13qvW2dSnIQQt/7D3xbYoT5hOU838JbkF0P3SAMFGKE+FyLZswnyRpxGfnYHZQqDmJA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/node@26.0.1':
     resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
+
+  '@webassemblyjs/ast@1.14.1':
+    resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2':
+    resolution: {integrity: sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==}
+
+  '@webassemblyjs/helper-api-error@1.13.2':
+    resolution: {integrity: sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==}
+
+  '@webassemblyjs/helper-buffer@1.14.1':
+    resolution: {integrity: sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    resolution: {integrity: sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==}
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2':
+    resolution: {integrity: sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    resolution: {integrity: sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==}
+
+  '@webassemblyjs/ieee754@1.13.2':
+    resolution: {integrity: sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==}
+
+  '@webassemblyjs/leb128@1.13.2':
+    resolution: {integrity: sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==}
+
+  '@webassemblyjs/utf8@1.13.2':
+    resolution: {integrity: sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    resolution: {integrity: sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==}
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    resolution: {integrity: sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==}
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    resolution: {integrity: sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==}
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    resolution: {integrity: sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==}
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
+
+  '@xtuc/ieee754@1.2.0':
+    resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
+
+  '@xtuc/long@4.2.2':
+    resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+
+  acorn-import-phases@1.0.4:
+    resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
+    engines: {node: '>=10.13.0'}
+    peerDependencies:
+      acorn: ^8.14.0
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv-formats@2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-keywords@5.1.0:
+    resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
+    peerDependencies:
+      ajv: ^8.8.2
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  baseline-browser-mapping@2.10.40:
+    resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.4:
+    resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+
+  chrome-trace-event@1.0.4:
+    resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
+    engines: {node: '>=6.0'}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  electron-to-chromium@1.5.380:
+    resolution: {integrity: sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==}
+
+  enhanced-resolve@5.24.1:
+    resolution: {integrity: sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==}
+    engines: {node: '>=10.13.0'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  eslint-scope@5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  jest-worker@27.5.1:
+    resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
+    engines: {node: '>= 10.13.0'}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  loader-runner@4.3.2:
+    resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
+    engines: {node: '>=6.11.5'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  minimizer-webpack-plugin@5.6.1:
+    resolution: {integrity: sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@minify-html/node': '*'
+      '@swc/core': '*'
+      '@swc/css': '*'
+      '@swc/html': '*'
+      clean-css: '*'
+      cssnano: '*'
+      csso: '*'
+      esbuild: '*'
+      html-minifier-terser: '*'
+      lightningcss: '*'
+      postcss: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@minify-html/node':
+        optional: true
+      '@swc/core':
+        optional: true
+      '@swc/css':
+        optional: true
+      '@swc/html':
+        optional: true
+      clean-css:
+        optional: true
+      cssnano:
+        optional: true
+      csso:
+        optional: true
+      esbuild:
+        optional: true
+      html-minifier-terser:
+        optional: true
+      lightningcss:
+        optional: true
+      postcss:
+        optional: true
+      uglify-js:
+        optional: true
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  node-releases@2.0.50:
+    resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
+    engines: {node: '>=18'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  rolldown@1.1.3:
+    resolution: {integrity: sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  schema-utils@4.3.3:
+    resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
+    engines: {node: '>= 10.13.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  terser@5.48.0:
+    resolution: {integrity: sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -30,12 +527,491 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  watchpack@2.5.2:
+    resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
+    engines: {node: '>=10.13.0'}
+
+  webpack-sources@3.5.0:
+    resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
+    engines: {node: '>=10.13.0'}
+
+  webpack@5.108.1:
+    resolution: {integrity: sha512-UUCihHQK3O7483Woa0SulNLDeAiOhHI2PN2PAPU4fVWJqbzhv04EJ8FaWtB9WWh3i8fRt28543U7VfuJTOrpgQ==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+
 snapshots:
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/source-map@0.3.11':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@oxc-project/types@0.137.0': {}
+
+  '@rolldown/binding-android-arm64@1.1.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.3':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.3':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@rspack/binding-darwin-arm64@2.1.1':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.1.1':
+    optional: true
+
+  '@rspack/binding-linux-arm64-gnu@2.1.1':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.1.1':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.1':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-musl@2.1.1':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@2.1.1':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.1.1':
+    optional: true
+
+  '@rspack/binding-wasm32-wasi@2.1.1':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.1.1':
+    optional: true
+
+  '@rspack/binding-win32-ia32-msvc@2.1.1':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.1.1':
+    optional: true
+
+  '@rspack/binding@2.1.1':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.1.1
+      '@rspack/binding-darwin-x64': 2.1.1
+      '@rspack/binding-linux-arm64-gnu': 2.1.1
+      '@rspack/binding-linux-arm64-musl': 2.1.1
+      '@rspack/binding-linux-riscv64-gnu': 2.1.1
+      '@rspack/binding-linux-riscv64-musl': 2.1.1
+      '@rspack/binding-linux-x64-gnu': 2.1.1
+      '@rspack/binding-linux-x64-musl': 2.1.1
+      '@rspack/binding-wasm32-wasi': 2.1.1
+      '@rspack/binding-win32-arm64-msvc': 2.1.1
+      '@rspack/binding-win32-ia32-msvc': 2.1.1
+      '@rspack/binding-win32-x64-msvc': 2.1.1
+
+  '@rspack/core@2.1.1':
+    dependencies:
+      '@rspack/binding': 2.1.1
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/node@26.0.1':
     dependencies:
       undici-types: 8.3.0
 
+  '@webassemblyjs/ast@1.14.1':
+    dependencies:
+      '@webassemblyjs/helper-numbers': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2': {}
+
+  '@webassemblyjs/helper-api-error@1.13.2': {}
+
+  '@webassemblyjs/helper-buffer@1.14.1': {}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    dependencies:
+      '@webassemblyjs/floating-point-hex-parser': 1.13.2
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2': {}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/wasm-gen': 1.14.1
+
+  '@webassemblyjs/ieee754@1.13.2':
+    dependencies:
+      '@xtuc/ieee754': 1.2.0
+
+  '@webassemblyjs/leb128@1.13.2':
+    dependencies:
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/utf8@1.13.2': {}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/helper-wasm-section': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-opt': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      '@webassemblyjs/wast-printer': 1.14.1
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@xtuc/long': 4.2.2
+
+  '@xtuc/ieee754@1.2.0': {}
+
+  '@xtuc/long@4.2.2': {}
+
+  acorn-import-phases@1.0.4(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
+  ajv-formats@2.1.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv-keywords@5.1.0(ajv@8.20.0):
+    dependencies:
+      ajv: 8.20.0
+      fast-deep-equal: 3.1.3
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  baseline-browser-mapping@2.10.40: {}
+
+  browserslist@4.28.4:
+    dependencies:
+      baseline-browser-mapping: 2.10.40
+      caniuse-lite: 1.0.30001799
+      electron-to-chromium: 1.5.380
+      node-releases: 2.0.50
+      update-browserslist-db: 1.2.3(browserslist@4.28.4)
+
+  buffer-from@1.1.2: {}
+
+  caniuse-lite@1.0.30001799: {}
+
+  chrome-trace-event@1.0.4: {}
+
+  commander@2.20.3: {}
+
+  electron-to-chromium@1.5.380: {}
+
+  enhanced-resolve@5.24.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  es-module-lexer@2.1.0: {}
+
+  escalade@3.2.0: {}
+
+  eslint-scope@5.1.1:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@4.3.0: {}
+
+  estraverse@5.3.0: {}
+
+  events@3.3.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.2: {}
+
+  graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
+
+  jest-worker@27.5.1:
+    dependencies:
+      '@types/node': 26.0.1
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
+  json-schema-traverse@1.0.0: {}
+
+  loader-runner@4.3.2: {}
+
+  merge-stream@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  minimizer-webpack-plugin@5.6.1(webpack@5.108.1):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.48.0
+      webpack: 5.108.1
+
+  neo-async@2.6.2: {}
+
+  node-releases@2.0.50: {}
+
+  picocolors@1.1.1: {}
+
+  require-from-string@2.0.2: {}
+
+  rolldown@1.1.3:
+    dependencies:
+      '@oxc-project/types': 0.137.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.3
+      '@rolldown/binding-darwin-arm64': 1.1.3
+      '@rolldown/binding-darwin-x64': 1.1.3
+      '@rolldown/binding-freebsd-x64': 1.1.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.3
+      '@rolldown/binding-linux-arm64-gnu': 1.1.3
+      '@rolldown/binding-linux-arm64-musl': 1.1.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.3
+      '@rolldown/binding-linux-s390x-gnu': 1.1.3
+      '@rolldown/binding-linux-x64-gnu': 1.1.3
+      '@rolldown/binding-linux-x64-musl': 1.1.3
+      '@rolldown/binding-openharmony-arm64': 1.1.3
+      '@rolldown/binding-wasm32-wasi': 1.1.3
+      '@rolldown/binding-win32-arm64-msvc': 1.1.3
+      '@rolldown/binding-win32-x64-msvc': 1.1.3
+
+  schema-utils@4.3.3:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
+  tapable@2.3.3: {}
+
+  terser@5.48.0:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.17.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+
+  tslib@2.8.1:
+    optional: true
+
   typescript@6.0.3: {}
 
   undici-types@8.3.0: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.4):
+    dependencies:
+      browserslist: 4.28.4
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  watchpack@2.5.2:
+    dependencies:
+      graceful-fs: 4.2.11
+
+  webpack-sources@3.5.0: {}
+
+  webpack@5.108.1:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
+      browserslist: 4.28.4
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.1
+      es-module-lexer: 2.1.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      minimizer-webpack-plugin: 5.6.1(webpack@5.108.1)
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      watchpack: 2.5.2
+      webpack-sources: 3.5.0
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js


### PR DESCRIPTION
## Summary

Adds a CI-oriented Cross-Bundler Benchmark for Unpack against webpack, Rspack, Rolldown, and Turbopack.

The benchmark runner:
- generates deterministic small/medium/large Benchmark Fixtures
- records cold and warm build measurements
- verifies generated Bundle runtime checksum separately from build timing
- emits raw JSON and a Markdown summary table
- treats unsupported or failed bundlers as explicit result statuses

The PR also adds a non-blocking GitHub Actions workflow that publishes benchmark output as a job summary, uploads the JSON report as an artifact, and creates or updates a PR comment with the same benchmark summary.

Closes #21.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm test`
- `git diff --check`
- `pnpm --filter @unpack-js/benchmarks bench -- --fixtures small --bundlers unpack,webpack,rspack,rolldown --workspace .benchmark-work/pr-smoke --output-json .benchmark-work/pr-smoke/results.json`

## Notes

The new `cross-bundler-benchmark.yml` workflow is intentionally non-blocking. The PR comment is updated in place using a marker so repeated pushes do not create duplicate benchmark comments.
