### PR TITLE
Align unpack benchmark mode

### DIFF
--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -17,6 +17,7 @@ export const adapters = {
     async build({ fixture, outputDir, cacheDir, persistentCache = true }) {
       const { default: unpack } = await import("@unpack-js/core");
       const compiler = unpack({
+        mode: "none",
         context: fixture.context,
         entry: fixture.entry,
         output: { path: outputDir },


### PR DESCRIPTION
## Summary

- Set `mode: "none"` in the Unpack cross-bundler adapter.

## Why

The benchmark already runs webpack/rspack in `mode: "none"`. Passing the same mode to Unpack keeps snapshot defaults and benchmark semantics aligned across webpack-compatible adapters.

## Validation

- `pnpm --filter @unpack-js/benchmarks test`
