### PR TITLE
Use Rspack-aligned mimalloc allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +568,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1235,6 +1254,7 @@ dependencies = [
 name = "unpack_node"
 version = "0.1.0"
 dependencies = [
+ "mimalloc",
  "napi",
  "napi-build",
  "napi-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ cbor4ii = { version = "1.2.2", features = ["serde1"] }
 divan = { package = "codspeed-divan-compat", version = "5.0.1" }
 futures = "0.3.31"
 filetime = "0.2.26"
+mimalloc = { version = "0.1.48", default-features = false }
 napi = "3.9.4"
 napi-build = "2.3.2"
 napi-derive = "3.5.7"

--- a/crates/unpack_node/Cargo.toml
+++ b/crates/unpack_node/Cargo.toml
@@ -16,5 +16,14 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 unpack_core = { path = "../unpack_core" }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+mimalloc = { workspace = true, features = ["local_dynamic_tls", "v3"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+mimalloc = { workspace = true, features = ["v3"] }
+
+[target.'cfg(all(not(target_os = "linux"), not(target_os = "macos"), not(target_family = "wasm")))'.dependencies]
+mimalloc = { workspace = true, features = ["v3"] }
+
 [build-dependencies]
 napi-build = { workspace = true }

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -15,6 +15,10 @@ use unpack_core::{
     SnapshotPathPattern, SnapshotStrategy,
 };
 
+#[global_allocator]
+#[cfg(not(any(miri, target_family = "wasm")))]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 const MAX_BLOCKING_THREADS: usize = 4;
 
 #[napi(object)]


### PR DESCRIPTION
## What changed

- Added `mimalloc` to the workspace with Rspack `main`'s current version: `0.1.48`.
- Configured `unpack_node` to use mimalloc as the native addon global allocator.
- Matched Rspack's platform feature choices: `v3` everywhere mimalloc is enabled, plus `local_dynamic_tls` on Linux.

## Why

Rspack main uses mimalloc in its native binding allocator path. Aligning Unpack's native addon allocator removes another runtime-level difference from no-cache benchmark comparisons.

## Validation

- `cargo check -p unpack_node`
- `cargo fmt --all --check`
- `cargo test --workspace`
- `pnpm --filter @unpack-js/core test`
- `pnpm --filter @unpack-js/benchmarks test`
