### PR TITLE
Document snapshot build cache alignment

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,10 @@ _Avoid_: Webpack-compatible output, snapshot-compatible webpack output
 The Node.js-facing programmable API for configuring and running Unpack from JavaScript.
 _Avoid_: Rust API, webpack-compatible API
 
+**Mode**:
+A JavaScript API option that selects a webpack-like default behavior profile, such as development, production, or none.
+_Avoid_: Environment variable, target, optimization preset
+
 **JavaScript API Test**:
 A test authored from the JavaScript side that exercises Unpack through the public JavaScript API boundary.
 _Avoid_: Rust core test, internal facade test
@@ -190,7 +194,7 @@ _Avoid_: Cache options, watch options
 
 **Build Cache**:
 Compiler-owned reusable build information that can be validated and reused across compilations.
-_Avoid_: Compilation cache, module graph reuse
+_Avoid_: Runtime module cache, compilation cache, module graph reuse
 
 **Cache Facade**:
 A scoped access point to the build cache for one compiler subsystem or cache item family.
@@ -212,6 +216,26 @@ _Avoid_: Cached module, parsed module cache
 A recorded view of filesystem inputs used to decide whether cached build information is still valid.
 _Avoid_: Watch event, mtime check
 
+**Snapshot**:
+A validation record created by File System Info that can contain file, context, missing, managed, and immutable filesystem inputs.
+_Avoid_: Watch dependency set, cache item, filesystem cache
+
+**Context Snapshot**:
+A recorded view of a filesystem directory context used to decide whether directory-sensitive cached build information is still valid.
+_Avoid_: Context module snapshot, directory cache, folder watch event
+
+**Snapshot Merge**:
+The File System Info operation that combines two file snapshots into one validation record while preserving each snapshot content category.
+_Avoid_: Manifest merge, cache pack merge, dependency concatenation
+
+**Missing Existence Snapshot**:
+A recorded absence check for a filesystem input where cache validation only needs to know whether that path has appeared.
+_Avoid_: Missing file timestamp, missing dependency error
+
+**File System Info**:
+Filesystem metadata service used to create and validate file snapshots with shared path classification and timestamp/hash caching for a compilation or persistent cache backend.
+_Avoid_: Filesystem wrapper, snapshot record, watcher cache
+
 **Snapshot Strategy**:
 The configured validation method for a file snapshot, such as timestamp validation, content-hash validation, or a combination of both.
 _Avoid_: Cache mode, watcher policy
@@ -220,9 +244,29 @@ _Avoid_: Cache mode, watcher policy
 A class of filesystem inputs that can use its own snapshot strategy, such as module resources, resolution inputs, or build dependencies.
 _Avoid_: Cache namespace, watcher group
 
+**Managed Path**:
+A filesystem path whose contents are assumed to be controlled by a package manager and stable unless the package-managed item changes.
+_Avoid_: Vendor path, ignored path, external dependency path
+
+**Immutable Path**:
+A filesystem path whose contents are assumed not to change because the path includes versioned or content-addressed identity.
+_Avoid_: Read-only path, permanent path, static path
+
+**Unmanaged Path**:
+A filesystem path that must not use managed-path or immutable-path assumptions when validating file snapshots.
+_Avoid_: Source path, dirty path, watched path
+
+**Snapshot Path Pattern**:
+A string path or regular expression used by snapshot options to classify filesystem inputs as managed, immutable, or unmanaged.
+_Avoid_: JavaScript RegExp compatibility promise, watch ignore pattern
+
 **Build Dependency**:
 A toolchain or configuration input whose change can invalidate persistent build cache entries.
 _Avoid_: Application dependency, module dependency
+
+**Resolve Build Dependency Snapshot**:
+A file snapshot of the resolution work needed to find configured build dependencies before deciding whether persistent cache entries can be reused.
+_Avoid_: Build dependency snapshot, resolver cache entry
 
 **Persistent Cache**:
 A build cache stored outside the process so later compiler instances can reuse validated build information.

