### PR TITLE
Add CI cross-bundler benchmark

### DIFF
--- a/.github/workflows/cross-bundler-benchmark.yml
+++ b/.github/workflows/cross-bundler-benchmark.yml
@@ -14,6 +14,8 @@ jobs:
     continue-on-error: true
     permissions:
       contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v5
 
@@ -70,6 +72,47 @@ jobs:
               echo
               echo "The benchmark did not produce a summary. Check the workflow logs for setup or runner failures."
             } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Comment benchmark summary on PR
+        if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          marker="<!-- unpack-cross-bundler-benchmark -->"
+          comment_file=".benchmark-work/ci/pr-comment.md"
+          mkdir -p "$(dirname "$comment_file")"
+
+          {
+            echo "$marker"
+            echo "## Cross-Bundler Benchmark"
+            echo
+            if [ -f .benchmark-work/ci/summary.md ]; then
+              cat .benchmark-work/ci/summary.md
+            else
+              echo "The benchmark did not produce a summary. Check the workflow logs for setup or runner failures."
+            fi
+            echo
+            echo "[Workflow run]($RUN_URL)"
+            echo
+            echo "Raw JSON results are uploaded as the \`cross-bundler-benchmark-results\` workflow artifact."
+          } > "$comment_file"
+
+          comment_id="$(
+            gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --paginate \
+              --jq ".[] | select(.user.type == \"Bot\" and (.body | contains(\"$marker\"))) | .id" \
+              | head -n 1
+          )"
+
+          if [ -n "$comment_id" ]; then
+            gh api --method PATCH "repos/${{ github.repository }}/issues/comments/$comment_id" \
+              -f body="$(cat "$comment_file")"
+          else
+            gh api --method POST "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+              -f body="$(cat "$comment_file")"
           fi
 
       - name: Upload benchmark results

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -45,6 +45,6 @@ Runtime verification is separate from build timing. A Bundle that builds but doe
 
 ## CI
 
-The `Cross-Bundler Benchmarks` workflow runs on pull requests and manual dispatch. It writes the table to the GitHub Actions job summary and uploads the JSON report as an artifact.
+The `Cross-Bundler Benchmarks` workflow runs on pull requests and manual dispatch. It writes the table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, and uploads the JSON report as an artifact.
 
 The workflow is intentionally non-blocking. Benchmark setup failures, external toolchain failures, or runtime verification failures should be visible in the workflow output without blocking unrelated code from merging.


### PR DESCRIPTION
## Summary

Adds a CI-oriented Cross-Bundler Benchmark for Unpack against webpack, Rspack, Rolldown, and Turbopack.

The benchmark runner:
- generates deterministic small/medium/large Benchmark Fixtures
- records cold and warm build measurements
- verifies generated Bundle runtime checksum separately from build timing
- emits raw JSON and a Markdown summary table
- treats unsupported or failed bundlers as explicit result statuses

The PR also adds a non-blocking GitHub Actions workflow that publishes benchmark output as a job summary, uploads the JSON report as an artifact, and creates or updates a PR comment with the same benchmark summary.

Closes #21.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm test`
- `git diff --check`
- `pnpm --filter @unpack-js/benchmarks bench -- --fixtures small --bundlers unpack,webpack,rspack,rolldown --workspace .benchmark-work/pr-smoke --output-json .benchmark-work/pr-smoke/results.json`

## Notes

The new `cross-bundler-benchmark.yml` workflow is intentionally non-blocking. The PR comment is updated in place using a marker so repeated pushes do not create duplicate benchmark comments.
