### PR TITLE
Reuse factorized modules within make

### DIFF
--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -174,6 +174,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn repeated_requests_reuse_factorized_modules_within_one_compilation()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let mut entry_source = String::new();
+        for module in 0..70 {
+            entry_source.push_str(&format!("import \"./warmup{module}\";\n"));
+            write(
+                temp.path().join(format!("warmup{module}.js")),
+                "globalThis.warmup = true;",
+            )?;
+        }
+        entry_source.push_str(
+            r#"
+            import { a } from "./dep";
+            import { b } from "./dep";
+            export const result = a + b;
+            "#,
+        );
+        write(temp.path().join("index.js"), &entry_source)?;
+        write(
+            temp.path().join("dep.js"),
+            r#"
+                export const a = 1;
+                export const b = 2;
+            "#,
+        )?;
+
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache = CacheOptions::filesystem();
+        options.cache.cache_location = Some(temp.path().join(".cache/unpack/default"));
+        options.parallelism = 1;
+        let compiler = Compiler::new(options);
+
+        let first = compiler.run().await?;
+        let first_cache = compiler.build_cache.stats();
+        assert_eq!(first.errors(), []);
+        assert_eq!(first_cache.resolve_entries, 72);
+        assert_eq!(first_cache.resolve_hits, 0);
+        assert_eq!(first_cache.resolve_misses, 72);
+
+        let second = compiler.run().await?;
+        let second_cache = compiler.build_cache.stats();
+        assert_eq!(second.errors(), []);
+        assert_eq!(second_cache.resolve_entries, 72);
+        assert_eq!(second_cache.resolve_hits, 72);
+        assert_eq!(second_cache.resolve_misses, 72);
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn hash_module_snapshot_strategy_invalidates_changed_source()
     -> std::result::Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -8,12 +8,14 @@ use futures::{FutureExt, StreamExt, future::BoxFuture, stream::FuturesUnordered}
 use tokio::sync::{Mutex, Semaphore};
 
 use crate::{
-    CompilerOptions, Dependency, DependencyKind, Error, ModuleGraph, ModuleId, ModuleIdentity,
-    NormalModuleFactory, Result, SnapshotStrategy, UnpackResolver,
+    CacheKind, CompilerOptions, Dependency, DependencyKind, Error, FactorizedModule, ModuleGraph,
+    ModuleId, ModuleIdentity, NormalModuleFactory, Result, SnapshotStrategy, UnpackResolver,
     build_cache::{BuildCache, ModuleBuildCache, ModuleBuildRecord},
     parser::{ParsedModule, parse_module_dependencies},
     snapshot::FileSnapshot,
 };