--- a/docs/adr/0086-align-effective-snapshot-option-surface.md
+++ b/docs/adr/0086-align-effective-snapshot-option-surface.md
@@ -1,0 +1,3 @@
+# Align effective snapshot option surface with webpack
+
+Unpack will expand JavaScript snapshot options toward webpack by accepting `module`, `resolve`, `buildDependencies`, `resolveBuildDependencies`, `managedPaths`, `immutablePaths`, and `unmanagedPaths` only when each option has active snapshot or build-cache behavior. `contextModule` remains rejected until Unpack has context modules, because accepting inert public options would imply support that does not exist. This revises the initial minimal surface in ADR 0079 and the deferral in ADR 0067: resolve-build-dependency and path-classification options now belong to build-cache alignment work, while context-module snapshots still wait for context modules.

--- a/docs/adr/0087-use-rust-regex-for-snapshot-path-patterns.md
+++ b/docs/adr/0087-use-rust-regex-for-snapshot-path-patterns.md
@@ -1,0 +1,3 @@
+# Use Rust regex for snapshot path patterns
+
+Unpack snapshot path options will accept both string paths and regular-expression patterns, but regular expressions will be compiled and matched by Rust rather than preserving full JavaScript `RegExp` semantics across N-API. This keeps managed, immutable, and unmanaged path classification inside the Rust snapshot implementation while making the public option surface closer to webpack; minor semantic differences from JavaScript regular expressions are accepted until a concrete compatibility issue requires a narrower bridge.

--- a/docs/adr/0088-normalize-snapshot-path-regex-flags.md
+++ b/docs/adr/0088-normalize-snapshot-path-regex-flags.md
@@ -1,0 +1,3 @@
+# Normalize snapshot path regex flags
+
+Unpack will normalize JavaScript `RegExp` snapshot path patterns into source and flags before passing them to Rust, and the first implementation will accept only no flags or `i`. Unsupported JavaScript flags are rejected instead of ignored because Rust performs the matching and cannot promise full JavaScript regular-expression behavior; this preserves a clear API contract while still allowing case-insensitive managed, immutable, and unmanaged path patterns.

--- a/docs/adr/0089-default-snapshot-managed-paths-to-node-modules.md
+++ b/docs/adr/0089-default-snapshot-managed-paths-to-node-modules.md
@@ -1,0 +1,3 @@
+# Default snapshot managed paths to node_modules only
+
+Unpack will default snapshot managed-path classification to `node_modules` and will not add webpack's PnP or Yarn cache defaults in the first implementation. This keeps the default persistent-cache invalidation model aligned with the most common Node package layout while avoiding package-manager-specific assumptions that Unpack does not otherwise support; users can still configure explicit managed, immutable, or unmanaged path patterns when their workspace layout needs different behavior.

--- a/docs/adr/0090-align-managed-path-snapshots-with-webpack-managed-items.md
+++ b/docs/adr/0090-align-managed-path-snapshots-with-webpack-managed-items.md
@@ -1,0 +1,3 @@
+# Align managed path snapshots with webpack managed items
+
+Unpack managed-path snapshots will follow webpack's managed item model instead of skipping every file under a managed path. A managed path match should identify the relevant package-like managed item, including scoped packages and nested `node_modules`, reject hidden managed items, and record managed item information such as missing, special `node_modules`, grouping-folder, or `name@version` state from `package.json`. This keeps managed paths useful for reducing per-file snapshot work while preserving cache invalidation when the package-managed item changes.

--- a/docs/adr/0091-prioritize-unmanaged-over-immutable-and-managed-paths.md
+++ b/docs/adr/0091-prioritize-unmanaged-over-immutable-and-managed-paths.md
@@ -1,0 +1,3 @@
+# Prioritize unmanaged paths over immutable and managed paths
+
+Unpack snapshot path classification will match webpack's precedence: `unmanagedPaths` overrides every managed or immutable assumption, `immutablePaths` applies next, and `managedPaths` applies last. This gives users an escape hatch for editable packages under otherwise managed directories such as `node_modules`, while still allowing explicitly immutable paths to bypass managed item checks when no unmanaged pattern matches.

--- a/docs/adr/0092-model-resolve-build-dependency-snapshots-at-cache-container-level.md
+++ b/docs/adr/0092-model-resolve-build-dependency-snapshots-at-cache-container-level.md
@@ -1,0 +1,3 @@
+# Model resolve build dependency snapshots at cache container level
+
+Unpack will implement `snapshot.resolveBuildDependencies` as persistent-cache container validation for the work needed to locate configured build dependency files, not as a separate cache facade. Because Unpack's first `cache.buildDependencies` shape is already an explicit map of file paths, the first resolve-build-dependency snapshot can live in the persistent cache manifest alongside build dependency snapshots; if build dependencies later accept package requests, globs, or config-driven discovery, the same category can expand into a fuller webpack-like resolve-build-dependency flow.

