### PR TITLE
Align Tokio runtime usage with Rspack

### DIFF
--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -381,7 +381,7 @@ impl BuildTask {
                 return Ok(Vec::new());
             }
         };
-        let parsed = match parse_module_dependencies(self.resource.clone(), source.clone()).await {
+        let parsed = match parse_module_dependencies(&self.resource, &source) {
             Ok(parsed) => parsed,
             Err(error) if error.is_compilation_error() => {
                 state

--- a/crates/unpack_core/src/parser.rs
+++ b/crates/unpack_core/src/parser.rs
@@ -37,17 +37,8 @@ struct ImportBinding {
     local: String,
 }
 
-pub(crate) async fn parse_module_dependencies(
-    path: PathBuf,
-    source: String,
-) -> Result<ParsedModule> {
-    let task_path = path.clone();
-    tokio::task::spawn_blocking(move || parse_module_dependencies_sync(&path, &source))
-        .await
-        .map_err(|error| Error::ParseTask {
-            path: task_path,
-            message: error.to_string(),
-        })?
+pub(crate) fn parse_module_dependencies(path: &Path, source: &str) -> Result<ParsedModule> {
+    parse_module_dependencies_sync(path, source)
 }
 
 fn parse_module_dependencies_sync(path: &Path, source: &str) -> Result<ParsedModule> {

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -1,7 +1,10 @@
 use std::{
     fs,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
 };
 
 use napi::{Env, Result, Task, bindgen_prelude::AsyncTask};
@@ -11,6 +14,8 @@ use unpack_core::{
     InfrastructureLogEvent, InfrastructureLogLevel, InfrastructureLoggingOptions, SnapshotOptions,
     SnapshotStrategy,
 };
+
+const MAX_BLOCKING_THREADS: usize = 4;
 
 #[napi(object)]
 pub struct NativeEntry {
@@ -305,7 +310,13 @@ fn run_compiler_inner(compiler: Option<&Compiler>, output_path: &Path) -> Native
     let Some(compiler) = compiler else {
         return infrastructure_error("CompilerClosedError", "compiler is closed");
     };
-    let runtime = match tokio::runtime::Builder::new_current_thread()
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .max_blocking_threads(MAX_BLOCKING_THREADS)
+        .thread_name_fn(|| {
+            static THREAD_ID: AtomicUsize = AtomicUsize::new(0);
+            let id = THREAD_ID.fetch_add(1, Ordering::SeqCst);
+            format!("unpack-tokio-{id}")
+        })
         .enable_all()
         .build()
     {


### PR DESCRIPTION
## What changed

- Switched the Node binding runtime from a current-thread Tokio runtime to a multi-thread runtime.
- Capped Tokio blocking threads at 4, matching Rspack's runtime configuration.
- Removed parser CPU work from `spawn_blocking` so module parsing runs on worker tasks.
- Kept filesystem reads on Tokio fs, leaving the blocking pool for fs work.

## Why

Callgrind profiling showed Unpack spending measurable instruction count in Tokio scheduling, and an earlier Valgrind run exposed excessive blocking-thread growth when parsing was dispatched through `spawn_blocking`. Rspack caps the blocking pool and does not use it as a general CPU execution pool.

## Impact

This makes Unpack's runtime behavior closer to Rspack for no-cache builds: CPU parsing stays on worker threads, while blocking threads are bounded and reserved for Tokio filesystem work.

## Validation

- `cargo fmt --all --check`
- `cargo test -p unpack_core`
- `cargo test --workspace`
- `pnpm --filter @unpack-js/core test`
- `pnpm --filter @unpack-js/benchmarks test`
