### PR TITLE
Remove persistent cache schema version guard

### DIFF
--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -16,7 +16,6 @@ use serde::{Deserialize, Serialize};
 
 const CACHE_MAGIC: &str = "UNPACK_PERSISTENT_CACHE";
 const PACK_MAGIC: &[u8] = b"UNPACK-CACHE-PACK\0";
-const CACHE_SCHEMA_VERSION: u32 = 6;
 const DEFAULT_PACK_FILE: &str = "packs/modules.cbor";
 const MANIFEST_FILE: &str = "container.json";
 
@@ -412,10 +411,7 @@ impl BuildCache {
         let Some(pack) = read_pack(cache_location, &manifest.pack_file) else {
             return;
         };
-        if pack.magic != CACHE_MAGIC
-            || pack.schema_version != CACHE_SCHEMA_VERSION
-            || pack.cache_version != self.cache_version()
-        {
+        if pack.magic != CACHE_MAGIC || pack.cache_version != self.cache_version() {
             return;
         }
 
@@ -445,7 +441,6 @@ impl BuildCache {
         let cache_version = self.cache_version();
         let pack = CachePackDto {
             magic: CACHE_MAGIC.to_string(),
-            schema_version: CACHE_SCHEMA_VERSION,
             cache_version: cache_version.clone(),
             resolve_records: resolve_records
                 .iter()
@@ -464,7 +459,6 @@ impl BuildCache {
 
         let manifest = CacheManifest {
             magic: CACHE_MAGIC.to_string(),
-            schema_version: CACHE_SCHEMA_VERSION,
             cache_version,
             pack_file: pack_file.to_string_lossy().replace('\\', "/"),
             build_dependencies: self
@@ -481,7 +475,6 @@ impl BuildCache {
 
     fn manifest_is_valid(&self, manifest: &CacheManifest) -> bool {
         manifest.magic == CACHE_MAGIC
-            && manifest.schema_version == CACHE_SCHEMA_VERSION
             && manifest.cache_version == self.cache_version()
             && self.build_dependency_snapshot_is_valid(
                 &manifest.build_dependencies,
@@ -546,7 +539,6 @@ fn read_pack(cache_location: &Path, pack_file: &str) -> Option<CachePackDto> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CacheManifest {
     magic: String,
-    schema_version: u32,
     cache_version: String,
     pack_file: String,
     build_dependencies: Snapshot,
@@ -556,7 +548,6 @@ struct CacheManifest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CachePackDto {
     magic: String,
-    schema_version: u32,
     cache_version: String,
     resolve_records: Vec<(ResolveRequest, ResolveRecord)>,
     module_builds: Vec<(ModuleIdentity, ModuleBuildRecord)>,

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -232,6 +232,8 @@ mod tests {
         let manifest = fs::read_to_string(cache_location.join("container.json"))?;
         assert!(manifest.contains("UNPACK_PERSISTENT_CACHE"));
         assert!(manifest.contains("test-version"));
+        let manifest_json: serde_json::Value = serde_json::from_str(&manifest)?;
+        assert!(manifest_json.get("schema_version").is_none());
 
         let second_compiler = Compiler::new(options);
         assert_eq!(second_compiler.build_cache.stats().resolve_entries, 2);

--- a/docs/adr/0127-remove-persistent-cache-schema-version-guard.md
+++ b/docs/adr/0127-remove-persistent-cache-schema-version-guard.md
@@ -1,0 +1,3 @@
+# Remove persistent cache schema version guard
+
+Unpack persistent cache manifests and cache pack DTOs will not carry a separate cache schema version. Persistent cache containers remain Unpack-private and are guarded by cache magic, pack magic, user cache version, build-dependency snapshots, and DTO deserialization failure; incompatible DTO changes should be handled through Serde compatibility, explicit user cache version changes, or decode rejection rather than a central schema-version constant. This supersedes the schema-version guard portion of ADR 0082 and ADR 0109.

--- a/docs/implementation/snapshot-build-cache-alignment.md
+++ b/docs/implementation/snapshot-build-cache-alignment.md
@@ -87,7 +87,7 @@ Replace file-only snapshots with aggregate snapshot records.
 - Add context snapshots with directory modified time plus stable directory-entry digest in timestamp mode.
 - Add missing existence snapshots that only validate absence/presence.
 - Add snapshot merge with webpack-like map override and set union behavior.
-- Keep the serialized snapshot schema Unpack-private and bump cache schema version when persistent DTOs change.
+- Keep the serialized snapshot schema Unpack-private while relying on cache magic, user cache version, and DTO deserialization failure to reject incompatible persistent cache data.
 
 Done when module, resolve, build-dependency, and resolve-build-dependency validation can all store the same aggregate snapshot type.
 


### PR DESCRIPTION
## Summary

- remove the persistent cache schema-version constant from manifest and pack validation/write paths
- assert filesystem cache manifests no longer include `schema_version`
- document the updated persistent-cache compatibility guard in ADR 0112 and the snapshot/cache implementation note

## Validation

- `cargo test -p unpack_core`
- `pnpm --filter @unpack-js/core test`