--- a/docs/adr/0093-apply-snapshot-path-classification-across-categories.md
+++ b/docs/adr/0093-apply-snapshot-path-classification-across-categories.md
@@ -1,0 +1,3 @@
+# Apply snapshot path classification across categories
+
+Unpack will apply managed, immutable, and unmanaged path classification inside the shared snapshot infrastructure for every effective snapshot category, including module resources, resolution inputs, build dependencies, and resolve-build-dependency inputs. The classification is not owned by individual cache items or facades; this keeps a filesystem input's invalidation semantics consistent regardless of which build-cache record references it.

--- a/docs/adr/0094-introduce-file-system-info-for-snapshots.md
+++ b/docs/adr/0094-introduce-file-system-info-for-snapshots.md
@@ -1,0 +1,3 @@
+# Introduce File System Info for snapshots
+
+Unpack will introduce `File System Info` as the shared snapshot infrastructure boundary, following webpack's architecture. `File System Info` owns snapshot creation, snapshot validation, managed/immutable/unmanaged path classification, managed item inspection, and timestamp/hash caching, while cache items continue to store validation data rather than performing filesystem policy decisions themselves. This prevents module, resolve, build-dependency, and resolve-build-dependency snapshots from drifting into separate invalidation semantics.

--- a/docs/adr/0095-bind-file-system-info-to-compiler-lifecycle.md
+++ b/docs/adr/0095-bind-file-system-info-to-compiler-lifecycle.md
@@ -1,0 +1,3 @@
+# Use per-compilation File System Info with compiler watch inputs
+
+Unpack will align with webpack by creating a fresh `File System Info` for each compilation instead of sharing one compiler-owned instance across repeated runs. The compiler owns snapshot path configuration and, during watch sessions, the latest file and context timestamp inputs collected by the watcher; each compilation seeds its `File System Info` from those inputs. Persistent cache backends may own a separate longer-lived `File System Info` for cache-container validation, but compilation snapshot caches should not silently survive unrelated non-watch runs.

--- a/docs/adr/0096-require-absolute-string-snapshot-path-patterns.md
+++ b/docs/adr/0096-require-absolute-string-snapshot-path-patterns.md
@@ -1,0 +1,3 @@
+# Require absolute string snapshot path patterns
+
+Unpack will require string entries in `snapshot.managedPaths`, `snapshot.immutablePaths`, and `snapshot.unmanagedPaths` to be absolute paths. These options classify filesystem locations globally rather than naming project-local inputs, so relative strings would make path matching depend on caller context in a way webpack does not. Generated defaults such as the `node_modules` managed path pattern remain Unpack-owned and do not require users to provide relative path strings.

--- a/docs/adr/0097-use-mode-aware-module-and-resolve-snapshot-defaults.md
+++ b/docs/adr/0097-use-mode-aware-module-and-resolve-snapshot-defaults.md
@@ -1,0 +1,3 @@
+# Use mode-aware module and resolve snapshot defaults
+
+Unpack will align module and resolve snapshot defaults with webpack's mode-aware behavior: production mode, including omitted mode once `mode` is exposed, defaults module and resolve snapshots to timestamp plus hash, while development and none default them to timestamp validation. Build-dependency and resolve-build-dependency snapshots continue to default to timestamp plus hash. This supersedes ADR 0081's fixed timestamp default for module resources and resolution inputs.

--- a/docs/adr/0098-expose-webpack-like-mode-in-javascript-api.md
+++ b/docs/adr/0098-expose-webpack-like-mode-in-javascript-api.md
@@ -1,0 +1,3 @@
+# Expose webpack-like mode in the JavaScript API
+
+Unpack will add `mode?: "development" | "production" | "none"` to the JavaScript API and use webpack's defaulting rule where omitted mode behaves as production for defaults that depend on mode. The first consumer is snapshot defaulting: module and resolve snapshots use timestamp plus hash in production or omitted mode, and timestamp-only in development or none. Other production or development defaults should be added explicitly as their corresponding features are introduced.

