### PR TITLE
Support disabling sourcemap emission

### DIFF
--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -118,6 +118,7 @@ pub(crate) fn create_assets(
                 entry_module,
                 &module_render_ids,
             ),
+            options.sourcemap,
         ));
     }
 
@@ -134,20 +135,27 @@ pub(crate) fn create_assets(
         assets.extend(emit_asset(
             chunk.filename().to_string(),
             render_async_chunk_asset(module_graph, chunk_graph, chunk, &module_render_ids),
+            options.sourcemap,
         ));
     }
 
     assets
 }
 
-fn emit_asset(filename: String, mut source: ConcatSource) -> Vec<Asset> {
+fn emit_asset(filename: String, mut source: ConcatSource, sourcemap: bool) -> Vec<Asset> {
     let map_filename = format!("{filename}.map");
-    source.add(RawStringSource::from(format!(
-        "\n//# sourceMappingURL={map_filename}\n"
-    )));
+    if sourcemap {
+        source.add(RawStringSource::from(format!(
+            "\n//# sourceMappingURL={map_filename}\n"
+        )));
+    }
 
     let mut assets = Vec::new();
-    let mut source_map = source.map(&ObjectPool::default(), &MapOptions::default());
+    let mut source_map = if sourcemap {
+        source.map(&ObjectPool::default(), &MapOptions::default())
+    } else {
+        None
+    };
     if let Some(map) = &mut source_map {
         map.set_file(Some(filename.clone().into()));
     }

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -32,6 +32,7 @@ pub struct CompilerOptions {
     pub snapshot: SnapshotOptions,
     pub infrastructure_logging: InfrastructureLoggingOptions,
     pub parallelism: usize,
+    pub sourcemap: bool,
 }
 
 impl CompilerOptions {
@@ -44,6 +45,7 @@ impl CompilerOptions {
             snapshot: SnapshotOptions::default(),
             infrastructure_logging: InfrastructureLoggingOptions::disabled(),
             parallelism: 100,
+            sourcemap: true,
         }
     }
 }

--- a/crates/unpack_core/tests/codegen.rs
+++ b/crates/unpack_core/tests/codegen.rs
@@ -147,6 +147,46 @@ async fn emits_node_require_chunks_for_dynamic_import() -> Result<(), Box<dyn st
 }
 
 #[tokio::test]
