### PR TITLE
Introduce File System Info snapshot validation

### DIFF
--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -10,13 +10,13 @@ use std::{
 use crate::{
     ModuleIdentity, SnapshotStrategy,
     parser::ParsedModule,
-    snapshot::{FileSetSnapshot, FileSnapshot},
+    snapshot::{FileSystemInfo, Snapshot},
 };
 use serde::{Deserialize, Serialize};
 
 const CACHE_MAGIC: &str = "UNPACK_PERSISTENT_CACHE";
 const PACK_MAGIC: &[u8] = b"UNPACK-CACHE-PACK\0";
-const CACHE_SCHEMA_VERSION: u32 = 2;
+const CACHE_SCHEMA_VERSION: u32 = 3;
 const DEFAULT_PACK_FILE: &str = "packs/modules.cbor";
 const MANIFEST_FILE: &str = "container.json";
 
@@ -24,6 +24,7 @@ const MANIFEST_FILE: &str = "container.json";
 pub(crate) struct BuildCache {
     options: CacheOptions,
     build_dependency_snapshot_strategy: SnapshotStrategy,
+    file_system_info: FileSystemInfo,
     inner: Arc<Mutex<BuildCacheInner>>,
 }
 
@@ -180,7 +181,7 @@ pub(crate) struct ResolveRecord {
     resource: PathBuf,
     file_dependencies: BTreeSet<PathBuf>,
     missing_dependencies: BTreeSet<PathBuf>,
-    snapshot: FileSetSnapshot,
+    snapshot: Snapshot,
 }
 
 impl ResolveRecord {
@@ -189,16 +190,18 @@ impl ResolveRecord {
         resource: PathBuf,
         file_dependencies: BTreeSet<PathBuf>,
         missing_dependencies: BTreeSet<PathBuf>,
+        file_system_info: &FileSystemInfo,
         strategy: SnapshotStrategy,
     ) -> crate::Result<Self> {
-        let snapshot = FileSetSnapshot::create(
-            file_dependencies
-                .iter()
-                .chain(missing_dependencies.iter())
-                .cloned(),
-            strategy,
-        )
-        .await?;
+        let snapshot = file_system_info
+            .create_snapshot(
+                file_dependencies
+                    .iter()
+                    .chain(missing_dependencies.iter())
+                    .cloned(),
+                strategy,
+            )
+            .await?;
         Ok(Self {
             identity,
             resource,
@@ -224,8 +227,14 @@ impl ResolveRecord {
         &self.missing_dependencies
     }
 
-    pub(crate) async fn is_valid(&self, strategy: SnapshotStrategy) -> bool {
-        self.snapshot.is_valid(strategy).await
+    pub(crate) async fn is_valid(
+        &self,
+        file_system_info: &FileSystemInfo,
+        strategy: SnapshotStrategy,
+    ) -> bool {
+        file_system_info
+            .is_snapshot_valid(&self.snapshot, strategy)
+            .await
     }
 }
 
@@ -233,11 +242,11 @@ impl ResolveRecord {
 pub(crate) struct ModuleBuildRecord {
     parsed: ParsedModule,
     source: String,
-    snapshot: FileSnapshot,
+    snapshot: Snapshot,
 }
 
 impl ModuleBuildRecord {
-    pub(crate) fn new(parsed: ParsedModule, source: String, snapshot: FileSnapshot) -> Self {
+    pub(crate) fn new(parsed: ParsedModule, source: String, snapshot: Snapshot) -> Self {
         Self {
             parsed,
             source,
@@ -253,8 +262,14 @@ impl ModuleBuildRecord {
         (self.parsed, self.source)
     }
 
-    pub(crate) async fn is_valid(&self, path: &Path, strategy: SnapshotStrategy) -> bool {
-        self.snapshot.is_valid(path, strategy).await
+    pub(crate) async fn is_valid(
+        &self,
+        file_system_info: &FileSystemInfo,
+        strategy: SnapshotStrategy,
+    ) -> bool {
+        file_system_info
+            .is_snapshot_valid(&self.snapshot, strategy)
+            .await
     }
 }
 
@@ -266,6 +281,7 @@ impl BuildCache {
         let cache = Self {
             options,
             build_dependency_snapshot_strategy,
+            file_system_info: FileSystemInfo::new(),
             inner: Arc::new(Mutex::new(BuildCacheInner::default())),
         };
         cache.restore_from_filesystem();
@@ -470,22 +486,14 @@ impl BuildCache {
             .map(|dependency| {
                 Ok(PersistentBuildDependencySnapshot {
                     name: dependency.name.clone(),
-                    files: dependency
-                        .files
-                        .iter()
-                        .map(|path| {
-                            Ok(PersistentFileSnapshot {
-                                path: path.clone(),
-                                snapshot: FileSnapshot::create_from_file_sync(
-                                    path,
-                                    self.build_dependency_snapshot_strategy,
-                                )
-                                .map_err(|error| {
-                                    io::Error::new(io::ErrorKind::InvalidData, error)
-                                })?,
-                            })
-                        })
-                        .collect::<io::Result<Vec<_>>>()?,
+                    files: dependency.files.clone(),
+                    snapshot: self
+                        .file_system_info
+                        .create_snapshot_sync(
+                            dependency.files.clone(),
+                            self.build_dependency_snapshot_strategy,
+                        )
+                        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?,
                 })
             })
             .collect()
@@ -510,14 +518,14 @@ impl BuildCache {
                 return false;
             }
 
-            dependency.files.iter().all(|path| {
-                snapshot.files.iter().any(|snapshot_file| {
-                    snapshot_file.path == *path
-                        && snapshot_file
-                            .snapshot
-                            .is_valid_sync(path, self.build_dependency_snapshot_strategy)
-                })
-            })
+            dependency
+                .files
+                .iter()
+                .all(|path| snapshot.files.contains(path))
+                && self.file_system_info.is_snapshot_valid_sync(
+                    &snapshot.snapshot,
+                    self.build_dependency_snapshot_strategy,
+                )
         })
     }
 }
@@ -545,13 +553,8 @@ struct CacheManifest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct PersistentBuildDependencySnapshot {
     name: String,
-    files: Vec<PersistentFileSnapshot>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct PersistentFileSnapshot {
-    path: PathBuf,
-    snapshot: FileSnapshot,
+    files: Vec<PathBuf>,
+    snapshot: Snapshot,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -8,6 +8,7 @@ use crate::{
     build_cache::BuildCache,
     code_generation,
     make::{self, MakeState},
+    snapshot::FileSystemInfo,
 };
 use tracing::Instrument;
 
@@ -23,6 +24,7 @@ pub struct Compilation {
     errors: Vec<Error>,
     watch_dependencies: WatchDependencies,
     infrastructure_log_events: Vec<InfrastructureLogEvent>,
+    file_system_info: FileSystemInfo,
 }
 
 impl Compilation {
@@ -42,6 +44,7 @@ impl Compilation {
             errors: Vec::new(),
             watch_dependencies: WatchDependencies::default(),
             infrastructure_log_events: Vec::new(),
+            file_system_info: FileSystemInfo::new(),
         }
     }
 
@@ -89,6 +92,7 @@ impl Compilation {
                 &self.options,
                 self.resolver.clone(),
                 self.build_cache.clone(),
+                self.file_system_info.clone(),
                 Arc::clone(&state),
             )
             .await;

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -15,7 +15,7 @@ use crate::{
     ModuleIdentity, NormalModuleFactory, Result, SnapshotStrategy, UnpackResolver,
     build_cache::{BuildCache, ModuleBuildCache, ModuleBuildRecord},
     parser::{ParsedModule, parse_module_dependencies},
-    snapshot::FileSnapshot,
+    snapshot::FileSystemInfo,
 };
 
 #[derive(Debug, Default)]
@@ -34,6 +34,7 @@ struct MakeServices {
     normal_module_factory: NormalModuleFactory,
     module_build_cache: ModuleBuildCache,
     module_snapshot_strategy: SnapshotStrategy,
+    file_system_info: FileSystemInfo,
     semaphore: Arc<Semaphore>,
 }
 
@@ -117,15 +118,18 @@ pub(crate) async fn run(
     options: &CompilerOptions,
     resolver: UnpackResolver,
     build_cache: BuildCache,
+    file_system_info: FileSystemInfo,
     state: Arc<Mutex<MakeState>>,
 ) -> Result<()> {
     let services = MakeServices {
         normal_module_factory: NormalModuleFactory::new(
             resolver,
             build_cache.normal_module_factory(),
+            file_system_info.clone(),
             options.snapshot.resolve,
         ),
         module_build_cache: build_cache.module_builds(),
+        file_system_info,
         module_snapshot_strategy: options.snapshot.module,
         semaphore: Arc::new(Semaphore::new(options.parallelism.max(1))),
     };
@@ -349,7 +353,10 @@ impl BuildTask {
 
         if let Some(record) = services.module_build_cache.get(&self.identity) {
             if record
-                .is_valid(&self.resource, services.module_snapshot_strategy)
+                .is_valid(
+                    &services.file_system_info,
+                    services.module_snapshot_strategy,
+                )
                 .await
             {
                 let process_dependencies =
@@ -396,9 +403,10 @@ impl BuildTask {
             return Ok(process_dependencies.into_iter().collect());
         }
 
-        let snapshot =
-            FileSnapshot::create(&self.resource, &source, services.module_snapshot_strategy)
-                .await?;
+        let snapshot = services
+            .file_system_info
+            .create_file_snapshot(&self.resource, &source, services.module_snapshot_strategy)
+            .await?;
         let record = ModuleBuildRecord::new(parsed.clone(), source.clone(), snapshot);
 
         state
@@ -642,7 +650,14 @@ mod tests {
             BuildCache::new(options.cache.clone(), options.snapshot.build_dependencies);
         let state = Arc::new(Mutex::new(MakeState::default()));
 
-        run(&options, resolver, build_cache.clone(), Arc::clone(&state)).await?;
+        run(
+            &options,
+            resolver,
+            build_cache.clone(),
+            FileSystemInfo::new(),
+            Arc::clone(&state),
+        )
+        .await?;
 
         let cache = build_cache.stats();
         let state = state.lock().await;

--- a/crates/unpack_core/src/normal_module_factory.rs
+++ b/crates/unpack_core/src/normal_module_factory.rs
@@ -8,12 +8,14 @@ use tokio::sync::OnceCell;
 use crate::{
     Dependency, ModuleIdentity, Result, SnapshotStrategy, UnpackResolver,
     build_cache::{NormalModuleFactoryCache, ResolveRecord, ResolveRequest},
+    snapshot::FileSystemInfo,
 };
 
 #[derive(Debug, Clone)]
 pub struct NormalModuleFactory {
     resolver: UnpackResolver,
     cache: NormalModuleFactoryCache,
+    file_system_info: FileSystemInfo,
     resolve_snapshot_strategy: SnapshotStrategy,
     runtime_factorize_cache: RuntimeFactorizeCache,
 }
@@ -27,11 +29,13 @@ impl NormalModuleFactory {
     pub(crate) fn new(
         resolver: UnpackResolver,
         cache: NormalModuleFactoryCache,
+        file_system_info: FileSystemInfo,
         resolve_snapshot_strategy: SnapshotStrategy,
     ) -> Self {
         Self {
             resolver,
             cache,
+            file_system_info,
             resolve_snapshot_strategy,
             runtime_factorize_cache: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -47,7 +51,10 @@ impl NormalModuleFactory {
             .expect("module dependency should have a request");
         let resolve_request = ResolveRequest::new(context, request);
         if let Some(record) = self.cache.get(&resolve_request) {
-            if record.is_valid(self.resolve_snapshot_strategy).await {
+            if record
+                .is_valid(&self.file_system_info, self.resolve_snapshot_strategy)
+                .await
+            {
                 return Ok(FactorizedModule::from_resolve_record(record));
             }
         }
@@ -106,6 +113,7 @@ impl NormalModuleFactory {
             resource,
             resolved.file_dependencies,
             resolved.missing_dependencies,
+            &self.file_system_info,
             self.resolve_snapshot_strategy,
         )
         .await?;
@@ -158,6 +166,7 @@ mod tests {
         let factory = NormalModuleFactory::new(
             UnpackResolver::new(resolve_options),
             build_cache.normal_module_factory(),
+            FileSystemInfo::new(),
             SnapshotStrategy::timestamp(),
         );
         let dependency = Dependency::new(DependencyKind::StaticImport, "./dep");

--- a/crates/unpack_core/src/snapshot.rs
+++ b/crates/unpack_core/src/snapshot.rs
@@ -53,8 +53,122 @@ impl SnapshotStrategy {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FileSystemInfo;
+
+impl FileSystemInfo {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+
+    pub(crate) async fn create_file_snapshot(
+        &self,
+        path: &Path,
+        source: &str,
+        strategy: SnapshotStrategy,
+    ) -> Result<Snapshot> {
+        Snapshot::create_file(path, source, strategy).await
+    }
+
+    pub(crate) async fn create_snapshot(
+        &self,
+        paths: impl IntoIterator<Item = PathBuf>,
+        strategy: SnapshotStrategy,
+    ) -> Result<Snapshot> {
+        Snapshot::create(paths, strategy).await
+    }
+
+    pub(crate) fn create_snapshot_sync(
+        &self,
+        paths: impl IntoIterator<Item = PathBuf>,
+        strategy: SnapshotStrategy,
+    ) -> Result<Snapshot> {
+        Snapshot::create_sync(paths, strategy)
+    }
+
+    pub(crate) async fn is_snapshot_valid(
+        &self,
+        snapshot: &Snapshot,
+        strategy: SnapshotStrategy,
+    ) -> bool {
+        snapshot.is_valid(strategy).await
+    }
+
+    pub(crate) fn is_snapshot_valid_sync(
+        &self,
+        snapshot: &Snapshot,
+        strategy: SnapshotStrategy,
+    ) -> bool {
+        snapshot.is_valid_sync(strategy)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct FileSnapshot {
+pub(crate) struct Snapshot {
+    files: Vec<SnapshottedFile>,
+}
+
+impl Snapshot {
+    async fn create_file(path: &Path, source: &str, strategy: SnapshotStrategy) -> Result<Self> {
+        Ok(Self {
+            files: vec![SnapshottedFile {
+                path: path.to_path_buf(),
+                snapshot: FileSnapshot::create(path, source, strategy).await?,
+            }],
+        })
+    }
+
+    async fn create(
+        paths: impl IntoIterator<Item = PathBuf>,
+        strategy: SnapshotStrategy,
+    ) -> Result<Self> {
+        let paths = normalize_paths(paths);
+        let mut files = Vec::with_capacity(paths.len());
+        for path in paths {
+            files.push(SnapshottedFile {
+                snapshot: FileSnapshot::create_from_path(&path, strategy).await?,
+                path,
+            });
+        }
+        Ok(Self { files })
+    }
+
+    fn create_sync(
+        paths: impl IntoIterator<Item = PathBuf>,
+        strategy: SnapshotStrategy,
+    ) -> Result<Self> {
+        let paths = normalize_paths(paths);
+        let mut files = Vec::with_capacity(paths.len());
+        for path in paths {
+            files.push(SnapshottedFile {
+                snapshot: FileSnapshot::create_from_file_sync(&path, strategy)?,
+                path,
+            });
+        }
+        Ok(Self { files })
+    }
+
+    async fn is_valid(&self, strategy: SnapshotStrategy) -> bool {
+        for file in &self.files {
+            if !file.snapshot.is_valid(&file.path, strategy).await {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn is_valid_sync(&self, strategy: SnapshotStrategy) -> bool {
+        for file in &self.files {
+            if !file.snapshot.is_valid_sync(&file.path, strategy) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct FileSnapshot {
     exists: bool,
     modified: Option<SystemTime>,
     source_hash: Option<u64>,
@@ -210,43 +324,16 @@ impl FileSnapshot {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct FileSetSnapshot {
-    files: Vec<SnapshottedFile>,
-}
-
-impl FileSetSnapshot {
-    pub(crate) async fn create(
-        paths: impl IntoIterator<Item = PathBuf>,
-        strategy: SnapshotStrategy,
-    ) -> Result<Self> {
-        let mut paths = paths.into_iter().collect::<Vec<_>>();
-        paths.sort();
-        paths.dedup();
-
-        let mut files = Vec::with_capacity(paths.len());
-        for path in paths {
-            files.push(SnapshottedFile {
-                snapshot: FileSnapshot::create_from_path(&path, strategy).await?,
-                path,
-            });
-        }
-        Ok(Self { files })
-    }
-
-    pub(crate) async fn is_valid(&self, strategy: SnapshotStrategy) -> bool {
-        for file in &self.files {
-            if !file.snapshot.is_valid(&file.path, strategy).await {
-                return false;
-            }
-        }
-        true
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct SnapshottedFile {
     path: PathBuf,
     snapshot: FileSnapshot,
+}
+
+fn normalize_paths(paths: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
+    let mut paths = paths.into_iter().collect::<Vec<_>>();
+    paths.sort();
+    paths.dedup();
+    paths
 }
 
 fn hash_bytes(source: &[u8]) -> u64 {
@@ -256,4 +343,44 @@ fn hash_bytes(source: &[u8]) -> u64 {
         hash = hash.wrapping_mul(0x100000001b3);
     }
     hash
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn file_system_info_validates_aggregate_file_snapshots()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let path = temp.path().join("module.js");
+        write(&path, "export const value = 'before';")?;
+        let source = fs::read_to_string(&path)?;
+        let file_system_info = FileSystemInfo::new();
+        let snapshot = file_system_info
+            .create_file_snapshot(&path, &source, SnapshotStrategy::hash())
+            .await?;
+
+        assert!(
+            file_system_info
+                .is_snapshot_valid(&snapshot, SnapshotStrategy::hash())
+                .await
+        );
+
+        write(&path, "export const value = 'after';")?;
+
+        assert!(
+            !file_system_info
+                .is_snapshot_valid(&snapshot, SnapshotStrategy::hash())
+                .await
+        );
+
+        Ok(())
+    }
+
+    fn write(path: impl AsRef<Path>, source: &str) -> std::io::Result<()> {
+        fs::write(path, source)
+    }
 }


### PR DESCRIPTION
## What changed

- Added `FileSystemInfo` as the shared snapshot creation and validation entrypoint for build-cache snapshots.
- Replaced per-record file snapshot validation with aggregate `Snapshot` records for module build records, resolve records, and persistent build dependency snapshots.
- Gave each `Compilation` its own `FileSystemInfo` and bumped the persistent cache schema version for the changed snapshot DTO shape.
- Rebased the implementation onto current `main`, preserving the existing logging and make-task factorization work.

## Why

This aligns the existing build-cache snapshot validation path with the planned webpack-like File System Info model while preserving current observable cache behavior.

Closes #37.

## Validation

- `cargo test --workspace`
- `pnpm test`