--- a/docs/adr/0099-require-at-least-one-snapshot-validation-method.md
+++ b/docs/adr/0099-require-at-least-one-snapshot-validation-method.md
@@ -1,0 +1,3 @@
+# Require at least one snapshot validation method
+
+Unpack will reject snapshot strategy objects where both `timestamp` and `hash` are false. Although webpack's schema permits this shape, Unpack will require every effective snapshot category to use at least one validation method so cache items cannot become silently permanent. Users who want to avoid reuse should disable the build cache with `cache: false` rather than configuring an unvalidated snapshot strategy.

--- a/docs/adr/0100-normalize-resolve-build-dependency-snapshots-independent-of-cache-kind.md
+++ b/docs/adr/0100-normalize-resolve-build-dependency-snapshots-independent-of-cache-kind.md
@@ -1,0 +1,3 @@
+# Normalize resolve build dependency snapshots independent of cache kind
+
+Unpack will accept and normalize `snapshot.resolveBuildDependencies` regardless of whether the current build cache is disabled, memory-backed, or filesystem-backed, matching webpack's option model. The first effective consumer is filesystem persistent-cache container validation, but keeping normalization independent of cache kind lets users switch cache type without rewriting snapshot configuration.

--- a/docs/adr/0101-reject-context-module-snapshot-options-until-context-modules-exist.md
+++ b/docs/adr/0101-reject-context-module-snapshot-options-until-context-modules-exist.md
@@ -1,0 +1,3 @@
+# Reject context module snapshot options until context modules exist
+
+Unpack will continue to reject `snapshot.contextModule` until context modules are implemented. This keeps the JavaScript API from accepting inert webpack-shaped options and preserves the rule that exposed snapshot options must have active behavior in Unpack. When context modules are added, their snapshot category should be introduced with real validation semantics rather than retrofitting a prior no-op option.

--- a/docs/adr/0102-use-snapshot-path-options-as-the-effective-path-classification-entrypoint.md
+++ b/docs/adr/0102-use-snapshot-path-options-as-the-effective-path-classification-entrypoint.md
@@ -1,0 +1,3 @@
+# Use snapshot path options as the effective path classification entrypoint
+
+Unpack will treat `snapshot.managedPaths`, `snapshot.immutablePaths`, and `snapshot.unmanagedPaths` as the canonical effective configuration for filesystem path classification. Although webpack's option types still include cache-level managed and immutable path fields, webpack's current application path feeds snapshot path options into compiler and cache-backend `File System Info` instances. Unpack will follow that effective behavior and avoid introducing separate cache-level path-classification entries until a concrete compatibility need appears.

--- a/docs/adr/0103-record-immutable-paths-in-snapshots.md
+++ b/docs/adr/0103-record-immutable-paths-in-snapshots.md
@@ -1,0 +1,3 @@
+# Record immutable paths in snapshots
+
+Unpack will record inputs matched by `snapshot.immutablePaths` in snapshot data instead of dropping them entirely. Immutable classification changes validation semantics, but the classified input should remain visible to snapshot inspection, merge behavior, and diagnostics. This follows webpack's model where managed and immutable inputs are represented in snapshot structures while allowing validation to avoid per-file timestamp or hash work for immutable paths.

--- a/docs/adr/0104-model-missing-inputs-as-existence-snapshots.md
+++ b/docs/adr/0104-model-missing-inputs-as-existence-snapshots.md
@@ -1,0 +1,3 @@
+# Model missing inputs as existence snapshots
+
+Unpack will model missing filesystem inputs with explicit missing existence snapshots instead of treating absent paths as ordinary file snapshots. Missing dependency validation only needs to know whether the path has appeared or disappeared, while timestamp and hash strategies apply to existing files or directories. This aligns resolver cache validation with webpack's snapshot model and keeps missing candidates from implying file-content validation work.

--- a/docs/adr/0105-add-context-snapshots-for-directory-inputs.md
+++ b/docs/adr/0105-add-context-snapshots-for-directory-inputs.md
@@ -1,0 +1,3 @@
+# Add context snapshots for directory inputs
+
+Unpack will add context snapshots for directory-sensitive filesystem inputs, following webpack's distinction between file, context, and missing snapshot content. Context snapshots are a lower-level filesystem validation concept and do not imply support for `snapshot.contextModule` or context modules. The first use should be resolver and resolve-build-dependency validation where directory contents can affect resolution results.

