### PR TITLE
Add GitHub Actions test CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: moonrepo/setup-rust@v0
+        with:
+          channel: stable
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.7.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install JavaScript dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test

--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 
 const CACHE_MAGIC: &str = "UNPACK_PERSISTENT_CACHE";
 const PACK_MAGIC: &[u8] = b"UNPACK-CACHE-PACK\0";
-const CACHE_SCHEMA_VERSION: u32 = 3;
+const CACHE_SCHEMA_VERSION: u32 = 4;
 const DEFAULT_PACK_FILE: &str = "packs/modules.cbor";
 const MANIFEST_FILE: &str = "container.json";
 
@@ -24,6 +24,7 @@ const MANIFEST_FILE: &str = "container.json";
 pub(crate) struct BuildCache {
     options: CacheOptions,
     build_dependency_snapshot_strategy: SnapshotStrategy,
+    resolve_build_dependency_snapshot_strategy: SnapshotStrategy,
     file_system_info: FileSystemInfo,
     inner: Arc<Mutex<BuildCacheInner>>,
 }
@@ -277,10 +278,12 @@ impl BuildCache {
     pub(crate) fn new(
         options: CacheOptions,
         build_dependency_snapshot_strategy: SnapshotStrategy,
+        resolve_build_dependency_snapshot_strategy: SnapshotStrategy,
     ) -> Self {
         let cache = Self {
             options,
             build_dependency_snapshot_strategy,
+            resolve_build_dependency_snapshot_strategy,
             file_system_info: FileSystemInfo::new(),
             inner: Arc::new(Mutex::new(BuildCacheInner::default())),
         };
@@ -459,7 +462,10 @@ impl BuildCache {
             schema_version: CACHE_SCHEMA_VERSION,
             cache_version,
             pack_file: pack_file.to_string_lossy().replace('\\', "/"),
-            build_dependencies: self.build_dependency_snapshots()?,
+            build_dependencies: self
+                .build_dependency_snapshots(self.build_dependency_snapshot_strategy)?,
+            resolve_build_dependencies: self
+                .build_dependency_snapshots(self.resolve_build_dependency_snapshot_strategy)?,
         };
         fs::create_dir_all(cache_location)?;
         let manifest_json = serde_json::to_vec_pretty(&manifest)
@@ -472,14 +478,24 @@ impl BuildCache {
         manifest.magic == CACHE_MAGIC
             && manifest.schema_version == CACHE_SCHEMA_VERSION
             && manifest.cache_version == self.cache_version()
-            && self.build_dependency_snapshots_are_valid(&manifest.build_dependencies)
+            && self.build_dependency_snapshots_are_valid(
+                &manifest.build_dependencies,
+                self.build_dependency_snapshot_strategy,
+            )
+            && self.build_dependency_snapshots_are_valid(
+                &manifest.resolve_build_dependencies,
+                self.resolve_build_dependency_snapshot_strategy,
+            )
     }
 
     fn cache_version(&self) -> String {
         self.options.version.clone().unwrap_or_default()
     }
 
-    fn build_dependency_snapshots(&self) -> io::Result<Vec<PersistentBuildDependencySnapshot>> {
+    fn build_dependency_snapshots(
+        &self,
+        strategy: SnapshotStrategy,
+    ) -> io::Result<Vec<PersistentBuildDependencySnapshot>> {
         self.options
             .build_dependencies
             .iter()
@@ -489,10 +505,7 @@ impl BuildCache {
                     files: dependency.files.clone(),
                     snapshot: self
                         .file_system_info
-                        .create_snapshot_sync(
-                            dependency.files.clone(),
-                            self.build_dependency_snapshot_strategy,
-                        )
+                        .create_snapshot_sync(dependency.files.clone(), strategy)
                         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?,
                 })
             })
@@ -502,6 +515,7 @@ impl BuildCache {
     fn build_dependency_snapshots_are_valid(
         &self,
         snapshots: &[PersistentBuildDependencySnapshot],
+        strategy: SnapshotStrategy,
     ) -> bool {
         if snapshots.len() != self.options.build_dependencies.len() {
             return false;
@@ -522,10 +536,9 @@ impl BuildCache {
                 .files
                 .iter()
                 .all(|path| snapshot.files.contains(path))
-                && self.file_system_info.is_snapshot_valid_sync(
-                    &snapshot.snapshot,
-                    self.build_dependency_snapshot_strategy,
-                )
+                && self
+                    .file_system_info
+                    .is_snapshot_valid_sync(&snapshot.snapshot, strategy)
         })
     }
 }
@@ -548,6 +561,7 @@ struct CacheManifest {
     cache_version: String,
     pack_file: String,
     build_dependencies: Vec<PersistentBuildDependencySnapshot>,
+    resolve_build_dependencies: Vec<PersistentBuildDependencySnapshot>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -58,8 +58,11 @@ pub struct Compiler {
 impl Compiler {
     pub fn new(options: CompilerOptions) -> Self {
         let resolver = UnpackResolver::new(options.resolve.clone());
-        let build_cache =
-            BuildCache::new(options.cache.clone(), options.snapshot.build_dependencies);
+        let build_cache = BuildCache::new(
+            options.cache.clone(),
+            options.snapshot.build_dependencies,
+            options.snapshot.resolve_build_dependencies,
+        );
         Self {
             options,
             resolver,

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -646,8 +646,11 @@ mod tests {
 
         let options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
         let resolver = UnpackResolver::new(options.resolve.clone());
-        let build_cache =
-            BuildCache::new(options.cache.clone(), options.snapshot.build_dependencies);
+        let build_cache = BuildCache::new(
+            options.cache.clone(),
+            options.snapshot.build_dependencies,
+            options.snapshot.resolve_build_dependencies,
+        );
         let state = Arc::new(Mutex::new(MakeState::default()));
 
         run(

--- a/crates/unpack_core/src/normal_module_factory.rs
+++ b/crates/unpack_core/src/normal_module_factory.rs
@@ -162,7 +162,11 @@ mod tests {
 
         let mut resolve_options = ResolveOptions::default();
         resolve_options.extensions = vec![".js".to_string()];
-        let build_cache = BuildCache::new(CacheOptions::disabled(), SnapshotStrategy::timestamp());
+        let build_cache = BuildCache::new(
+            CacheOptions::disabled(),
+            SnapshotStrategy::timestamp(),
+            SnapshotStrategy::timestamp(),
+        );
         let factory = NormalModuleFactory::new(
             UnpackResolver::new(resolve_options),
             build_cache.normal_module_factory(),

--- a/crates/unpack_core/src/snapshot.rs
+++ b/crates/unpack_core/src/snapshot.rs
@@ -12,6 +12,7 @@ pub struct SnapshotOptions {
     pub module: SnapshotStrategy,
     pub resolve: SnapshotStrategy,
     pub build_dependencies: SnapshotStrategy,
+    pub resolve_build_dependencies: SnapshotStrategy,
 }
 
 impl Default for SnapshotOptions {
@@ -20,6 +21,7 @@ impl Default for SnapshotOptions {
             module: SnapshotStrategy::timestamp(),
             resolve: SnapshotStrategy::timestamp(),
             build_dependencies: SnapshotStrategy::timestamp_and_hash(),
+            resolve_build_dependencies: SnapshotStrategy::timestamp_and_hash(),
         }
     }
 }

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -60,6 +60,8 @@ pub struct NativeSnapshotOptions {
     pub resolve: NativeSnapshotStrategy,
     #[napi(js_name = "buildDependencies")]
     pub build_dependencies: NativeSnapshotStrategy,
+    #[napi(js_name = "resolveBuildDependencies")]
+    pub resolve_build_dependencies: NativeSnapshotStrategy,
 }
 
 #[napi(object)]
@@ -216,6 +218,9 @@ fn snapshot_options_from_native(options: NativeSnapshotOptions) -> SnapshotOptio
         module: snapshot_strategy_from_native(options.module),
         resolve: snapshot_strategy_from_native(options.resolve),
         build_dependencies: snapshot_strategy_from_native(options.build_dependencies),
+        resolve_build_dependencies: snapshot_strategy_from_native(
+            options.resolve_build_dependencies,
+        ),
     }
 }
 

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -4,6 +4,7 @@ import { isAbsolute, resolve } from "node:path";
 
 export interface UnpackOptions {
   context?: string;
+  mode?: Mode;
   entry: string | Record<string, string>;
   output?: {
     path?: string;
@@ -12,6 +13,8 @@ export interface UnpackOptions {
   snapshot?: SnapshotOptions;
   infrastructureLogging?: InfrastructureLoggingOptions;
 }
+
+export type Mode = "development" | "production" | "none";
 
 export type CacheOptions =
   | boolean
@@ -30,6 +33,7 @@ export interface SnapshotOptions {
   module?: SnapshotStrategyOptions;
   resolve?: SnapshotStrategyOptions;
   buildDependencies?: SnapshotStrategyOptions;
+  resolveBuildDependencies?: SnapshotStrategyOptions;
 }
 
 export interface SnapshotStrategyOptions {
@@ -138,6 +142,7 @@ interface NormalizedSnapshotOptions {
   module: NormalizedSnapshotStrategy;
   resolve: NormalizedSnapshotStrategy;
   buildDependencies: NormalizedSnapshotStrategy;
+  resolveBuildDependencies: NormalizedSnapshotStrategy;
 }
 
 interface NormalizedSnapshotStrategy {
@@ -744,7 +749,7 @@ function normalizeOptions(options: UnpackOptions): NormalizedOptions {
   assertPlainObject(options, "options");
   assertKnownKeys(
     options,
-    ["context", "entry", "output", "cache", "snapshot", "infrastructureLogging"],
+    ["context", "mode", "entry", "output", "cache", "snapshot", "infrastructureLogging"],
     "options"
   );
 
@@ -752,6 +757,7 @@ function normalizeOptions(options: UnpackOptions): NormalizedOptions {
     options.context === undefined
       ? process.cwd()
       : assertString(options.context, "options.context");
+  const mode = options.mode === undefined ? "production" : assertMode(options.mode);
   const normalizedContext = resolve(process.cwd(), context);
   const output = options.output ?? {};
   assertPlainObject(output, "options.output");
@@ -770,7 +776,7 @@ function normalizeOptions(options: UnpackOptions): NormalizedOptions {
     entries: normalizeEntry(options.entry),
     outputPath,
     cache: normalizeCacheOptions(options.cache, normalizedContext),
-    snapshot: normalizeSnapshotOptions(options.snapshot),
+    snapshot: normalizeSnapshotOptions(options.snapshot, mode),
     infrastructureLogging: normalizeInfrastructureLoggingOptions(options.infrastructureLogging)
   };
 }
@@ -899,28 +905,38 @@ function normalizeBuildDependencies(
 }
 
 function normalizeSnapshotOptions(
-  snapshot: SnapshotOptions | undefined
+  snapshot: SnapshotOptions | undefined,
+  mode: Mode
 ): NormalizedSnapshotOptions {
+  const moduleAndResolveDefaults = defaultModuleAndResolveSnapshotStrategy(mode);
+
   if (snapshot === undefined) {
     return {
-      module: { timestamp: true, hash: false },
-      resolve: { timestamp: true, hash: false },
-      buildDependencies: { timestamp: true, hash: true }
+      module: { ...moduleAndResolveDefaults },
+      resolve: { ...moduleAndResolveDefaults },
+      buildDependencies: { timestamp: true, hash: true },
+      resolveBuildDependencies: { timestamp: true, hash: true }
     };
   }
 
   assertPlainObject(snapshot, "options.snapshot");
-  assertKnownKeys(snapshot, ["module", "resolve", "buildDependencies"], "options.snapshot");
+  assertKnownKeys(
+    snapshot,
+    ["module", "resolve", "buildDependencies", "resolveBuildDependencies"],
+    "options.snapshot"
+  );
 
   return {
-    module: normalizeSnapshotStrategy(snapshot.module, "options.snapshot.module", {
-      timestamp: true,
-      hash: false
-    }),
-    resolve: normalizeSnapshotStrategy(snapshot.resolve, "options.snapshot.resolve", {
-      timestamp: true,
-      hash: false
-    }),
+    module: normalizeSnapshotStrategy(
+      snapshot.module,
+      "options.snapshot.module",
+      moduleAndResolveDefaults
+    ),
+    resolve: normalizeSnapshotStrategy(
+      snapshot.resolve,
+      "options.snapshot.resolve",
+      moduleAndResolveDefaults
+    ),
     buildDependencies: normalizeSnapshotStrategy(
       snapshot.buildDependencies,
       "options.snapshot.buildDependencies",
@@ -928,8 +944,22 @@ function normalizeSnapshotOptions(
         timestamp: true,
         hash: true
       }
+    ),
+    resolveBuildDependencies: normalizeSnapshotStrategy(
+      snapshot.resolveBuildDependencies,
+      "options.snapshot.resolveBuildDependencies",
+      {
+        timestamp: true,
+        hash: true
+      }
     )
   };
+}
+
+function defaultModuleAndResolveSnapshotStrategy(mode: Mode): NormalizedSnapshotStrategy {
+  return mode === "development" || mode === "none"
+    ? { timestamp: true, hash: false }
+    : { timestamp: true, hash: true };
 }
 
 function normalizeSnapshotStrategy(
@@ -943,13 +973,17 @@ function normalizeSnapshotStrategy(
 
   assertPlainObject(strategy, name);
   assertKnownKeys(strategy, ["timestamp", "hash"], name);
-  return {
+  const normalized = {
     timestamp:
       strategy.timestamp === undefined
         ? defaults.timestamp
         : assertBoolean(strategy.timestamp, `${name}.timestamp`),
     hash: strategy.hash === undefined ? defaults.hash : assertBoolean(strategy.hash, `${name}.hash`)
   };
+  if (!normalized.timestamp && !normalized.hash) {
+    throw new TypeError(`${name} must enable timestamp or hash validation`);
+  }
+  return normalized;
 }
 
 function normalizeInfrastructureLoggingOptions(
@@ -1247,6 +1281,13 @@ function normalizePath(value: unknown, name: string, context: string): string {
 function assertCacheType(value: unknown): "memory" | "filesystem" {
   if (value !== "memory" && value !== "filesystem") {
     throw new TypeError("options.cache.type must be 'memory' or 'filesystem'");
+  }
+  return value;
+}
+
+function assertMode(value: unknown): Mode {
+  if (value !== "development" && value !== "production" && value !== "none") {
+    throw new TypeError("options.mode must be 'development', 'production', or 'none'");
   }
   return value;
 }

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -205,6 +205,32 @@ test("snapshot module hash detects same-timestamp source edits", async () => {
   }
 });
 
+test("omitted and production mode default module snapshots to timestamp plus hash", async () => {
+  await assertSameTimestampModuleEditEmits("after", {});
+  await assertSameTimestampModuleEditEmits("after", { mode: "production" });
+});
+
+test("development and none default module snapshots to timestamp only", async () => {
+  await assertSameTimestampModuleEditEmits("before", { mode: "development" });
+  await assertSameTimestampModuleEditEmits("before", { mode: "none" });
+});
+
+test("mode does not weaken build dependency snapshot defaults", async () => {
+  await assertSameTimestampBuildDependencyEditEmits({
+    snapshot: {
+      resolveBuildDependencies: { timestamp: true, hash: false }
+    }
+  });
+});
+
+test("mode does not weaken resolve build dependency snapshot defaults", async () => {
+  await assertSameTimestampBuildDependencyEditEmits({
+    snapshot: {
+      buildDependencies: { timestamp: true, hash: false }
+    }
+  });
+});
+
 test("accepts filesystem cache option shape", async () => {
   const fixture = await createFixture({
     "src/index.js": "export const value = 1;",
@@ -688,6 +714,15 @@ test("top-level option validation throws synchronously", () => {
       unpack({
         entry: "./src/index.js",
         // @ts-expect-error intentionally testing runtime validation
+        mode: "staging"
+      }),
+    /options.mode must be 'development', 'production', or 'none'/
+  );
+  assert.throws(
+    () =>
+      unpack({
+        entry: "./src/index.js",
+        // @ts-expect-error intentionally testing runtime validation
         plugins: []
       }),
     /unknown option 'plugins'/
@@ -786,6 +821,70 @@ test("cache and snapshot option validation throws synchronously", () => {
       }),
     /options.snapshot.module.timestamp must be a boolean/
   );
+  assert.doesNotThrow(() =>
+    unpack({
+      entry: "./src/index.js",
+      snapshot: {
+        resolve: {
+          timestamp: false
+        }
+      }
+    })
+  );
+  assert.doesNotThrow(() =>
+    unpack({
+      entry: "./src/index.js",
+      mode: "production",
+      snapshot: {
+        resolve: {
+          timestamp: false
+        }
+      }
+    })
+  );
+  assert.throws(
+    () =>
+      unpack({
+        entry: "./src/index.js",
+        snapshot: {
+          module: {
+            timestamp: false,
+            hash: false
+          }
+        }
+      }),
+    /options.snapshot.module must enable timestamp or hash validation/
+  );
+  assert.throws(
+    () =>
+      unpack({
+        entry: "./src/index.js",
+        mode: "development",
+        snapshot: {
+          resolve: {
+            timestamp: false
+          },
+          resolveBuildDependencies: {
+            timestamp: true,
+            hash: false
+          }
+        }
+      }),
+    /options.snapshot.resolve must enable timestamp or hash validation/
+  );
+  assert.throws(
+    () =>
+      unpack({
+        entry: "./src/index.js",
+        snapshot: {
+          resolveBuildDependencies: {
+            timestamp: false,
+            hash: false
+          }
+        }
+      }),
+    /options.snapshot.resolveBuildDependencies must enable timestamp or hash validation/
+  );
 });
 
 test("watch option validation throws synchronously", async () => {
@@ -866,6 +965,100 @@ test("watch option validation throws synchronously", async () => {
 
 async function runCompiler(options: Parameters<typeof unpack>[0]) {
   return runExistingCompiler(unpack(options));
+}
+
+async function assertSameTimestampModuleEditEmits(
+  expected: string,
+  options: Partial<Parameters<typeof unpack>[0]>
+) {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 'before';"
+  });
+  const entry = join(fixture, "src/index.js");
+  const stableTime = new Date("2020-01-01T00:00:00.000Z");
+  await utimes(entry, stableTime, stableTime);
+  const compiler = unpack({
+    context: fixture,
+    entry: "./src/index.js",
+    cache: true,
+    ...options
+  });
+
+  try {
+    const first = await runExistingCompiler(compiler);
+    assert.equal(first.err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /before/);
+
+    await writeFile(entry, "export const value = 'after';", { encoding: "utf8" });
+    await utimes(entry, stableTime, stableTime);
+
+    const second = await runExistingCompiler(compiler);
+    assert.equal(second.err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), new RegExp(expected));
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+}
+
+async function assertSameTimestampBuildDependencyEditEmits(
+  options: Partial<Parameters<typeof unpack>[0]>
+) {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 'before';",
+    "config/build.js": "export default 'before';"
+  });
+  const entry = join(fixture, "src/index.js");
+  const config = join(fixture, "config/build.js");
+  const cacheLocation = join(fixture, ".cache/unpack/default");
+  const stableTime = new Date("2020-01-01T00:00:00.000Z");
+  await utimes(entry, stableTime, stableTime);
+  await utimes(config, stableTime, stableTime);
+
+  try {
+    const firstCompiler = unpack({
+      context: fixture,
+      mode: "development",
+      entry: "./src/index.js",
+      cache: {
+        type: "filesystem",
+        cacheLocation,
+        buildDependencies: {
+          config: ["./config/build.js"]
+        }
+      },
+      ...options
+    });
+    const first = await runExistingCompiler(firstCompiler);
+    await closeCompiler(firstCompiler);
+    assert.equal(first.err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /before/);
+
+    await writeFile(entry, "export const value = 'after';", { encoding: "utf8" });
+    await writeFile(config, "export default 'after';", { encoding: "utf8" });
+    await utimes(entry, stableTime, stableTime);
+    await utimes(config, stableTime, stableTime);
+
+    const secondCompiler = unpack({
+      context: fixture,
+      mode: "development",
+      entry: "./src/index.js",
+      cache: {
+        type: "filesystem",
+        cacheLocation,
+        buildDependencies: {
+          config: ["./config/build.js"]
+        }
+      },
+      ...options
+    });
+    const second = await runExistingCompiler(secondCompiler);
+    await closeCompiler(secondCompiler);
+    assert.equal(second.err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /after/);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
 }
 
 async function runExistingCompiler(compiler: ReturnType<typeof unpack>) {


### PR DESCRIPTION
## Summary

Adds a standard GitHub Actions CI workflow that runs the repository test suite on pushes to `main`, pull requests, and manual dispatches.

The workflow sets up Rust, pnpm 11.7.0, and Node.js 24, installs JavaScript dependencies with the frozen lockfile, then runs the existing `pnpm test` script so CI matches the repository-defined test entry point.

## Validation

- `pnpm test`