### PR TITLE
Add no-cache build metric to bundler benchmark

### DIFF
--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -35,11 +35,12 @@ The runner emits a Markdown summary and can write the raw JSON report with `--ou
 
 Important fields:
 
-- `cold_build_ms`: build time after clearing benchmark-owned output and cache state.
-- `warm_build_ms`: build time for the second run in the same job while preserving benchmark-owned cache state.
+- `cold_build_ms`: build time after clearing benchmark-owned output and persistent cache state.
+- `warm_build_ms`: build time for the second run in the same job while preserving benchmark-owned persistent cache state.
+- `no_cache_build_ms`: build time for an additional clean build with persistent cache disabled. Bundlers without a persistent-cache option run this as a separate clean one-shot build.
 - `output_bytes`: bytes emitted under the benchmark output path, excluding runner metadata.
 - `version_source`: the npm package version or fixed source commit used for the bundler.
-- `status`: `success`, `unsupported`, `setup_failed`, `build_failed`, `runtime_failed`, or a warm-build variant.
+- `status`: `success`, `unsupported`, `setup_failed`, `build_failed`, `runtime_failed`, or a warm/no-cache build variant.
 
 Runtime verification is separate from build timing. A Bundle that builds but does not export the expected checksum is marked `runtime_failed` and should not be treated as a valid performance result.
 

--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -13,17 +13,19 @@ export const adapters = {
   unpack: {
     name: "unpack",
     versionSource: () => `@unpack-js/core@${packageVersion("@unpack-js/core")}`,
-    async build({ fixture, outputDir, cacheDir }) {
+    async build({ fixture, outputDir, cacheDir, persistentCache = true }) {
       const { default: unpack } = await import("@unpack-js/core");
       const compiler = unpack({
         context: fixture.context,
         entry: fixture.entry,
         output: { path: outputDir },
-        cache: {
-          type: "filesystem",
-          cacheLocation: cacheDir,
-          idleTimeout: 0
-        }
+        cache: persistentCache
+          ? {
+              type: "filesystem",
+              cacheLocation: cacheDir,
+              idleTimeout: 0
+            }
+          : false
       });
 
       try {
@@ -46,15 +48,17 @@ export const adapters = {
   webpack: {
     name: "webpack",
     versionSource: () => `webpack@${packageVersion("webpack")}`,
-    async build({ fixture, outputDir, cacheDir }) {
+    async build({ fixture, outputDir, cacheDir, persistentCache = true }) {
       const webpackModule = await import("webpack");
       const webpack = webpackModule.default ?? webpackModule;
       const compiler = webpack({
         ...webpackLikeConfig({ fixture, outputDir }),
-        cache: {
-          type: "filesystem",
-          cacheDirectory: cacheDir
-        }
+        cache: persistentCache
+          ? {
+              type: "filesystem",
+              cacheDirectory: cacheDir
+            }
+          : false
       });
 
       try {
@@ -71,18 +75,20 @@ export const adapters = {
   rspack: {
     name: "rspack",
     versionSource: () => `@rspack/core@${packageVersion("@rspack/core")}`,
-    async build({ fixture, outputDir, cacheDir }) {
+    async build({ fixture, outputDir, cacheDir, persistentCache = true }) {
       const rspackModule = await import("@rspack/core");
       const rspack = rspackModule.rspack ?? rspackModule.default;
       const compiler = rspack({
         ...webpackLikeConfig({ fixture, outputDir }),
-        cache: {
-          type: "persistent",
-          storage: {
-            type: "filesystem",
-            directory: cacheDir
-          }
-        }
+        cache: persistentCache
+          ? {
+              type: "persistent",
+              storage: {
+                type: "filesystem",
+                directory: cacheDir
+              }
+            }
+          : false
       });
 
       try {
@@ -154,7 +160,7 @@ export const adapters = {
       });
       preparedTurbopackBuilds.add(prepareKey);
     },
-    async build({ fixture, cacheDir, options }) {
+    async build({ fixture, cacheDir, persistentCache = true, options }) {
       const repo = options.turbopackRepo;
       if (!repo) {
         throw unsupported("Turbopack requires --turbopack-repo pointing at a fixed Next.js checkout");
@@ -167,25 +173,26 @@ export const adapters = {
         profile === "dev" ? "debug" : profile,
         "turbopack-cli"
       );
+      const args = [
+        "build",
+        "--dir",
+        fixture.context,
+        "--root",
+        fixture.context,
+        "--target",
+        "node",
+        "--no-minify",
+        "--no-sourcemap",
+        "--no-scope-hoist"
+      ];
+      if (persistentCache) {
+        args.push("--persistent-caching", "--cache-dir", cacheDir);
+      }
+      args.push(fixture.entry);
 
       await execFile(
         binary,
-        [
-          "build",
-          "--dir",
-          fixture.context,
-          "--root",
-          fixture.context,
-          "--target",
-          "node",
-          "--no-minify",
-          "--no-sourcemap",
-          "--no-scope-hoist",
-          "--persistent-caching",
-          "--cache-dir",
-          cacheDir,
-          fixture.entry
-        ],
+        args,
         {
           cwd: repo,
           env: { ...process.env, CI: process.env.CI ?? "1" },

--- a/packages/benchmarks/src/runner.mjs
+++ b/packages/benchmarks/src/runner.mjs
@@ -52,7 +52,7 @@ export async function runBenchmark(options = {}) {
   }
 
   return {
-    schema_version: 1,
+    schema_version: 2,
     generated_at: new Date().toISOString(),
     results
   };
@@ -60,8 +60,8 @@ export async function runBenchmark(options = {}) {
 
 export function toSummaryMarkdown(report) {
   const lines = [
-    "| fixture | bundler | version/source | cold_build_ms | warm_build_ms | output_bytes | status |",
-    "| --- | --- | --- | ---: | ---: | ---: | --- |"
+    "| fixture | bundler | version/source | cold_build_ms | warm_build_ms | no_cache_build_ms | output_bytes | status |",
+    "| --- | --- | --- | ---: | ---: | ---: | ---: | --- |"
   ];
 
   for (const result of report.results) {
@@ -72,6 +72,7 @@ export function toSummaryMarkdown(report) {
         result.version_source ?? "",
         formatNumber(result.cold_build_ms),
         formatNumber(result.warm_build_ms),
+        formatNumber(result.no_cache_build_ms),
         formatNumber(result.output_bytes, 0),
         result.status
       ].join(" | ").replace(/^/, "| ").replace(/$/, " |")
@@ -88,6 +89,11 @@ async function runBundlerBenchmark({ adapter, bundler, fixture, workspaceDir, op
     ? adapter.outputDir({ fixture, baseDir, options })
     : join(baseDir, "output");
   const cacheDir = join(baseDir, "cache");
+  const noCacheBaseDir = join(baseDir, "no-cache");
+  const noCacheOutputDir = adapter?.outputDir
+    ? adapter.outputDir({ fixture, baseDir: noCacheBaseDir, options })
+    : join(noCacheBaseDir, "output");
+  const noCacheCacheDir = join(noCacheBaseDir, "cache");
 
   if (!adapter) {
     return emptyResult({
@@ -117,6 +123,7 @@ async function runBundlerBenchmark({ adapter, bundler, fixture, workspaceDir, op
     fixture,
     outputDir,
     cacheDir,
+    persistentCache: true,
     options
   });
   if (cold.status !== "success") {
@@ -129,14 +136,37 @@ async function runBundlerBenchmark({ adapter, bundler, fixture, workspaceDir, op
     fixture,
     outputDir,
     cacheDir,
+    persistentCache: true,
     options
   });
 
-  return resultFromPhases({ fixture, bundler, versionSource, cold, warm });
+  if (warm.status !== "success") {
+    return resultFromPhases({ fixture, bundler, versionSource, cold, warm });
+  }
+
+  const noCache = await timedBuild({
+    adapter,
+    phase: "no-cache",
+    fixture,
+    outputDir: noCacheOutputDir,
+    cacheDir: noCacheCacheDir,
+    persistentCache: false,
+    options
+  });
+
+  return resultFromPhases({ fixture, bundler, versionSource, cold, warm, noCache });
 }
 
-async function timedBuild({ adapter, phase, fixture, outputDir, cacheDir, options }) {
-  if (phase === "cold") {
+async function timedBuild({
+  adapter,
+  phase,
+  fixture,
+  outputDir,
+  cacheDir,
+  persistentCache,
+  options
+}) {
+  if (phase === "cold" || phase === "no-cache") {
     await rm(outputDir, { recursive: true, force: true });
     await rm(cacheDir, { recursive: true, force: true });
   }
@@ -151,6 +181,7 @@ async function timedBuild({ adapter, phase, fixture, outputDir, cacheDir, option
       outputDir,
       cacheDir,
       phase,
+      persistentCache,
       options
     });
   } catch (error) {
@@ -221,15 +252,23 @@ async function verifyBundle({ entryFile, outputDir, expectedChecksum }) {
   }
 }
 
-function resultFromPhases({ fixture, bundler, versionSource, cold, warm }) {
+function resultFromPhases({ fixture, bundler, versionSource, cold, warm, noCache }) {
   const status =
     cold.status !== "success"
       ? cold.status
       : warm && warm.status !== "success"
         ? `warm_${warm.status}`
+        : noCache && noCache.status !== "success"
+          ? `no_cache_${noCache.status}`
         : "success";
   const message =
-    cold.status !== "success" ? cold.message : warm?.status !== "success" ? warm.message : null;
+    cold.status !== "success"
+      ? cold.message
+      : warm?.status !== "success"
+        ? warm.message
+        : noCache?.status !== "success"
+          ? noCache.message
+          : null;
 
   return {
     fixture: fixture.name,
@@ -237,13 +276,19 @@ function resultFromPhases({ fixture, bundler, versionSource, cold, warm }) {
     version_source: versionSource,
     cold_build_ms: cold.status === "success" ? cold.build_ms : null,
     warm_build_ms: warm?.status === "success" ? warm.build_ms : null,
-    output_bytes: warm?.output_bytes ?? cold.output_bytes,
+    no_cache_build_ms: noCache?.status === "success" ? noCache.build_ms : null,
+    output_bytes: warm?.output_bytes ?? noCache?.output_bytes ?? cold.output_bytes,
     cold_status: cold.status,
     warm_status: warm?.status ?? "not_run",
+    no_cache_status: noCache?.status ?? "not_run",
     verify_status:
-      cold.status === "runtime_failed" || warm?.status === "runtime_failed"
+      cold.status === "runtime_failed" ||
+      warm?.status === "runtime_failed" ||
+      noCache?.status === "runtime_failed"
         ? "runtime_failed"
-        : cold.status === "success" && (!warm || warm.status === "success")
+        : cold.status === "success" &&
+            (!warm || warm.status === "success") &&
+            (!noCache || noCache.status === "success")
           ? "success"
           : "not_run",
     status,
@@ -258,9 +303,11 @@ function emptyResult({ fixture, bundler, versionSource, status, message }) {
     version_source: versionSource,
     cold_build_ms: null,
     warm_build_ms: null,
+    no_cache_build_ms: null,
     output_bytes: null,
     cold_status: "not_run",
     warm_status: "not_run",
+    no_cache_status: "not_run",
     verify_status: "not_run",
     status,
     error: message

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -10,8 +10,9 @@ import { runBenchmark, toSummaryMarkdown } from "../src/runner.mjs";
 
 const execFileAsync = promisify(execFile);
 
-test("runner emits cold and warm measurements for a verified bundle", async () => {
+test("runner emits persistent-cache and no-cache measurements for a verified bundle", async () => {
   const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
+  const calls = [];
 
   try {
     const report = await runBenchmark({
@@ -19,22 +20,34 @@ test("runner emits cold and warm measurements for a verified bundle", async () =
       fixtures: ["small"],
       bundlers: ["fake"],
       adapters: {
-        fake: fakeAdapter()
+        fake: fakeAdapter({ calls })
       }
     });
 
-    assert.equal(report.schema_version, 1);
+    assert.equal(report.schema_version, 2);
     assert.equal(report.results.length, 1);
     assert.equal(report.results[0].fixture, "small");
     assert.equal(report.results[0].bundler, "fake");
     assert.equal(report.results[0].status, "success");
     assert.equal(report.results[0].cold_status, "success");
     assert.equal(report.results[0].warm_status, "success");
+    assert.equal(report.results[0].no_cache_status, "success");
     assert.equal(report.results[0].verify_status, "success");
     assert.equal(typeof report.results[0].cold_build_ms, "number");
     assert.equal(typeof report.results[0].warm_build_ms, "number");
+    assert.equal(typeof report.results[0].no_cache_build_ms, "number");
     assert.ok(report.results[0].output_bytes > 0);
-    assert.match(toSummaryMarkdown(report), /\\| small \\| fake \\| fake@1\\.0\\.0 \\|/);
+    assert.deepEqual(
+      calls.map(({ phase, persistentCache }) => ({ phase, persistentCache })),
+      [
+        { phase: "cold", persistentCache: true },
+        { phase: "warm", persistentCache: true },
+        { phase: "no-cache", persistentCache: false }
+      ]
+    );
+    const summary = toSummaryMarkdown(report);
+    assert.match(summary, /no_cache_build_ms/);
+    assert.match(summary, /\\| small \\| fake \\| fake@1\\.0\\.0 \\|/);
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }
@@ -56,7 +69,9 @@ test("runner marks a built bundle with the wrong checksum as runtime_failed", as
     assert.equal(report.results[0].status, "runtime_failed");
     assert.equal(report.results[0].cold_status, "runtime_failed");
     assert.equal(report.results[0].warm_status, "not_run");
+    assert.equal(report.results[0].no_cache_status, "not_run");
     assert.equal(report.results[0].warm_build_ms, null);
+    assert.equal(report.results[0].no_cache_build_ms, null);
     assert.match(report.results[0].error, /expected bundle checksum/);
   } finally {
     await rm(workspace, { recursive: true, force: true });
@@ -81,6 +96,7 @@ test("runner reports unsupported adapters explicitly", async () => {
     assert.equal(report.results[0].status, "unsupported");
     assert.equal(report.results[0].cold_build_ms, null);
     assert.equal(report.results[0].warm_build_ms, null);
+    assert.equal(report.results[0].no_cache_build_ms, null);
     assert.match(report.results[0].error, /not available/);
   } finally {
     await rm(workspace, { recursive: true, force: true });
@@ -119,11 +135,12 @@ test("CLI accepts pnpm-style -- separator and writes JSON output", async () => {
   }
 });
 
-function fakeAdapter({ checksumOffset = 0, error } = {}) {
+function fakeAdapter({ checksumOffset = 0, error, calls } = {}) {
   return {
     name: "fake",
     versionSource: () => "fake@1.0.0",
-    async build({ fixture, outputDir }) {
+    async build({ fixture, outputDir, phase, persistentCache }) {
+      calls?.push({ phase, persistentCache });
       if (error) {
         throw error;
       }


### PR DESCRIPTION
## Summary

- Add a third cross-bundler build measurement, `no_cache_build_ms`, alongside existing cold and warm persistent-cache timings.
- Disable persistent cache for the extra build in Unpack, webpack, Rspack, and Turbopack adapters; Rolldown continues to run as a clean one-shot build because it has no persistent-cache option in this benchmark.
- Bump the benchmark report schema to version 2 and document the new field.

## Validation

- `pnpm --filter @unpack-js/benchmarks test`
- `git diff --check`
- `UNPACK_NATIVE_PROFILE=release pnpm --filter @unpack-js/core build`
- `pnpm --filter @unpack-js/benchmarks bench -- --fixtures small --bundlers unpack,webpack,rspack,rolldown --workspace .benchmark-work/no-cache-smoke --output-json .benchmark-work/no-cache-smoke/results.json --summary-md .benchmark-work/no-cache-smoke/summary.md`