--- a/docs/adr/0106-include-directory-entry-digest-in-context-timestamp-snapshots.md
+++ b/docs/adr/0106-include-directory-entry-digest-in-context-timestamp-snapshots.md
@@ -1,0 +1,3 @@
+# Include directory entry digest in context timestamp snapshots
+
+Unpack context snapshots will include a stable digest of directory entries when using timestamp validation, not just the directory modified time. This mirrors webpack's `timestampHash` idea and protects resolver snapshots from missing directory-content changes on filesystems with coarse or unreliable directory mtimes. Hash validation may later add deeper content hashing, but timestamp-mode context snapshots still need a directory-entry digest.

--- a/docs/adr/0107-support-snapshot-merge-in-file-system-info.md
+++ b/docs/adr/0107-support-snapshot-merge-in-file-system-info.md
@@ -1,0 +1,3 @@
+# Support snapshot merge in File System Info
+
+Unpack `File System Info` will support merging snapshots, following webpack's `mergeSnapshots` behavior. A snapshot merge combines each snapshot content category, takes the earliest available start time, unions set-like managed content, and lets later map entries override earlier entries for the same path. Persistent cache container validation should use snapshot merge for build-dependency and resolve-build-dependency snapshots instead of inventing manifest-specific merge logic.

--- a/docs/adr/0108-use-aggregate-snapshot-records.md
+++ b/docs/adr/0108-use-aggregate-snapshot-records.md
@@ -1,0 +1,3 @@
+# Use aggregate snapshot records
+
+Unpack will replace the narrow `FileSnapshot` and `FileSetSnapshot` validation model with aggregate snapshot records created and validated by `File System Info`. A snapshot can contain file, context, missing-existence, managed item, managed file, managed context, managed missing, and immutable path-classified content. Cache items and persistent cache manifests should store these aggregate snapshots as validation records so module, resolve, build-dependency, and resolve-build-dependency cache data share one invalidation model.

--- a/docs/adr/0109-keep-aggregate-snapshot-schema-unpack-private.md
+++ b/docs/adr/0109-keep-aggregate-snapshot-schema-unpack-private.md
@@ -1,0 +1,3 @@
+# Keep aggregate snapshot schema Unpack-private
+
+Unpack aggregate snapshots will align with webpack's validation semantics but will not attempt to serialize snapshots in webpack's object or pack-file format. Snapshot records remain part of Unpack's private persistent cache schema, guarded by cache schema versioning as described in ADR 0082. This lets the Rust implementation use native structs and enums while preserving compatibility through explicit Unpack cache migrations rather than webpack binary/object compatibility.

--- a/docs/adr/0110-implement-snapshot-alignment-from-api-to-validation-model.md
+++ b/docs/adr/0110-implement-snapshot-alignment-from-api-to-validation-model.md
@@ -1,0 +1,3 @@
+# Implement snapshot alignment from API to validation model
+
+Unpack will implement snapshot alignment in public-contract-first order: normalize JavaScript `mode` and snapshot options, pass the expanded Rust option model across N-API, introduce `File System Info` with aggregate snapshots, migrate cache records and persistent manifests to those snapshots, and then add behavior tests for webpack-aligned defaults and validation. This sequencing keeps the exposed option contract and error behavior explicit before replacing the lower-level snapshot DTOs.

--- a/docs/adr/0111-test-snapshot-alignment-through-javascript-api-behavior.md
+++ b/docs/adr/0111-test-snapshot-alignment-through-javascript-api-behavior.md
@@ -1,0 +1,3 @@
+# Test snapshot alignment through JavaScript API behavior
+
+Unpack snapshot alignment should be verified through JavaScript API and integration behavior, not only Rust unit tests. Required coverage includes mode-aware snapshot defaults, snapshot path option validation, regular-expression pattern normalization, continued rejection of `snapshot.contextModule`, rejection of unvalidated strategies, managed item invalidation, unmanaged-over-managed precedence, missing candidate invalidation, and context directory invalidation. These tests define the observable webpack-aligned behavior for the first snapshot alignment implementation.

