### PR TITLE
Cache resolver dependency path lookups

### DIFF
--- a/crates/unpack_core/src/resolver.rs
+++ b/crates/unpack_core/src/resolver.rs
@@ -1,8 +1,9 @@
 use std::{
     collections::BTreeSet,
+    collections::HashMap,
     fs,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use crate::{Error, ModuleIdentity, Result};
@@ -12,12 +13,20 @@ pub use rspack_resolver::ResolveOptions;
 #[derive(Debug, Clone)]
 pub struct UnpackResolver {
     inner: Arc<rspack_resolver::Resolver>,
+    path_cache: Arc<Mutex<PathResolutionCache>>,
+}
+
+#[derive(Debug, Default)]
+struct PathResolutionCache {
+    normalized: HashMap<PathBuf, PathBuf>,
+    is_dir: HashMap<PathBuf, bool>,
 }
 
 impl UnpackResolver {
     pub fn new(options: ResolveOptions) -> Self {
         Self {
             inner: Arc::new(rspack_resolver::Resolver::new(options)),
+            path_cache: Arc::new(Mutex::new(PathResolutionCache::default())),
         }
     }
 
@@ -42,15 +51,15 @@ impl UnpackResolver {
         let file_dependencies = context
             .file_dependencies
             .into_iter()
-            .map(|path| normalize_resolver_dependency(path.as_path()))
+            .map(|path| self.normalize_resolver_dependency(path.as_path()))
             .collect::<BTreeSet<_>>();
         let missing_dependencies = context
             .missing_dependencies
             .into_iter()
-            .map(|path| normalize_resolver_dependency(path.as_path()))
+            .map(|path| self.normalize_resolver_dependency(path.as_path()))
             .collect::<BTreeSet<_>>();
         let context_dependencies =
-            context_dependencies(directory, &file_dependencies, &missing_dependencies);
+            self.context_dependencies(directory, &file_dependencies, &missing_dependencies);
 
         Ok(ResolveResult {
             resource: ResolvedResource {
@@ -62,6 +71,84 @@ impl UnpackResolver {
             context_dependencies,
             missing_dependencies,
         })
+    }
+
+    fn normalize_resolver_dependency(&self, path: &Path) -> PathBuf {
+        if let Some(cached) = self
+            .path_cache
+            .lock()
+            .expect("resolver path cache mutex should not be poisoned")
+            .normalized
+            .get(path)
+            .cloned()
+        {
+            return cached;
+        }
+
+        let normalized = normalize_resolver_dependency_uncached(path);
+        let mut cache = self
+            .path_cache
+            .lock()
+            .expect("resolver path cache mutex should not be poisoned");
+        cache
+            .normalized
+            .entry(path.to_path_buf())
+            .or_insert_with(|| normalized.clone())
+            .clone()
+    }
+
+    fn path_is_dir(&self, path: &Path) -> bool {
+        if let Some(is_dir) = self
+            .path_cache
+            .lock()
+            .expect("resolver path cache mutex should not be poisoned")
+            .is_dir
+            .get(path)
+            .copied()
+        {
+            return is_dir;
+        }
+
+        let is_dir = path.is_dir();
+        self.path_cache
+            .lock()
+            .expect("resolver path cache mutex should not be poisoned")
+            .is_dir
+            .entry(path.to_path_buf())
+            .or_insert(is_dir);
+        is_dir
+    }
+
+    fn context_dependencies(
+        &self,
+        search_directory: &Path,
+        file_dependencies: &BTreeSet<PathBuf>,
+        missing_dependencies: &BTreeSet<PathBuf>,
+    ) -> BTreeSet<PathBuf> {
+        let search_directory = self.normalize_resolver_dependency(search_directory);
+        file_dependencies
+            .iter()
+            .chain(missing_dependencies.iter())
+            .filter_map(|path| self.context_dependency(&search_directory, path))
+            .collect()
+    }
+
+    fn context_dependency(&self, search_directory: &Path, dependency: &Path) -> Option<PathBuf> {
+        if dependency
+            .file_name()
+            .is_some_and(|name| name == "node_modules")
+        {
+            return None;
+        }
+
+        let parent = dependency.parent()?;
+        if !self.path_is_dir(parent) {
+            return None;
+        }
+
+        let parent = self.normalize_resolver_dependency(parent);
+        (parent.starts_with(search_directory) || has_component(&parent, "node_modules"))
+            .then_some(parent)
     }
 }
 
@@ -89,7 +176,7 @@ impl From<ResolvedResource> for ModuleIdentity {
     }
 }
 
-fn normalize_resolver_dependency(path: &Path) -> PathBuf {
+fn normalize_resolver_dependency_uncached(path: &Path) -> PathBuf {
     if let Ok(canonical) = fs::canonicalize(path) {
         return canonical;
     }
@@ -104,37 +191,6 @@ fn normalize_resolver_dependency(path: &Path) -> PathBuf {
         Some(file_name) => canonical_parent.join(file_name),
         None => canonical_parent,
     }
-}
-
-fn context_dependencies(
-    search_directory: &Path,
-    file_dependencies: &BTreeSet<PathBuf>,
-    missing_dependencies: &BTreeSet<PathBuf>,
-) -> BTreeSet<PathBuf> {
-    let search_directory = normalize_resolver_dependency(search_directory);
-    file_dependencies
-        .iter()
-        .chain(missing_dependencies.iter())
-        .filter_map(|path| context_dependency(&search_directory, path))
-        .collect()
-}
-
-fn context_dependency(search_directory: &Path, dependency: &Path) -> Option<PathBuf> {
-    if dependency
-        .file_name()
-        .is_some_and(|name| name == "node_modules")
-    {
-        return None;
-    }
-
-    let parent = dependency.parent()?;
-    if !parent.is_dir() {
-        return None;
-    }
-
-    let parent = normalize_resolver_dependency(parent);
-    (parent.starts_with(search_directory) || has_component(&parent, "node_modules"))
-        .then_some(parent)
 }
 
 fn has_component(path: &Path, name: &str) -> bool {


### PR DESCRIPTION
## Summary

- Cache normalized resolver dependency paths within `UnpackResolver`.
- Cache parent-directory `is_dir` checks used while deriving context dependencies.

## Why

The make phase repeatedly normalizes the same resolver dependency paths and checks the same parent directories while collecting file, missing, and context dependencies. Keeping that memoization local to the resolver preserves behavior while reducing repeated filesystem work.

## Validation

- `cargo test -p unpack_core`
