### PR TITLE
Run cross-bundler benchmarks on main

### DIFF
--- a/.github/workflows/cross-bundler-benchmark.yml
+++ b/.github/workflows/cross-bundler-benchmark.yml
@@ -1,6 +1,9 @@
 name: Cross-Bundler Benchmarks
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -51,7 +51,7 @@ Runtime verification is separate from build timing. A Bundle that builds but doe
 
 ## CI
 
-The `Cross-Bundler Benchmarks` workflow runs on pull requests and manual dispatch. It writes the table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, and uploads the JSON report as an artifact.
+The `Cross-Bundler Benchmarks` workflow runs on pushes to `main`, pull requests, and manual dispatch. It writes the table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, and uploads the JSON report as an artifact.
 
 The workflow builds the Unpack native addon with `UNPACK_NATIVE_PROFILE=release` so benchmark results compare optimized native builds.
 


### PR DESCRIPTION
## Summary

- Run the Cross-Bundler Benchmarks workflow on pushes to `main`.
- Keep the existing pull request and manual dispatch triggers.
- Update the benchmark implementation docs to match the CI trigger behavior.

## Impact

Merges to `main` will now produce cross-bundler benchmark summaries and upload the raw benchmark artifact, giving maintainers a post-merge signal in addition to PR and manual runs.

## Validation

- `git diff --check HEAD~1 HEAD`