--- a/docs/implementation/snapshot-build-cache-alignment.md
+++ b/docs/implementation/snapshot-build-cache-alignment.md
@@ -1,0 +1,144 @@
+# Snapshot Build Cache Alignment Implementation Plan
+
+This plan aligns Unpack's build-cache snapshot model with webpack's effective architecture. The work expands the JavaScript snapshot option surface, introduces File System Info, and replaces narrow file-only snapshots with aggregate snapshot records that can validate files, directories, missing inputs, managed items, and persistent cache container dependencies.
+
+## Target Shape
+
+Snapshot validation should have one shared model across memory cache, persistent cache, resolver records, and module build records:
+
+1. The JavaScript API exposes webpack-like `mode` and effective snapshot options.
+2. `snapshot.*Paths` are the canonical path classification entrypoint.
+3. Each compilation creates its own File System Info, seeded from watch timestamp inputs when available.
+4. Persistent cache validation may use a separate longer-lived File System Info.
+5. Cache items and cache manifests store aggregate snapshots instead of ad hoc file snapshots.
+6. Snapshot semantics align with webpack, while the serialized cache schema remains Unpack-private.
+
+## Key Decisions
+
+- Accept effective snapshot options: `module`, `resolve`, `buildDependencies`, `resolveBuildDependencies`, `managedPaths`, `immutablePaths`, and `unmanagedPaths`.
+- Continue rejecting `snapshot.contextModule` until context modules exist.
+- Add `mode?: "development" | "production" | "none"`; omitted mode behaves like production for mode-aware defaults.
+- Default `module` and `resolve` snapshots to timestamp plus hash in production or omitted mode, and timestamp-only in development or none.
+- Default `buildDependencies` and `resolveBuildDependencies` to timestamp plus hash.
+- Reject snapshot strategies where both `timestamp` and `hash` are false.
+- Support string and RegExp snapshot path patterns; string paths must be absolute.
+- Normalize JavaScript RegExp values into source and flags, and only accept no flags or `i`.
+- Use Rust regex matching for snapshot path patterns; minor JavaScript RegExp semantic differences are accepted.
+- Default managed path classification to `node_modules` only; do not add PnP or Yarn defaults.
+- Apply path classification in this precedence order: unmanaged, immutable, managed.
+- Model managed paths with webpack-like managed items instead of skipping every file under a managed path.
+- Represent missing inputs as missing existence snapshots, not file snapshots.
+- Add context snapshots for directory inputs, including a directory-entry digest in timestamp mode.
+- Support snapshot merge in File System Info for persistent cache container validation.
+
+## Non-Goals
+
+- Do not add context modules or accept `snapshot.contextModule` as a no-op.
+- Do not expose `cache.managedPaths` or `cache.immutablePaths` as effective Unpack entries.
+- Do not support PnP or Yarn-specific default path classification.
+- Do not promise webpack-compatible snapshot serialization.
+- Do not add code generation or asset cache items in this work.
+
+## Slice 1: JavaScript API Normalization
+
+Add `mode` and expand `SnapshotOptions` in the TypeScript wrapper.
+
+- Add `mode?: "development" | "production" | "none"` to public options.
+- Normalize omitted mode as production for mode-aware defaults.
+- Add `resolveBuildDependencies`, `managedPaths`, `immutablePaths`, and `unmanagedPaths`.
+- Keep `contextModule` as an unknown option that throws.
+- Reject `{ timestamp: false, hash: false }`.
+- Require string path patterns to be absolute.
+- Normalize RegExp patterns into `{ source, flags }`.
+- Reject unsupported RegExp flags.
+
+Done when JavaScript API tests cover defaults, validation errors, and native option payloads.
+
+## Slice 2: Native and Rust Option Model
+
+Carry the expanded option surface across N-API and into `unpack_core`.
+
+- Add a Rust `Mode` model.
+- Add snapshot categories for `resolve_build_dependencies`.
+- Add snapshot path pattern DTOs for exact absolute paths and Rust regex patterns.
+- Compile regex patterns in Rust, including case-insensitive handling for `i`.
+- Build default `node_modules` managed path patterns without PnP or Yarn assumptions.
+- Keep snapshot option normalization deterministic between JavaScript and Rust.
+
+Done when Rust compiler options can represent every effective snapshot option without using JavaScript-only types.
+
+## Slice 3: File System Info
+
+Introduce File System Info as the shared snapshot infrastructure.
+
+- Create a per-compilation File System Info.
+- Seed compilation File System Info from watch-provided file and context timestamp maps when available.
+- Let persistent cache backend validation own a separate File System Info.
+- Centralize timestamp, hash, context, managed item, missing existence, and snapshot validity caching.
+- Move path classification out of individual cache items.
+
+Done when snapshot creation and validation go through File System Info rather than direct `FileSnapshot` reads.
+
+## Slice 4: Aggregate Snapshot Records
+
+Replace file-only snapshots with aggregate snapshot records.
+
+- Add snapshot content for files, contexts, missing existence, managed item info, managed files, managed contexts, managed missing inputs, and immutable-classified inputs.
+- Add context snapshots with directory modified time plus stable directory-entry digest in timestamp mode.
+- Add missing existence snapshots that only validate absence/presence.
+- Add snapshot merge with webpack-like map override and set union behavior.
+- Keep the serialized snapshot schema Unpack-private and bump cache schema version when persistent DTOs change.
+
+Done when module, resolve, build-dependency, and resolve-build-dependency validation can all store the same aggregate snapshot type.
+
+## Slice 5: Managed Path Semantics
+
+Implement webpack-like managed item behavior.
+
+- Recognize package-like managed items under managed paths.
+- Support scoped packages and nested `node_modules`.
+- Reject hidden managed items.
+- Record special managed states such as missing, `node_modules`, grouping folder, and `name@version` from `package.json`.
+- Let unmanaged patterns override managed and immutable matches.
+- Let immutable matches bypass per-file work while still being represented in snapshots.
+
+Done when managed package metadata changes invalidate cache entries and unmanaged overrides force normal validation.
+
+## Slice 6: Cache Record Migration
+
+Move cache records and manifests onto aggregate snapshots.
+
+- Change `ModuleBuildRecord` to store an aggregate snapshot for module resources.
+- Change `ResolveRecord` to store an aggregate snapshot for file, context, and missing resolver inputs.
+- Store build-dependency snapshots in the persistent cache manifest as aggregate snapshots.
+- Add resolve-build-dependency snapshots at the persistent cache container level.
+- Use snapshot merge when accumulating build-dependency and resolve-build-dependency snapshots.
+- Preserve cache disabled and memory cache behavior.
+
+Done when filesystem cache restore validates through aggregate snapshots and stale packs are ignored rather than partially restored.
+
+## Slice 7: Tests
+
+Verify the behavior through JavaScript API and integration tests.
+
+- Omitted mode and production default module and resolve snapshots to timestamp plus hash.
+- Development and none default module and resolve snapshots to timestamp-only.
+- Snapshot path options accept absolute strings and supported RegExp patterns.
+- Snapshot path options reject relative strings and unsupported RegExp flags.
+- `snapshot.contextModule` is rejected.
+- Unvalidated snapshot strategies are rejected.
+- Managed package `name@version` changes invalidate cache.
+- Unmanaged patterns override managed defaults.
+- Missing resolver candidates appearing on disk invalidate resolve cache.
+- Context directory candidate changes invalidate resolve cache.
+
+Done when tests fail against the old file-only snapshot model and pass with File System Info plus aggregate snapshots.
+
+## Suggested Issue Slices
+
+1. Expose mode and expanded snapshot options in the JavaScript API.
+2. Add Rust snapshot option models and snapshot path pattern matching.
+3. Introduce File System Info and aggregate snapshot records.
+4. Implement managed, immutable, unmanaged, missing, and context snapshot semantics.
+5. Migrate module, resolve, and persistent cache records to aggregate snapshots.
+6. Add JavaScript API behavior tests for webpack-aligned snapshot defaults and invalidation.


### PR DESCRIPTION
## What changed

- Added snapshot/build-cache ADRs covering the webpack-aligned option surface, path classification, File System Info, aggregate snapshots, and testing direction.
- Added the snapshot build cache alignment implementation plan.
- Updated `CONTEXT.md` with the snapshot/build-cache terms used by the ADRs.

## Validation

- `git diff --check origin/main...HEAD`
- Not run: code tests; documentation-only change.
