### PR TITLE
Validate persistent cache containers with snapshots

### DIFF
--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 
 const CACHE_MAGIC: &str = "UNPACK_PERSISTENT_CACHE";
 const PACK_MAGIC: &[u8] = b"UNPACK-CACHE-PACK\0";
-const CACHE_SCHEMA_VERSION: u32 = 4;
+const CACHE_SCHEMA_VERSION: u32 = 5;
 const DEFAULT_PACK_FILE: &str = "packs/modules.cbor";
 const MANIFEST_FILE: &str = "container.json";
 
@@ -463,9 +463,9 @@ impl BuildCache {
             cache_version,
             pack_file: pack_file.to_string_lossy().replace('\\', "/"),
             build_dependencies: self
-                .build_dependency_snapshots(self.build_dependency_snapshot_strategy)?,
+                .build_dependency_snapshot(self.build_dependency_snapshot_strategy)?,
             resolve_build_dependencies: self
-                .build_dependency_snapshots(self.resolve_build_dependency_snapshot_strategy)?,
+                .build_dependency_snapshot(self.resolve_build_dependency_snapshot_strategy)?,
         };
         fs::create_dir_all(cache_location)?;
         let manifest_json = serde_json::to_vec_pretty(&manifest)
@@ -478,11 +478,11 @@ impl BuildCache {
         manifest.magic == CACHE_MAGIC
             && manifest.schema_version == CACHE_SCHEMA_VERSION
             && manifest.cache_version == self.cache_version()
-            && self.build_dependency_snapshots_are_valid(
+            && self.build_dependency_snapshot_is_valid(
                 &manifest.build_dependencies,
                 self.build_dependency_snapshot_strategy,
             )
-            && self.build_dependency_snapshots_are_valid(
+            && self.build_dependency_snapshot_is_valid(
                 &manifest.resolve_build_dependencies,
                 self.resolve_build_dependency_snapshot_strategy,
             )
@@ -492,54 +492,38 @@ impl BuildCache {
         self.options.version.clone().unwrap_or_default()
     }
 
-    fn build_dependency_snapshots(
-        &self,
-        strategy: SnapshotStrategy,
-    ) -> io::Result<Vec<PersistentBuildDependencySnapshot>> {
-        self.options
+    fn build_dependency_snapshot(&self, strategy: SnapshotStrategy) -> io::Result<Snapshot> {
+        let snapshots = self
+            .options
             .build_dependencies
             .iter()
             .map(|dependency| {
-                Ok(PersistentBuildDependencySnapshot {
-                    name: dependency.name.clone(),
-                    files: dependency.files.clone(),
-                    snapshot: self
-                        .file_system_info
-                        .create_snapshot_sync(dependency.files.clone(), strategy)
-                        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?,
-                })
+                self.file_system_info
+                    .create_snapshot_sync(dependency.files.clone(), strategy)
+                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
             })
-            .collect()
+            .collect::<io::Result<Vec<_>>>()?;
+
+        Ok(self.file_system_info.merge_snapshots(snapshots.iter()))
     }
 
-    fn build_dependency_snapshots_are_valid(
+    fn build_dependency_snapshot_is_valid(
         &self,
-        snapshots: &[PersistentBuildDependencySnapshot],
+        snapshot: &Snapshot,
         strategy: SnapshotStrategy,
     ) -> bool {
-        if snapshots.len() != self.options.build_dependencies.len() {
-            return false;
-        }
+        snapshot.has_exact_paths(self.build_dependency_paths())
+            && self
+                .file_system_info
+                .is_snapshot_valid_sync(snapshot, strategy)
+    }
 
-        self.options.build_dependencies.iter().all(|dependency| {
-            let Some(snapshot) = snapshots
-                .iter()
-                .find(|snapshot| snapshot.name == dependency.name)
-            else {
-                return false;
-            };
-            if snapshot.files.len() != dependency.files.len() {
-                return false;
-            }
-
-            dependency
-                .files
-                .iter()
-                .all(|path| snapshot.files.contains(path))
-                && self
-                    .file_system_info
-                    .is_snapshot_valid_sync(&snapshot.snapshot, strategy)
-        })
+    fn build_dependency_paths(&self) -> Vec<PathBuf> {
+        self.options
+            .build_dependencies
+            .iter()
+            .flat_map(|dependency| dependency.files.iter().cloned())
+            .collect()
     }
 }
 
@@ -560,15 +544,8 @@ struct CacheManifest {
     schema_version: u32,
     cache_version: String,
     pack_file: String,
-    build_dependencies: Vec<PersistentBuildDependencySnapshot>,
-    resolve_build_dependencies: Vec<PersistentBuildDependencySnapshot>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct PersistentBuildDependencySnapshot {
-    name: String,
-    files: Vec<PathBuf>,
-    snapshot: Snapshot,
+    build_dependencies: Snapshot,
+    resolve_build_dependencies: Snapshot,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -236,6 +236,13 @@ mod tests {
         let manifest = fs::read_to_string(cache_location.join("container.json"))?;
         assert!(manifest.contains("UNPACK_PERSISTENT_CACHE"));
         assert!(manifest.contains("test-version"));
+        let manifest_json: serde_json::Value = serde_json::from_str(&manifest)?;
+        assert!(manifest_json["build_dependencies"].get("files").is_some());
+        assert!(
+            manifest_json["resolve_build_dependencies"]
+                .get("files")
+                .is_some()
+        );
 
         let second_compiler = Compiler::new(options);
         assert_eq!(second_compiler.build_cache.stats().resolve_entries, 2);

--- a/crates/unpack_core/src/snapshot.rs
+++ b/crates/unpack_core/src/snapshot.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     fs, io,
     path::{Path, PathBuf},
     time::SystemTime,
@@ -103,6 +104,13 @@ impl FileSystemInfo {
     ) -> bool {
         snapshot.is_valid_sync(strategy)
     }
+
+    pub(crate) fn merge_snapshots<'a>(
+        &self,
+        snapshots: impl IntoIterator<Item = &'a Snapshot>,
+    ) -> Snapshot {
+        Snapshot::merge(snapshots)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -166,6 +174,29 @@ impl Snapshot {
             }
         }
         true
+    }
+
+    pub(crate) fn has_exact_paths(&self, paths: impl IntoIterator<Item = PathBuf>) -> bool {
+        let paths = normalize_paths(paths);
+        self.files.len() == paths.len()
+            && self
+                .files
+                .iter()
+                .zip(paths.iter())
+                .all(|(file, path)| file.path == *path)
+    }
+
+    fn merge<'a>(snapshots: impl IntoIterator<Item = &'a Snapshot>) -> Self {
+        let mut files = BTreeMap::new();
+        for snapshot in snapshots {
+            for file in &snapshot.files {
+                files.insert(file.path.clone(), file.clone());
+            }
+        }
+
+        Self {
+            files: files.into_values().collect(),
+        }
     }
 }
 
@@ -376,6 +407,47 @@ mod tests {
         assert!(
             !file_system_info
                 .is_snapshot_valid(&snapshot, SnapshotStrategy::hash())
+                .await
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn file_system_info_merges_snapshots_with_path_union_and_later_override()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let shared = temp.path().join("shared.js");
+        let extra = temp.path().join("extra.js");
+        let file_system_info = FileSystemInfo::new();
+
+        write(&shared, "export const value = 'before';")?;
+        let stale_shared = file_system_info
+            .create_snapshot(vec![shared.clone()], SnapshotStrategy::hash())
+            .await?;
+        write(&shared, "export const value = 'after';")?;
+        let fresh_shared = file_system_info
+            .create_snapshot(vec![shared.clone()], SnapshotStrategy::hash())
+            .await?;
+        write(&extra, "export const extra = true;")?;
+        let extra_snapshot = file_system_info
+            .create_snapshot(vec![extra.clone()], SnapshotStrategy::hash())
+            .await?;
+
+        let merged =
+            file_system_info.merge_snapshots([&stale_shared, &extra_snapshot, &fresh_shared]);
+
+        assert!(
+            file_system_info
+                .is_snapshot_valid(&merged, SnapshotStrategy::hash())
+                .await
+        );
+
+        write(&extra, "export const extra = false;")?;
+
+        assert!(
+            !file_system_info
+                .is_snapshot_valid(&merged, SnapshotStrategy::hash())
                 .await
         );
 

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -265,10 +265,16 @@ test("accepts filesystem cache option shape", async () => {
 
     assert.equal(first.err, null);
     assert.equal(first.stats?.hasErrors(), false);
-    assert.match(
-      await readFile(join(fixture, ".cache/unpack/test-cache/container.json"), "utf8"),
-      /UNPACK_PERSISTENT_CACHE/
-    );
+    const manifest = JSON.parse(
+      await readFile(join(fixture, ".cache/unpack/test-cache/container.json"), "utf8")
+    ) as {
+      magic?: string;
+      build_dependencies?: { files?: unknown[] };
+      resolve_build_dependencies?: { files?: unknown[] };
+    };
+    assert.equal(manifest.magic, "UNPACK_PERSISTENT_CACHE");
+    assert.equal(manifest.build_dependencies?.files?.length, 1);
+    assert.equal(manifest.resolve_build_dependencies?.files?.length, 1);
     assert.ok(await readFile(join(fixture, ".cache/unpack/test-cache/packs/modules.cbor")));
 
     const secondCompiler = unpack({


### PR DESCRIPTION
## Summary

- Store persistent cache manifest build-dependency validation as aggregate Snapshot records.
- Store resolve-build-dependency validation at the persistent cache container level.
- Add File System Info snapshot merge support for container snapshot accumulation.
- Cover manifest shape, stale container rejection, and merge behavior with Rust and JavaScript API tests.

## Validation

- `pnpm test`

Closes #41
