### PR TITLE
Build Unpack benchmark addon in release mode

### DIFF
--- a/.github/workflows/cross-bundler-benchmark.yml
+++ b/.github/workflows/cross-bundler-benchmark.yml
@@ -40,6 +40,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build Unpack JavaScript API
+        env:
+          UNPACK_NATIVE_PROFILE: release
         run: pnpm --filter @unpack-js/core build
 
       - name: Checkout fixed Turbopack source

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -47,4 +47,6 @@ Runtime verification is separate from build timing. A Bundle that builds but doe
 
 The `Cross-Bundler Benchmarks` workflow runs on pull requests and manual dispatch. It writes the table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, and uploads the JSON report as an artifact.
 
+The workflow builds the Unpack native addon with `UNPACK_NATIVE_PROFILE=release` so benchmark results compare optimized native builds.
+
 The workflow is intentionally non-blocking. Benchmark setup failures, external toolchain failures, or runtime verification failures should be visible in the workflow output without blocking unrelated code from merging.


### PR DESCRIPTION
## Summary

- Build the Unpack JavaScript API with `UNPACK_NATIVE_PROFILE=release` in the cross-bundler benchmark workflow.
- Document that CI benchmark results compare optimized Unpack native builds.

## Why

`packages/unpack/scripts/build-native.mjs` defaults to a debug native addon unless `UNPACK_NATIVE_PROFILE=release` is set. The benchmark was therefore comparing a debug Unpack native build with optimized external bundlers such as Rspack, which distorted the large fixture results.

## Validation

- `git diff --check`
- `UNPACK_NATIVE_PROFILE=release pnpm --filter @unpack-js/core build`
- `pnpm --filter @unpack-js/benchmarks bench -- --fixtures small --bundlers unpack,rspack --workspace .benchmark-work/release-pr-smoke --output-json .benchmark-work/release-pr-smoke/results.json --summary-md .benchmark-work/release-pr-smoke/summary.md`