### PR TITLE
Reduce make phase bookkeeping overhead

### DIFF
--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -103,9 +103,15 @@ impl Compilation {
             self.entries = std::mem::take(&mut state.entries).into_values().collect();
             self.errors = std::mem::take(&mut state.errors);
             self.watch_dependencies = WatchDependencies {
-                files: std::mem::take(&mut state.file_dependencies),
-                contexts: std::mem::take(&mut state.context_dependencies),
-                missing: std::mem::take(&mut state.missing_dependencies),
+                files: std::mem::take(&mut state.file_dependencies)
+                    .into_iter()
+                    .collect(),
+                contexts: std::mem::take(&mut state.context_dependencies)
+                    .into_iter()
+                    .collect(),
+                missing: std::mem::take(&mut state.missing_dependencies)
+                    .into_iter()
+                    .collect(),
             };
 
             if result.is_ok() {

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -23,9 +23,9 @@ pub(crate) struct MakeState {
     pub module_graph: ModuleGraph,
     pub entries: BTreeMap<usize, ModuleId>,
     pub errors: Vec<Error>,
-    pub file_dependencies: BTreeSet<PathBuf>,
-    pub context_dependencies: BTreeSet<PathBuf>,
-    pub missing_dependencies: BTreeSet<PathBuf>,
+    pub file_dependencies: HashSet<PathBuf>,
+    pub context_dependencies: HashSet<PathBuf>,
+    pub missing_dependencies: HashSet<PathBuf>,
     modules_by_identity: HashMap<ModuleIdentity, ModuleId>,
 }
 
@@ -373,7 +373,7 @@ impl BuildTask {
             }
         }
 
-        let source = match tokio::fs::read_to_string(&self.resource).await {
+        let source = match std::fs::read_to_string(&self.resource) {
             Ok(source) => source,
             Err(error) => {
                 let error = Error::read(&self.resource, error);


### PR DESCRIPTION
## Summary

- Use `HashSet` for make-phase watch dependency accumulation, then convert to the public sorted sets when finalizing the compilation.
- Read module source with `std::fs::read_to_string` in build tasks to avoid per-small-file tokio fs scheduling overhead.

## Why

The benchmark fixtures read many tiny JavaScript files and insert many repeated watch dependencies. These changes keep the observable sorted watch dependency API while making the hot make path cheaper.

## Validation

- `cargo test -p unpack_core`
