### PR TITLE
Fix Turbopack warm benchmark cache flush

### DIFF
--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -29,6 +29,11 @@ pnpm --filter @unpack-js/benchmarks bench -- \
   --turbopack-commit a88f25caf0070b582a8ed83b1ae9e7135d7fd3bc
 ```
 
+During `prepare`, the Turbopack adapter applies a benchmark-local patch to the
+fixed checkout so `turbopack-cli build` explicitly stops TurboTasks before
+process exit. Turbopack build sessions use shutdown-time persistent cache
+storage, so this flushes the cold build cache for the warm measurement.
+
 ## Result Shape
 
 The runner emits a Markdown summary and can write the raw JSON report with `--output-json`.

--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -1,4 +1,5 @@
 import { execFile as execFileCallback } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
@@ -127,7 +128,7 @@ export const adapters = {
     name: "turbopack",
     outputDir: ({ fixture }) => join(fixture.context, "dist"),
     versionSource: ({ options }) =>
-      `vercel/next.js@${options.turbopackCommit ?? DEFAULT_TURBOPACK_COMMIT}`,
+      `vercel/next.js@${options.turbopackCommit ?? DEFAULT_TURBOPACK_COMMIT}+benchmark-cache-flush`,
     async prepare({ options }) {
       const repo = options.turbopackRepo;
       if (!repo) {
@@ -139,6 +140,8 @@ export const adapters = {
       if (preparedTurbopackBuilds.has(prepareKey)) {
         return;
       }
+
+      await applyTurbopackBuildCacheFlushPatch(repo);
 
       const args = ["build", "--package", "turbopack-cli", "--bin", "turbopack-cli"];
       if (profile === "release") {
@@ -198,6 +201,43 @@ export const adapters = {
     }
   }
 };
+
+export async function applyTurbopackBuildCacheFlushPatch(repo) {
+  const buildSourcePath = join(
+    repo,
+    "turbopack",
+    "crates",
+    "turbopack-cli",
+    "src",
+    "build",
+    "mod.rs"
+  );
+  const source = await readFile(buildSourcePath, "utf8");
+
+  if (source.includes("tt.stop_and_wait().await;")) {
+    return;
+  }
+
+  const target = `    builder.build().await?;
+
+    // Intentionally leak this \`Arc\`. Otherwise we'll waste time during process exit performing a
+`;
+  const replacement = `    builder.build().await?;
+
+    if args.common.persistent_caching {
+        // Benchmark patch: flush ReadWriteOnShutdown storage before process exit.
+        tt.stop_and_wait().await;
+    }
+
+    // Intentionally leak this \`Arc\`. Otherwise we'll waste time during process exit performing a
+`;
+
+  if (!source.includes(target)) {
+    throw new Error("unable to patch Turbopack build cache shutdown path");
+  }
+
+  await writeFile(buildSourcePath, source.replace(target, replacement), "utf8");
+}
 
 function webpackLikeConfig({ fixture, outputDir }) {
   return {

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
 
+import { adapters, applyTurbopackBuildCacheFlushPatch } from "../src/adapters.mjs";
 import { runBenchmark, toSummaryMarkdown } from "../src/runner.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -114,6 +115,95 @@ test("CLI accepts pnpm-style -- separator and writes JSON output", async () => {
     const report = JSON.parse(await readFile(outputJson, "utf8"));
     assert.equal(report.results[0].bundler, "turbopack");
     assert.equal(report.results[0].status, "unsupported");
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("turbopack build enables persistent cache for warm measurements", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
+
+  try {
+    const repo = join(workspace, "next.js");
+    const binary = join(repo, "target", "release", "turbopack-cli");
+    const argsLog = join(repo, "turbopack-args.txt");
+    const fixtureContext = join(workspace, "fixture");
+    const cacheDir = join(workspace, "cache");
+
+    await mkdir(join(repo, "target", "release"), { recursive: true });
+    await mkdir(fixtureContext, { recursive: true });
+    await writeFile(
+      binary,
+      `#!/bin/sh\nprintf '%s\\n' "$@" > "${argsLog}"\n`,
+      "utf8"
+    );
+    await chmod(binary, 0o755);
+
+    await adapters.turbopack.build({
+      fixture: {
+        context: fixtureContext,
+        entry: "./src/index.js"
+      },
+      cacheDir,
+      options: {
+        turbopackRepo: repo,
+        turbopackProfile: "release"
+      }
+    });
+
+    const args = (await readFile(argsLog, "utf8")).trim().split("\n");
+    assert.ok(args.includes("--persistent-caching"));
+    assert.equal(args[args.indexOf("--cache-dir") + 1], cacheDir);
+    assert.equal(args.at(-1), "./src/index.js");
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("turbopack prepare patches build shutdown to flush persistent cache", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
+
+  try {
+    const repo = join(workspace, "next.js");
+    const buildSourcePath = join(
+      repo,
+      "turbopack",
+      "crates",
+      "turbopack-cli",
+      "src",
+      "build",
+      "mod.rs"
+    );
+
+    await mkdir(join(repo, "turbopack", "crates", "turbopack-cli", "src", "build"), {
+      recursive: true
+    });
+    await writeFile(
+      buildSourcePath,
+      `async fn build() {
+    builder.build().await?;
+
+    // Intentionally leak this \`Arc\`. Otherwise we'll waste time during process exit performing a
+    // ton of drop calls.
+    if !args.force_memory_cleanup {
+        forget(tt);
+    }
+}
+`,
+      "utf8"
+    );
+
+    await applyTurbopackBuildCacheFlushPatch(repo);
+    const patched = await readFile(buildSourcePath, "utf8");
+    assert.match(patched, /if args\.common\.persistent_caching \{/);
+    assert.match(patched, /tt\.stop_and_wait\(\)\.await;/);
+    assert.ok(
+      patched.indexOf("tt.stop_and_wait().await;") >
+        patched.indexOf("builder.build().await?;")
+    );
+
+    await applyTurbopackBuildCacheFlushPatch(repo);
+    assert.equal(await readFile(buildSourcePath, "utf8"), patched);
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Fixes the Turbopack cross-bundler warm benchmark path so the cold build's persistent cache is flushed before the warm measurement.

Turbopack build sessions use shutdown-time persistent cache storage. The benchmark now applies a local patch to the fixed Next.js checkout before building `turbopack-cli`, inserting `tt.stop_and_wait().await` when persistent caching is enabled. The reported Turbopack source is marked with `+benchmark-cache-flush` so benchmark results are clear about the local patch.

## Root Cause

The benchmark preserved Turbopack's cache directory between cold and warm runs, but the fixed `turbopack-cli build` path did not explicitly stop TurboTasks before process exit. That meant shutdown-time cache persistence was not reliably triggered, so the warm build could behave like another fresh CLI build.

## Validation

- `pnpm --filter @unpack-js/benchmarks test`