### PR TITLE
Validate resolver cache snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1215,7 @@ version = "0.1.0"
 dependencies = [
  "cbor4ii",
  "codspeed-divan-compat",
+ "filetime",
  "futures",
  "regex",
  "rspack_resolver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/unpack-dev/unpack"
 cbor4ii = { version = "1.2.2", features = ["serde1"] }
 divan = { package = "codspeed-divan-compat", version = "5.0.1" }
 futures = "0.3.31"
+filetime = "0.2.26"
 napi = "3.9.4"
 napi-build = "2.3.2"
 napi-derive = "3.5.7"

--- a/crates/unpack_core/Cargo.toml
+++ b/crates/unpack_core/Cargo.toml
@@ -22,6 +22,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 divan = { workspace = true }
+filetime = { workspace = true }
 tempfile = { workspace = true }
 
 [[bench]]

--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 
 const CACHE_MAGIC: &str = "UNPACK_PERSISTENT_CACHE";
 const PACK_MAGIC: &[u8] = b"UNPACK-CACHE-PACK\0";
-const CACHE_SCHEMA_VERSION: u32 = 5;
+const CACHE_SCHEMA_VERSION: u32 = 6;
 const DEFAULT_PACK_FILE: &str = "packs/modules.cbor";
 const MANIFEST_FILE: &str = "container.json";
 
@@ -181,6 +181,7 @@ pub(crate) struct ResolveRecord {
     identity: ModuleIdentity,
     resource: PathBuf,
     file_dependencies: BTreeSet<PathBuf>,
+    context_dependencies: BTreeSet<PathBuf>,
     missing_dependencies: BTreeSet<PathBuf>,
     snapshot: Snapshot,
 }
@@ -190,16 +191,16 @@ impl ResolveRecord {
         identity: ModuleIdentity,
         resource: PathBuf,
         file_dependencies: BTreeSet<PathBuf>,
+        context_dependencies: BTreeSet<PathBuf>,
         missing_dependencies: BTreeSet<PathBuf>,
         file_system_info: &FileSystemInfo,
         strategy: SnapshotStrategy,
     ) -> crate::Result<Self> {
         let snapshot = file_system_info
-            .create_snapshot(
-                file_dependencies
-                    .iter()
-                    .chain(missing_dependencies.iter())
-                    .cloned(),
+            .create_resolve_snapshot(
+                file_dependencies.iter().cloned(),
+                context_dependencies.iter().cloned(),
+                missing_dependencies.iter().cloned(),
                 strategy,
             )
             .await?;
@@ -207,6 +208,7 @@ impl ResolveRecord {
             identity,
             resource,
             file_dependencies,
+            context_dependencies,
             missing_dependencies,
             snapshot,
         })
@@ -592,6 +594,57 @@ pub(crate) struct BuildCacheStats {
 
 fn resolve_records(inner: &mut BuildCacheInner) -> &mut CacheStore<ResolveRequest, ResolveRecord> {
     &mut inner.resolve_records
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeSet, fs, path::Path};
+
+    use filetime::{FileTime, set_file_mtime};
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::{ModuleIdentity, snapshot::FileSystemInfo};
+
+    #[tokio::test]
+    async fn resolve_record_context_snapshot_invalidates_directory_entry_changes()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempdir()?;
+        let context = temp.path().join("src");
+        let resource = context.join("dep.js");
+        write(&resource, "export const value = 'js';")?;
+        let original_mtime = FileTime::from_system_time(fs::metadata(&context)?.modified()?);
+        let file_system_info = FileSystemInfo::new();
+        let record = ResolveRecord::new(
+            ModuleIdentity::new(resource.clone()),
+            resource,
+            BTreeSet::new(),
+            BTreeSet::from([context.clone()]),
+            BTreeSet::new(),
+            &file_system_info,
+            SnapshotStrategy::timestamp(),
+        )
+        .await?;
+
+        write(context.join("dep.ts"), "export const value = 'ts';")?;
+        set_file_mtime(&context, original_mtime)?;
+
+        assert!(
+            !record
+                .is_valid(&file_system_info, SnapshotStrategy::timestamp())
+                .await
+        );
+
+        Ok(())
+    }
+
+    fn write(path: impl AsRef<Path>, source: &str) -> io::Result<()> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(path, source)
+    }
 }
 
 fn module_builds(

--- a/crates/unpack_core/src/normal_module_factory.rs
+++ b/crates/unpack_core/src/normal_module_factory.rs
@@ -112,6 +112,7 @@ impl NormalModuleFactory {
             identity,
             resource,
             resolved.file_dependencies,
+            resolved.context_dependencies,
             resolved.missing_dependencies,
             &self.file_system_info,
             self.resolve_snapshot_strategy,

--- a/crates/unpack_core/src/resolver.rs
+++ b/crates/unpack_core/src/resolver.rs
@@ -39,6 +39,18 @@ impl UnpackResolver {
             .resolve_with_context(directory, request, &mut context)
             .await
             .map_err(|error| Error::resolve(directory, request, error))?;
+        let file_dependencies = context
+            .file_dependencies
+            .into_iter()
+            .map(|path| normalize_resolver_dependency(path.as_path()))
+            .collect::<BTreeSet<_>>();
+        let missing_dependencies = context
+            .missing_dependencies
+            .into_iter()
+            .map(|path| normalize_resolver_dependency(path.as_path()))
+            .collect::<BTreeSet<_>>();
+        let context_dependencies =
+            context_dependencies(directory, &file_dependencies, &missing_dependencies);
 
         Ok(ResolveResult {
             resource: ResolvedResource {
@@ -46,16 +58,9 @@ impl UnpackResolver {
                 query: resolution.query().map(ToOwned::to_owned),
                 fragment: resolution.fragment().map(ToOwned::to_owned),
             },
-            file_dependencies: context
-                .file_dependencies
-                .into_iter()
-                .map(|path| normalize_resolver_dependency(path.as_path()))
-                .collect(),
-            missing_dependencies: context
-                .missing_dependencies
-                .into_iter()
-                .map(|path| normalize_resolver_dependency(path.as_path()))
-                .collect(),
+            file_dependencies,
+            context_dependencies,
+            missing_dependencies,
         })
     }
 }
@@ -64,6 +69,7 @@ impl UnpackResolver {
 pub struct ResolveResult {
     pub resource: ResolvedResource,
     pub file_dependencies: BTreeSet<PathBuf>,
+    pub context_dependencies: BTreeSet<PathBuf>,
     pub missing_dependencies: BTreeSet<PathBuf>,
 }
 
@@ -98,4 +104,40 @@ fn normalize_resolver_dependency(path: &Path) -> PathBuf {
         Some(file_name) => canonical_parent.join(file_name),
         None => canonical_parent,
     }
+}
+
+fn context_dependencies(
+    search_directory: &Path,
+    file_dependencies: &BTreeSet<PathBuf>,
+    missing_dependencies: &BTreeSet<PathBuf>,
+) -> BTreeSet<PathBuf> {
+    let search_directory = normalize_resolver_dependency(search_directory);
+    file_dependencies
+        .iter()
+        .chain(missing_dependencies.iter())
+        .filter_map(|path| context_dependency(&search_directory, path))
+        .collect()
+}
+
+fn context_dependency(search_directory: &Path, dependency: &Path) -> Option<PathBuf> {
+    if dependency
+        .file_name()
+        .is_some_and(|name| name == "node_modules")
+    {
+        return None;
+    }
+
+    let parent = dependency.parent()?;
+    if !parent.is_dir() {
+        return None;
+    }
+
+    let parent = normalize_resolver_dependency(parent);
+    (parent.starts_with(search_directory) || has_component(&parent, "node_modules"))
+        .then_some(parent)
+}
+
+fn has_component(path: &Path, name: &str) -> bool {
+    path.components()
+        .any(|component| component.as_os_str() == name)
 }

--- a/crates/unpack_core/src/snapshot.rs
+++ b/crates/unpack_core/src/snapshot.rs
@@ -137,12 +137,14 @@ impl FileSystemInfo {
         Snapshot::create_file(path, source, strategy, self).await
     }
 
-    pub(crate) async fn create_snapshot(
+    pub(crate) async fn create_resolve_snapshot(
         &self,
-        paths: impl IntoIterator<Item = PathBuf>,
+        files: impl IntoIterator<Item = PathBuf>,
+        contexts: impl IntoIterator<Item = PathBuf>,
+        missing: impl IntoIterator<Item = PathBuf>,
         strategy: SnapshotStrategy,
     ) -> Result<Snapshot> {
-        Snapshot::create(paths, strategy, self).await
+        Snapshot::create_resolve(files, contexts, missing, strategy, self).await
     }
 
     pub(crate) fn create_snapshot_sync(
@@ -192,7 +194,7 @@ impl FileSystemInfo {
         SnapshotPathClassification::Unclassified
     }
 
-    fn file_snapshot_applies(&self, path: &Path) -> bool {
+    fn ordinary_snapshot_applies(&self, path: &Path) -> bool {
         match self.classify_path(path) {
             SnapshotPathClassification::Unmanaged | SnapshotPathClassification::Unclassified => {
                 true
@@ -244,17 +246,29 @@ impl Snapshot {
         })
     }
 
-    async fn create(
-        paths: impl IntoIterator<Item = PathBuf>,
+    async fn create_resolve(
+        files: impl IntoIterator<Item = PathBuf>,
+        contexts: impl IntoIterator<Item = PathBuf>,
+        missing: impl IntoIterator<Item = PathBuf>,
         strategy: SnapshotStrategy,
         file_system_info: &FileSystemInfo,
     ) -> Result<Self> {
-        let paths = normalize_paths(paths);
-        let mut entries = Vec::with_capacity(paths.len());
-        for path in paths {
+        let files = normalize_paths(files);
+        let contexts = normalize_paths(contexts);
+        let missing = normalize_paths(missing);
+        let mut entries = Vec::with_capacity(files.len() + contexts.len() + missing.len());
+
+        for path in files {
             entries
                 .push(SnapshotEntry::create_file(&path, None, strategy, file_system_info).await?);
         }
+        for path in contexts {
+            entries.push(SnapshotEntry::create_context(&path, strategy, file_system_info).await?);
+        }
+        for path in missing {
+            entries.push(SnapshotEntry::create_missing(&path));
+        }
+
         Ok(Self { entries })
     }
 
@@ -301,6 +315,8 @@ impl Snapshot {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 enum SnapshotEntry {
     File(SnapshottedFile),
+    Context(SnapshottedContext),
+    MissingExistence { path: PathBuf },
     ImmutablePath { path: PathBuf },
     ManagedPath(ManagedPathSnapshot),
 }
@@ -312,18 +328,8 @@ impl SnapshotEntry {
         strategy: SnapshotStrategy,
         file_system_info: &FileSystemInfo,
     ) -> Result<Self> {
-        match file_system_info.classify_path(path) {
-            SnapshotPathClassification::Managed(boundary) => {
-                if let Some(snapshot) = ManagedPathSnapshot::create(path, &boundary) {
-                    return Ok(Self::ManagedPath(snapshot));
-                }
-            }
-            SnapshotPathClassification::Immutable => {
-                return Ok(Self::ImmutablePath {
-                    path: path.to_path_buf(),
-                });
-            }
-            SnapshotPathClassification::Unmanaged | SnapshotPathClassification::Unclassified => {}
+        if let Some(entry) = Self::classified_path_entry(path, file_system_info) {
+            return Ok(entry);
         }
 
         let snapshot = match source {
@@ -341,24 +347,49 @@ impl SnapshotEntry {
         strategy: SnapshotStrategy,
         file_system_info: &FileSystemInfo,
     ) -> Result<Self> {
-        match file_system_info.classify_path(path) {
-            SnapshotPathClassification::Managed(boundary) => {
-                if let Some(snapshot) = ManagedPathSnapshot::create(path, &boundary) {
-                    return Ok(Self::ManagedPath(snapshot));
-                }
-            }
-            SnapshotPathClassification::Immutable => {
-                return Ok(Self::ImmutablePath {
-                    path: path.to_path_buf(),
-                });
-            }
-            SnapshotPathClassification::Unmanaged | SnapshotPathClassification::Unclassified => {}
+        if let Some(entry) = Self::classified_path_entry(path, file_system_info) {
+            return Ok(entry);
         }
 
         Ok(Self::File(SnapshottedFile {
             path: path.to_path_buf(),
             snapshot: FileSnapshot::create_from_file_sync(path, strategy)?,
         }))
+    }
+
+    async fn create_context(
+        path: &Path,
+        strategy: SnapshotStrategy,
+        file_system_info: &FileSystemInfo,
+    ) -> Result<Self> {
+        if let Some(entry) = Self::classified_path_entry(path, file_system_info) {
+            return Ok(entry);
+        }
+
+        Ok(Self::Context(SnapshottedContext {
+            path: path.to_path_buf(),
+            snapshot: ContextSnapshot::create(path, strategy).await?,
+        }))
+    }
+
+    fn create_missing(path: &Path) -> Self {
+        Self::MissingExistence {
+            path: path.to_path_buf(),
+        }
+    }
+
+    fn classified_path_entry(path: &Path, file_system_info: &FileSystemInfo) -> Option<Self> {
+        match file_system_info.classify_path(path) {
+            SnapshotPathClassification::Managed(boundary) => {
+                ManagedPathSnapshot::create(path, &boundary).map(Self::ManagedPath)
+            }
+            SnapshotPathClassification::Immutable => Some(Self::ImmutablePath {
+                path: path.to_path_buf(),
+            }),
+            SnapshotPathClassification::Unmanaged | SnapshotPathClassification::Unclassified => {
+                None
+            }
+        }
     }
 
     async fn is_valid(
@@ -368,8 +399,16 @@ impl SnapshotEntry {
     ) -> bool {
         match self {
             Self::File(file) => {
-                file_system_info.file_snapshot_applies(&file.path)
+                file_system_info.ordinary_snapshot_applies(&file.path)
                     && file.snapshot.is_valid(&file.path, strategy).await
+            }
+            Self::Context(context) => {
+                file_system_info.ordinary_snapshot_applies(&context.path)
+                    && context.snapshot.is_valid(&context.path, strategy).await
+            }
+            Self::MissingExistence { path } => {
+                file_system_info.ordinary_snapshot_applies(path)
+                    && MissingExistenceSnapshot::is_valid(path).await
             }
             Self::ImmutablePath { path } => {
                 file_system_info.classify_path(path) == SnapshotPathClassification::Immutable
@@ -386,8 +425,16 @@ impl SnapshotEntry {
     fn is_valid_sync(&self, strategy: SnapshotStrategy, file_system_info: &FileSystemInfo) -> bool {
         match self {
             Self::File(file) => {
-                file_system_info.file_snapshot_applies(&file.path)
+                file_system_info.ordinary_snapshot_applies(&file.path)
                     && file.snapshot.is_valid_sync(&file.path, strategy)
+            }
+            Self::Context(context) => {
+                file_system_info.ordinary_snapshot_applies(&context.path)
+                    && context.snapshot.is_valid_sync(&context.path, strategy)
+            }
+            Self::MissingExistence { path } => {
+                file_system_info.ordinary_snapshot_applies(path)
+                    && MissingExistenceSnapshot::is_valid_sync(path)
             }
             Self::ImmutablePath { path } => {
                 file_system_info.classify_path(path) == SnapshotPathClassification::Immutable
@@ -399,6 +446,106 @@ impl SnapshotEntry {
                 ) && snapshot.is_valid()
             }
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ContextSnapshot {
+    exists: bool,
+    modified: Option<SystemTime>,
+    entries_hash: Option<u64>,
+}
+
+impl ContextSnapshot {
+    async fn create(path: &Path, strategy: SnapshotStrategy) -> Result<Self> {
+        Self::create_sync(path, strategy)
+    }
+
+    fn create_sync(path: &Path, strategy: SnapshotStrategy) -> Result<Self> {
+        let metadata = match fs::metadata(path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                return Ok(Self {
+                    exists: false,
+                    modified: None,
+                    entries_hash: None,
+                });
+            }
+            Err(error) => return Err(Error::read(path, error)),
+        };
+
+        if !metadata.is_dir() {
+            return Ok(Self {
+                exists: false,
+                modified: None,
+                entries_hash: None,
+            });
+        }
+
+        let modified = if strategy.timestamp {
+            Some(
+                metadata
+                    .modified()
+                    .map_err(|error| Error::read(path, error))?,
+            )
+        } else {
+            None
+        };
+        let entries_hash = (strategy.timestamp || strategy.hash)
+            .then(|| directory_entries_hash(path))
+            .transpose()?;
+
+        Ok(Self {
+            exists: true,
+            modified,
+            entries_hash,
+        })
+    }
+
+    async fn is_valid(&self, path: &Path, strategy: SnapshotStrategy) -> bool {
+        self.is_valid_sync(path, strategy)
+    }
+
+    fn is_valid_sync(&self, path: &Path, strategy: SnapshotStrategy) -> bool {
+        if !self.exists {
+            return matches!(fs::metadata(path), Err(error) if error.kind() == io::ErrorKind::NotFound);
+        }
+
+        let Ok(metadata) = fs::metadata(path) else {
+            return false;
+        };
+        if !metadata.is_dir() {
+            return false;
+        }
+
+        if strategy.timestamp {
+            let Ok(modified) = metadata.modified() else {
+                return false;
+            };
+            if Some(modified) != self.modified {
+                return false;
+            }
+        }
+
+        if (strategy.timestamp || strategy.hash)
+            && directory_entries_hash(path).ok() != self.entries_hash
+        {
+            return false;
+        }
+
+        true
+    }
+}
+
+struct MissingExistenceSnapshot;
+
+impl MissingExistenceSnapshot {
+    async fn is_valid(path: &Path) -> bool {
+        Self::is_valid_sync(path)
+    }
+
+    fn is_valid_sync(path: &Path) -> bool {
+        matches!(fs::metadata(path), Err(error) if error.kind() == io::ErrorKind::NotFound)
     }
 }
 
@@ -614,11 +761,41 @@ struct SnapshottedFile {
     snapshot: FileSnapshot,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct SnapshottedContext {
+    path: PathBuf,
+    snapshot: ContextSnapshot,
+}
+
 fn normalize_paths(paths: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
     let mut paths = paths.into_iter().collect::<Vec<_>>();
     paths.sort();
     paths.dedup();
     paths
+}
+
+fn directory_entries_hash(path: &Path) -> Result<u64> {
+    let mut entries = fs::read_dir(path)
+        .map_err(|error| Error::read(path, error))?
+        .map(|entry| {
+            let entry = entry.map_err(|error| Error::read(path, error))?;
+            let file_type = entry
+                .file_type()
+                .map_err(|error| Error::read(entry.path(), error))?;
+            let kind = if file_type.is_dir() {
+                "d"
+            } else if file_type.is_file() {
+                "f"
+            } else if file_type.is_symlink() {
+                "l"
+            } else {
+                "o"
+            };
+            Ok(format!("{}\0{kind}", entry.file_name().to_string_lossy()))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    entries.sort();
+    Ok(hash_bytes(entries.join("\0").as_bytes()))
 }
 
 fn managed_item_root(path: &Path, boundary: &ManagedPathBoundary) -> Option<PathBuf> {
@@ -721,6 +898,8 @@ fn hash_bytes(source: &[u8]) -> u64 {
 mod tests {
     use std::{fs, path::Path};
 
+    use filetime::{FileTime, set_file_mtime};
+
     use super::*;
 
     #[tokio::test]
@@ -746,6 +925,98 @@ mod tests {
         assert!(
             !file_system_info
                 .is_snapshot_valid(&snapshot, SnapshotStrategy::hash())
+                .await
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn missing_existence_snapshots_invalidate_when_path_appears()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let missing = temp.path().join("dep.ts");
+        let file_system_info = FileSystemInfo::new();
+        let snapshot = file_system_info
+            .create_resolve_snapshot(
+                Vec::new(),
+                Vec::new(),
+                vec![missing.clone()],
+                SnapshotStrategy::timestamp(),
+            )
+            .await?;
+
+        assert!(
+            file_system_info
+                .is_snapshot_valid(&snapshot, SnapshotStrategy::timestamp())
+                .await
+        );
+
+        write(&missing, "export const value = 'ts';")?;
+
+        assert!(
+            !file_system_info
+                .is_snapshot_valid(&snapshot, SnapshotStrategy::timestamp())
+                .await
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn managed_missing_candidates_are_recorded_as_existence_snapshots()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let package_root = temp.path().join("node_modules/pkg");
+        let missing = package_root.join("feature.ts");
+        write(
+            package_root.join("package.json"),
+            r#"{"name":"pkg","version":"1.0.0"}"#,
+        )?;
+        let file_system_info = FileSystemInfo::new();
+        let snapshot = file_system_info
+            .create_resolve_snapshot(
+                Vec::new(),
+                Vec::new(),
+                vec![missing.clone()],
+                SnapshotStrategy::timestamp(),
+            )
+            .await?;
+
+        write(&missing, "export const value = 'ts';")?;
+
+        assert!(
+            !file_system_info
+                .is_snapshot_valid(&snapshot, SnapshotStrategy::timestamp())
+                .await
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn context_timestamp_snapshots_include_directory_entries()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let context = temp.path().join("src");
+        write(context.join("dep.js"), "export const value = 'js';")?;
+        let original_mtime = FileTime::from_system_time(fs::metadata(&context)?.modified()?);
+        let file_system_info = FileSystemInfo::new();
+        let snapshot = file_system_info
+            .create_resolve_snapshot(
+                Vec::new(),
+                vec![context.clone()],
+                Vec::new(),
+                SnapshotStrategy::timestamp(),
+            )
+            .await?;
+
+        write(context.join("dep.ts"), "export const value = 'ts';")?;
+        set_file_mtime(&context, original_mtime)?;
+
+        assert!(
+            !file_system_info
+                .is_snapshot_valid(&snapshot, SnapshotStrategy::timestamp())
                 .await
         );
 

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -231,6 +231,41 @@ test("mode does not weaken resolve build dependency snapshot defaults", async ()
   });
 });
 
+test("resolver snapshots invalidate same-timestamp context candidate additions", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "import { value } from './dep'; export const result = value;",
+    "src/dep.js": "export const value = 'js';"
+  });
+  const sourceRoot = join(fixture, "src");
+  const stableTime = new Date("2020-01-01T00:00:00.000Z");
+  await utimes(sourceRoot, stableTime, stableTime);
+  const compiler = unpack({
+    context: fixture,
+    mode: "development",
+    entry: "./src/index.js",
+    cache: true,
+    snapshot: {
+      resolve: { timestamp: true, hash: false }
+    }
+  });
+
+  try {
+    assert.equal((await runExistingCompiler(compiler)).err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /js/);
+
+    await writeFile(join(sourceRoot, "dep.ts"), "export const value = 'ts';", {
+      encoding: "utf8"
+    });
+    await utimes(sourceRoot, stableTime, stableTime);
+
+    assert.equal((await runExistingCompiler(compiler)).err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /ts/);
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 test("default managed node_modules snapshots invalidate on package version changes", async () => {
   const fixture = await createNodeModulesFixture();
   const moduleFile = join(fixture, "node_modules/pkg/index.js");
@@ -347,6 +382,38 @@ test("immutable path patterns bypass module snapshot file validation", async () 
     await utimes(moduleFile, stableTime, stableTime);
     assert.equal((await runExistingCompiler(compiler)).err, null);
     assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /before/);
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("resolver missing candidates invalidate managed packages", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "import { value } from 'pkg/feature'; export const result = value;",
+    "node_modules/pkg/package.json": JSON.stringify({ name: "pkg", version: "1.0.0" }),
+    "node_modules/pkg/feature.js": "export const value = 'js';"
+  });
+  const packageRoot = join(fixture, "node_modules/pkg");
+  const compiler = unpack({
+    context: fixture,
+    entry: "./src/index.js",
+    cache: true,
+    snapshot: {
+      resolve: { timestamp: true, hash: false }
+    }
+  });
+
+  try {
+    assert.equal((await runExistingCompiler(compiler)).err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /js/);
+
+    await writeFile(join(packageRoot, "feature.ts"), "export const value = 'ts';", {
+      encoding: "utf8"
+    });
+
+    assert.equal((await runExistingCompiler(compiler)).err, null);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /ts/);
   } finally {
     await closeCompiler(compiler);
     await rm(fixture, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- Extends resolve records to store aggregate snapshots for file, context, and missing resolver inputs.
- Adds missing-existence snapshots for resolver candidates, including managed `node_modules` candidates.
- Adds context snapshots with directory-entry digests so same-timestamp candidate additions invalidate cached resolve records.

## Notes

This is stacked on #48 because issue #40 depends on the snapshot path classification work from #39.

Closes #40.

## Validation

- `cargo test -p unpack_core --no-fail-fast`
- `pnpm --filter @unpack-js/core test`
- `pnpm test`
- `git diff --check codex/snapshot-path-classification...HEAD`