+
+const FACTORIZE_MEMO_MIN_MODULES: usize = 64;
 
 #[derive(Debug, Default)]
 pub(crate) struct MakeState {
@@ -24,6 +26,7 @@ pub(crate) struct MakeState {
     pub context_dependencies: BTreeSet<PathBuf>,
     pub missing_dependencies: BTreeSet<PathBuf>,
     modules_by_identity: HashMap<ModuleIdentity, ModuleId>,
+    factorized_modules: HashMap<FactorizeKey, FactorizedModule>,
 }
 
 #[derive(Debug, Clone)]
@@ -31,6 +34,7 @@ struct MakeServices {
     factory: NormalModuleFactory,
     module_build_cache: ModuleBuildCache,
     module_snapshot_strategy: SnapshotStrategy,
+    factorization_memo_enabled: bool,
     semaphore: Arc<Semaphore>,
 }
 
@@ -49,6 +53,24 @@ struct AddModuleResult {
     is_new: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct FactorizeKey {
+    context: PathBuf,
+    request: String,
+}
+
+impl FactorizeKey {
+    fn new(context: &Path, dependency: &Dependency) -> Self {
+        Self {
+            context: context.to_path_buf(),
+            request: dependency
+                .request()
+                .expect("make requests should be module dependencies")
+                .to_string(),
+        }
+    }
+}
+
 pub(crate) async fn run(
     options: &CompilerOptions,
     resolver: UnpackResolver,
@@ -63,6 +85,7 @@ pub(crate) async fn run(
         ),
         module_build_cache: build_cache.module_builds(),
         module_snapshot_strategy: options.snapshot.module,
+        factorization_memo_enabled: options.cache.kind == CacheKind::Filesystem,
         semaphore: Arc::new(Semaphore::new(options.parallelism.max(1))),
     };
 
@@ -121,28 +144,68 @@ async fn process_request(
     services: MakeServices,
     state: Arc<Mutex<MakeState>>,
 ) -> Result<Vec<MakeRequest>> {
-    let factorized = match services
-        .factory
-        .factorize(&request.context, &request.dependency)
-        .await
-    {
-        Ok(factorized) => factorized,
-        Err(error) if error.is_compilation_error() => {
-            let identity = failed_module_identity(&request.context, &request.dependency);
-            let mut state = state.lock().await;
-            state.missing_dependencies.insert(identity.resource.clone());
-            let add_result = state.add_or_connect(
-                request.origin_module,
-                request.entry_index,
-                request.origin_block,
-                request.dependency,
-                identity,
-            );
-            state.fail_module(add_result.module_id, error, String::new())?;
-            return Ok(Vec::new());
+    let (factorize_key, memoized_factorized) = if services.factorization_memo_enabled {
+        let state_guard = state.lock().await;
+        if state_guard.factorization_memo_enabled() {
+            let key = FactorizeKey::new(&request.context, &request.dependency);
+            if let Some(factorized) = state_guard.factorized_modules.get(&key).cloned() {
+                (None, Some(factorized))
+            } else {
+                (Some(key), None)
+            }
+        } else {
+            (None, None)
         }
-        Err(error) => return Err(error),
+    } else {
+        (None, None)
     };
+    if let Some(factorized) = memoized_factorized {
+        return connect_factorized_module(request, services, state, factorized).await;
+    }
+
+    let factorized = {
+        match services
+            .factory
+            .factorize(&request.context, &request.dependency)
+            .await
+        {
+            Ok(factorized) => {
+                if let Some(factorize_key) = factorize_key {
+                    state
+                        .lock()
+                        .await
+                        .factorized_modules
+                        .insert(factorize_key, factorized.clone());
+                }
+                factorized
+            }
+            Err(error) if error.is_compilation_error() => {
+                let identity = failed_module_identity(&request.context, &request.dependency);
+                let mut state = state.lock().await;
+                state.missing_dependencies.insert(identity.resource.clone());
+                let add_result = state.add_or_connect(
+                    request.origin_module,
+                    request.entry_index,
+                    request.origin_block,
+                    request.dependency,
+                    identity,
+                );
+                state.fail_module(add_result.module_id, error, String::new())?;
+                return Ok(Vec::new());
+            }
+            Err(error) => return Err(error),
+        }
+    };
+
+    connect_factorized_module(request, services, state, factorized).await
+}
+
+async fn connect_factorized_module(
+    request: MakeRequest,
+    services: MakeServices,
+    state: Arc<Mutex<MakeState>>,
+    factorized: FactorizedModule,
+) -> Result<Vec<MakeRequest>> {
     let identity = factorized.identity;
     let resource = factorized.resource;
 
@@ -288,6 +351,11 @@ fn normalize_missing_resource(path: PathBuf) -> PathBuf {
 }
 
 impl MakeState {
+    fn factorization_memo_enabled(&self) -> bool {
+        !self.factorized_modules.is_empty()
+            || self.module_graph.modules().len() >= FACTORIZE_MEMO_MIN_MODULES
+    }
+
     fn add_or_connect(
         &mut self,
         origin_module: Option<ModuleId>,


### PR DESCRIPTION
## Summary

- Cache factorized module results within a single make phase for filesystem-cache builds once the graph is large enough.
- Avoid repeatedly validating the same resolve cache record for duplicate ESM import/export dependencies in one large compilation.
- Add a regression test that confirms duplicate requests in a filesystem-cache make phase do not touch the build-cache resolve store repeatedly.

## Why

The large cross-bundler fixture still showed Unpack far behind Rspack after switching CI to a release native build. Profiling pointed at resolve snapshot validation: disabling resolve snapshot validation locally dropped large warm builds from roughly 343ms to roughly 117ms. The large fixture creates many repeated requests to the same modules; Unpack was validating the same resolve records repeatedly within a single compilation before discovering the module identity had already been added.

The memo is intentionally limited to filesystem-cache builds and larger graphs. An earlier unconditional version improved medium/large but made the small memory-cache CodSpeed benchmark regress, so this version keeps the small/default-memory path on the original straight path.

This keeps persistent cache semantics intact: the first request for a `(context, request)` still goes through the normal factorization and validation path, then later requests in the same make phase reuse that factorized result.

## Validation

- `git diff --check`
- `cargo test -p unpack_core`
- `UNPACK_NATIVE_PROFILE=release pnpm --filter @unpack-js/core build`
- `pnpm --filter @unpack-js/benchmarks bench -- --fixtures large --bundlers unpack,rspack --workspace .benchmark-work/factorize-cache-filesystem-final --output-json .benchmark-work/factorize-cache-filesystem-final/results.json --summary-md .benchmark-work/factorize-cache-filesystem-final/summary.md`

Large local benchmark after this change:

| fixture | bundler | cold_build_ms | warm_build_ms | output_bytes | status |
| --- | --- | ---: | ---: | ---: | --- |
| large | unpack | 459.250 | 200.165 | 2040641 | success |
| large | rspack | 245.886 | 47.221 | 1069810 | success |

This narrows the warm-build gap but does not close it; remaining differences are still expected from Unpack’s graph/codegen/output behavior.