### PR TITLE
Reduce no-cache factorization overhead

### DIFF
--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -336,8 +336,12 @@ where
     K: Eq + Hash,
     V: Clone,
 {
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.build_cache.options.kind != CacheKind::Disabled
+    }
+
     pub(crate) fn get(&self, key: &K) -> Option<V> {
-        if self.build_cache.options.kind == CacheKind::Disabled {
+        if !self.is_enabled() {
             return None;
         }
 
@@ -350,7 +354,7 @@ where
     }
 
     pub(crate) fn store(&self, key: K, value: V) {
-        if self.build_cache.options.kind == CacheKind::Disabled {
+        if !self.is_enabled() {
             return;
         }
 

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -387,6 +387,15 @@ impl BuildTask {
         };
         let process_dependencies =
             process_dependencies_task(self.module_id, &issuer_context, &parsed);
+
+        if !services.module_build_cache.is_enabled() {
+            state
+                .lock()
+                .await
+                .finish_build(self.module_id, parsed, source)?;
+            return Ok(process_dependencies.into_iter().collect());
+        }
+
         let snapshot =
             FileSnapshot::create(&self.resource, &source, services.module_snapshot_strategy)
                 .await?;

--- a/crates/unpack_core/src/normal_module_factory.rs
+++ b/crates/unpack_core/src/normal_module_factory.rs
@@ -1,7 +1,9 @@
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, HashMap},
     path::{Path, PathBuf},
+    sync::{Arc, Mutex},
 };
+use tokio::sync::OnceCell;
 
 use crate::{
     Dependency, ModuleIdentity, Result, SnapshotStrategy, UnpackResolver,
@@ -13,7 +15,13 @@ pub struct NormalModuleFactory {
     resolver: UnpackResolver,
     cache: NormalModuleFactoryCache,
     resolve_snapshot_strategy: SnapshotStrategy,
+    runtime_factorize_cache: RuntimeFactorizeCache,
 }
+
+// Per-compilation singleflight cache; separate from BuildCache so cache:false
+// still coalesces duplicate factory work within one make run.
+type RuntimeFactorizeCache =
+    Arc<Mutex<HashMap<ResolveRequest, Arc<OnceCell<Result<FactorizedModule>>>>>>;
 
 impl NormalModuleFactory {
     pub(crate) fn new(
@@ -25,6 +33,7 @@ impl NormalModuleFactory {
             resolver,
             cache,
             resolve_snapshot_strategy,
+            runtime_factorize_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -43,12 +52,55 @@ impl NormalModuleFactory {
             }
         }
 
+        self.factorize_with_runtime_cache(context, request, resolve_request)
+            .await
+    }
+
+    async fn factorize_with_runtime_cache(
+        &self,
+        context: &Path,
+        request: &str,
+        resolve_request: ResolveRequest,
+    ) -> Result<FactorizedModule> {
+        let cell = {
+            let mut cache = self
+                .runtime_factorize_cache
+                .lock()
+                .expect("runtime factorize cache mutex should not be poisoned");
+            cache
+                .entry(resolve_request.clone())
+                .or_insert_with(|| Arc::new(OnceCell::new()))
+                .clone()
+        };
+
+        cell.get_or_init(|| async {
+            self.factorize_uncached(context, request, resolve_request)
+                .await
+        })
+        .await
+        .clone()
+    }
+
+    async fn factorize_uncached(
+        &self,
+        context: &Path,
+        request: &str,
+        resolve_request: ResolveRequest,
+    ) -> Result<FactorizedModule> {
         let resolved = self
             .resolver
             .resolve_with_dependencies(context, request)
             .await?;
         let identity = ModuleIdentity::from(resolved.resource);
         let resource = identity.resource.clone();
+        if !self.cache.is_enabled() {
+            return Ok(FactorizedModule {
+                identity,
+                resource,
+                file_dependencies: resolved.file_dependencies,
+                missing_dependencies: resolved.missing_dependencies,
+            });
+        }
         let record = ResolveRecord::new(
             identity,
             resource,
@@ -79,5 +131,51 @@ impl FactorizedModule {
             file_dependencies: record.file_dependencies().clone(),
             missing_dependencies: record.missing_dependencies().clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::{
+        CacheOptions, Dependency, DependencyKind, UnpackResolver, build_cache::BuildCache,
+        resolver::ResolveOptions,
+    };
+
+    #[tokio::test]
+    async fn runtime_factorize_cache_reuses_results_when_build_cache_is_disabled()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempdir()?;
+        fs::write(temp.path().join("dep.js"), "export const value = 1;")?;
+
+        let mut resolve_options = ResolveOptions::default();
+        resolve_options.extensions = vec![".js".to_string()];
+        let build_cache = BuildCache::new(CacheOptions::disabled(), SnapshotStrategy::timestamp());
+        let factory = NormalModuleFactory::new(
+            UnpackResolver::new(resolve_options),
+            build_cache.normal_module_factory(),
+            SnapshotStrategy::timestamp(),
+        );
+        let dependency = Dependency::new(DependencyKind::StaticImport, "./dep");
+
+        let first = factory.factorize(temp.path(), &dependency).await?;
+        let second = factory.factorize(temp.path(), &dependency).await?;
+
+        assert_eq!(first, second);
+        assert_eq!(build_cache.stats().resolve_entries, 0);
+        assert_eq!(
+            factory
+                .runtime_factorize_cache
+                .lock()
+                .expect("runtime factorize cache mutex should not be poisoned")
+                .len(),
+            1
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- add a per-compilation NormalModuleFactory singleflight cache so duplicate factorize work is coalesced even when build cache is disabled
- skip resolve/module snapshot record construction on cache:false paths, since the disabled BuildCache will discard those records
- expose CacheFacade::is_enabled for call sites that need to avoid disabled-cache work

## Performance
Release cross-bundler benchmark:

```
pnpm --filter @unpack-js/benchmarks bench -- --fixtures medium,large --bundlers unpack,rspack --workspace .benchmark-work/perf-final-release --output-json .benchmark-work/perf-final-release/report.json
```

| fixture | bundler | no_cache_build_ms | output_bytes |
| --- | --- | ---: | ---: |
| medium | unpack | 40.484 | 382729 |
| medium | rspack | 13.017 | 202124 |
| large | unpack | 224.703 | 2040642 |
| large | rspack | 92.490 | 1069810 |

A one-command large-fixture red check dropped below 3x: unpack 235.543ms vs rspack 90.231ms, ratio 2.61x.

## Validation
- cargo fmt --check
- cargo test --workspace
- pnpm --filter @unpack-js/core test
- pnpm --filter @unpack-js/benchmarks test
- git diff --check