+async fn disables_sourcemap_assets_when_configured() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    write(
+        temp.path().join("src/index.js"),
+        r#"
+            export const value = 42;
+        "#,
+    )?;
+
+    let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./src/index")]);
+    options.sourcemap = false;
+    let compiler = Compiler::new(options);
+    let compilation = compiler.run().await?;
+
+    assert_eq!(compilation.errors(), []);
+    assert_eq!(compilation.assets().len(), 1);
+    assert!(
+        compilation
+            .assets()
+            .iter()
+            .any(|asset| asset.filename == "main.js")
+    );
+    assert!(
+        compilation
+            .assets()
+            .iter()
+            .all(|asset| !asset.filename.ends_with(".map"))
+    );
+
+    let main = compilation
+        .assets()
+        .iter()
+        .find(|asset| asset.filename == "main.js")
+        .expect("main asset should exist");
+    assert!(!main.source.contains("sourceMappingURL"));
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn preserves_import_live_bindings() -> Result<(), Box<dyn std::error::Error>> {
     if !node_available() {
         return Ok(());

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -37,6 +37,7 @@ pub struct NativeCompilerOptions {
     pub snapshot: NativeSnapshotOptions,
     #[napi(js_name = "infrastructureLogging")]
     pub infrastructure_logging: NativeInfrastructureLoggingOptions,
+    pub sourcemap: bool,
 }
 
 #[napi(object)]
@@ -205,6 +206,7 @@ impl NativeCompiler {
         compiler_options.snapshot = snapshot_options_from_native(options.snapshot)?;
         compiler_options.infrastructure_logging =
             infrastructure_logging_options_from_native(options.infrastructure_logging);
+        compiler_options.sourcemap = options.sourcemap;
         let compiler = Compiler::new(compiler_options);
 
         Ok(Self {

--- a/docs/adr/0128-support-boolean-sourcemap-option.md
+++ b/docs/adr/0128-support-boolean-sourcemap-option.md
@@ -1,0 +1,3 @@
+# Support a boolean sourcemap option
+
+The JavaScript API will expose a narrow `sourcemap?: boolean` option. It defaults to `true`, preserving the existing behavior of emitting source map assets and `sourceMappingURL` comments. When set to `false`, asset creation emits only JavaScript assets and omits source map references. This supersedes ADR 0069's first-API constraint while still avoiding webpack's full `devtool` surface until Unpack has a broader source map mode model.

--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -20,6 +20,7 @@ export const adapters = {
         context: fixture.context,
         entry: fixture.entry,
         output: { path: outputDir },
+        sourcemap: false,
         cache: persistentCache
           ? {
               type: "filesystem",

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -9,6 +9,7 @@ export interface UnpackOptions {
   output?: {
     path?: string;
   };
+  sourcemap?: boolean;
   cache?: CacheOptions;
   snapshot?: SnapshotOptions;
   infrastructureLogging?: InfrastructureLoggingOptions;
@@ -122,6 +123,7 @@ interface NormalizedOptions {
   context: string;
   entries: NormalizedEntry[];
   outputPath: string;
+  sourcemap: boolean;
   cache: NormalizedCacheOptions;
   snapshot: NormalizedSnapshotOptions;
   infrastructureLogging: NormalizedInfrastructureLoggingOptions;
@@ -807,7 +809,16 @@ function normalizeOptions(options: UnpackOptions): NormalizedOptions {
   assertPlainObject(options, "options");
   assertKnownKeys(
     options,
-    ["context", "mode", "entry", "output", "cache", "snapshot", "infrastructureLogging"],
+    [
+      "context",
+      "mode",
+      "entry",
+      "output",
+      "sourcemap",
+      "cache",
+      "snapshot",
+      "infrastructureLogging"
+    ],
     "options"
   );
 
@@ -833,6 +844,10 @@ function normalizeOptions(options: UnpackOptions): NormalizedOptions {
     context: normalizedContext,
     entries: normalizeEntry(options.entry),
     outputPath,
+    sourcemap:
+      options.sourcemap === undefined
+        ? true
+        : assertBoolean(options.sourcemap, "options.sourcemap"),
     cache: normalizeCacheOptions(options.cache, normalizedContext),
     snapshot: normalizeSnapshotOptions(options.snapshot, mode),
     infrastructureLogging: normalizeInfrastructureLoggingOptions(options.infrastructureLogging)

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -60,6 +60,32 @@ test("supports object entries", async () => {
   }
 });
 
+test("can disable sourcemap emission", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 42;"
+  });
+
+  try {
+    const { err, stats } = await runCompiler({
+      context: fixture,
+      entry: "./src/index.js",
+      sourcemap: false
+    });
+
+    assert.equal(err, null);
+    assert.ok(stats);
+    assert.deepEqual(
+      stats.toJson().assets.map((asset) => asset.name).sort(),
+      ["main.js"]
+    );
+    const main = await readFile(join(fixture, "dist/main.js"), "utf8");
+    await assert.rejects(readFile(join(fixture, "dist/main.js.map"), "utf8"));
+    assert.doesNotMatch(main, /sourceMappingURL/);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 test("unpack options callback closes the returned compiler", async () => {
   const fixture = await createFixture({
     "src/index.js": "export const value = 1;"
@@ -952,6 +978,15 @@ test("top-level option validation throws synchronously", () => {
         mode: "staging"
       }),
     /options.mode must be 'development', 'production', or 'none'/
+  );
+  assert.throws(
+    () =>
+      unpack({
+        entry: "./src/index.js",
+        // @ts-expect-error intentionally testing runtime validation
+        sourcemap: "hidden"
+      }),
+    /options.sourcemap must be a boolean/
   );
   assert.throws(
     () =>


### PR DESCRIPTION
## What changed

- Added a narrow `sourcemap?: boolean` JavaScript API option that defaults to `true`.
- Threaded the option through the N-API boundary into `CompilerOptions`.
- Skipped `.map` asset creation and `sourceMappingURL` comments when `sourcemap: false`.
- Updated the Unpack benchmark adapter to pass `sourcemap: false`, matching the other benchmark adapters.
- Added ADR 0128 to supersede the first-API decision that deferred sourcemap configurability.

## Why

Benchmarks already disable sourcemaps for webpack, Rspack, Turbopack, and Rolldown. Unpack previously always emitted sourcemaps, so no-cache benchmark comparisons included extra source map work for Unpack only.

## Impact

Existing users keep the current default behavior. Callers that set `sourcemap: false` get only JavaScript assets, without source map files or source map reference comments.

## Validation

- `cargo fmt --all --check`
- `cargo test -p unpack_core --test codegen`
- `pnpm --filter @unpack-js/core test`
- `cargo test --workspace`
- `pnpm --filter @unpack-js/benchmarks test`
