### PR TITLE
Speed up no-cache builds

### DIFF
--- a/crates/unpack_core/src/chunk_graph.rs
+++ b/crates/unpack_core/src/chunk_graph.rs
@@ -174,6 +174,7 @@ impl ChunkGraph {
     ) -> Self {
         let mut graph = Self::default();
         let mut async_groups_by_target = HashMap::new();
+        let render_context = RenderPathContext::new(options.context.as_path());
 
         for (entry_index, entry_module) in entries.iter().copied().enumerate() {
             let entry_name = options
@@ -229,8 +230,7 @@ impl ChunkGraph {
                 {
                     group
                 } else {
-                    let render_id =
-                        chunk_render_id(options.context.as_path(), module_graph, target);
+                    let render_id = chunk_render_id(&render_context, module_graph, target);
                     let chunk = graph.add_chunk(render_id.clone(), format!("{render_id}.js"));
                     let group = graph.add_chunk_group(ChunkGroupKind::Async, Some(origin));
                     graph.connect_chunk_and_group(chunk, group);
@@ -379,20 +379,49 @@ fn import_block_target(module_graph: &ModuleGraph, origin: AsyncBlockOrigin) -> 
         .map(|connection| connection.module)
 }
 
-fn chunk_render_id(context: &Path, module_graph: &ModuleGraph, module: ModuleId) -> String {
+fn chunk_render_id(
+    context: &RenderPathContext,
+    module_graph: &ModuleGraph,
+    module: ModuleId,
+) -> String {
     let resource = module_graph
         .module(module)
         .map(|module| module.identity().resource.as_path())
         .unwrap_or_else(|| Path::new("chunk"));
-    let relative = make_relative(context, resource);
+    let relative = context.make_relative(resource);
     sanitize_chunk_id(&relative)
 }
 
-fn make_relative(context: &Path, resource: &Path) -> String {
-    let context = std::fs::canonicalize(context).unwrap_or_else(|_| context.to_path_buf());
-    let resource = std::fs::canonicalize(resource).unwrap_or_else(|_| PathBuf::from(resource));
-    let relative = resource.strip_prefix(&context).unwrap_or(&resource);
-    relative.to_string_lossy().replace('\\', "/")
+#[derive(Debug, Clone)]
+struct RenderPathContext {
+    raw_context: PathBuf,
+    context: PathBuf,
+}
+
+impl RenderPathContext {
+    fn new(context: &Path) -> Self {
+        Self {
+            raw_context: context.to_path_buf(),
+            context: std::fs::canonicalize(context).unwrap_or_else(|_| context.to_path_buf()),
+        }
+    }
+
+    fn make_relative(&self, resource: &Path) -> String {
+        if let Ok(relative) = resource
+            .strip_prefix(&self.context)
+            .or_else(|_| resource.strip_prefix(&self.raw_context))
+        {
+            return normalize_path(relative);
+        }
+
+        let resource = std::fs::canonicalize(resource).unwrap_or_else(|_| PathBuf::from(resource));
+        let relative = resource.strip_prefix(&self.context).unwrap_or(&resource);
+        normalize_path(relative)
+    }
+}
+
+fn normalize_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
 }
 
 fn sanitize_chunk_id(relative: &str) -> String {

--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -349,12 +349,12 @@ fn render_module_factory(
             &mut init_fragments,
         );
     }
-    for (dependency_index, dependency) in module.dependencies().iter().enumerate() {
+    for (dependency_id, dependency) in module.dependencies().iter().enumerate() {
         apply_dependency_template(
             dependency,
             module_id,
             None,
-            Some(dependency_index),
+            Some(dependency_id),
             module_graph,
             chunk_graph,
             module.exports_info(),
@@ -364,12 +364,12 @@ fn render_module_factory(
         );
     }
     for (block_index, block) in module.blocks().iter().enumerate() {
-        for (dependency_index, dependency) in block.dependencies().iter().enumerate() {
+        for (dependency_id, dependency) in block.dependencies().iter().enumerate() {
             apply_dependency_template(
                 dependency,
                 module_id,
                 Some(block_index),
-                Some(dependency_index),
+                Some(dependency_id),
                 module_graph,
                 chunk_graph,
                 module.exports_info(),
@@ -424,7 +424,7 @@ fn apply_dependency_template(
     dependency: &Dependency,
     module_id: ModuleId,
     origin_block: Option<usize>,
-    dependency_index: Option<usize>,
+    dependency_id: Option<usize>,
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
     exports_info: &ExportsInfo,
@@ -439,7 +439,7 @@ fn apply_dependency_template(
         Dependency::HarmonyImportSideEffect(dep) => apply_harmony_import_side_effect_dependency(
             dep,
             module_id,
-            dependency_index,
+            dependency_id,
             module_graph,
             module_render_ids,
             init_fragments,
@@ -447,7 +447,7 @@ fn apply_dependency_template(
         Dependency::HarmonyImportSpecifier(dep) => apply_harmony_import_specifier_dependency(
             dep,
             module_id,
-            dependency_index,
+            dependency_id,
             module_graph,
             module_render_ids,
             source,
@@ -462,7 +462,7 @@ fn apply_dependency_template(
             apply_harmony_export_imported_specifier_dependency(
                 dep,
                 module_id,
-                dependency_index,
+                dependency_id,
                 module_graph,
                 exports_info,
                 module_render_ids,
@@ -473,7 +473,7 @@ fn apply_dependency_template(
             dep,
             module_id,
             origin_block,
-            dependency_index,
+            dependency_id,
             module_graph,
             chunk_graph,
             module_render_ids,
@@ -502,15 +502,15 @@ fn apply_export_header_dependency(dep: &HarmonyExportHeaderDependency, source: &
 fn apply_harmony_import_side_effect_dependency(
     dep: &HarmonyImportSideEffectDependency,
     module_id: ModuleId,
-    dependency_index: Option<usize>,
+    dependency_id: Option<usize>,
     module_graph: &ModuleGraph,
     module_render_ids: &HashMap<ModuleId, String>,
     init_fragments: &mut Vec<InitFragment>,
 ) {
-    let Some(dependency_index) = dependency_index else {
+    let Some(dependency_id) = dependency_id else {
         return;
     };
-    let Some(target) = module_graph.module_for_dependency(module_id, None, dependency_index) else {
+    let Some(target) = module_graph.module_for_dependency(module_id, None, dependency_id) else {
         return;
     };
     let import_var = import_var(&dep.module.request, dep.module.source_order.unwrap_or(0));
@@ -525,16 +525,15 @@ fn apply_harmony_import_side_effect_dependency(
 fn apply_harmony_import_specifier_dependency(
     dep: &HarmonyImportSpecifierDependency,
     module_id: ModuleId,
-    dependency_index: Option<usize>,
+    dependency_id: Option<usize>,
     module_graph: &ModuleGraph,
     module_render_ids: &HashMap<ModuleId, String>,
     source: &mut ReplaceSource,
 ) {
-    let Some(dependency_index) = dependency_index else {
+    let Some(dependency_id) = dependency_id else {
         return;
     };
-    let Some(_target) = module_graph.module_for_dependency(module_id, None, dependency_index)
-    else {
+    let Some(_target) = module_graph.module_for_dependency(module_id, None, dependency_id) else {
         return;
     };
     let expression = import_expression(
@@ -605,17 +604,16 @@ fn apply_harmony_export_expression_dependency(
 fn apply_harmony_export_imported_specifier_dependency(
     dep: &HarmonyExportImportedSpecifierDependency,
     module_id: ModuleId,
-    dependency_index: Option<usize>,
+    dependency_id: Option<usize>,
     module_graph: &ModuleGraph,
     exports_info: &ExportsInfo,
     module_render_ids: &HashMap<ModuleId, String>,
     init_fragments: &mut Vec<InitFragment>,
 ) {
-    let Some(dependency_index) = dependency_index else {
+    let Some(dependency_id) = dependency_id else {
         return;
     };
-    let Some(_target) = module_graph.module_for_dependency(module_id, None, dependency_index)
-    else {
+    let Some(_target) = module_graph.module_for_dependency(module_id, None, dependency_id) else {
         return;
     };
     let import_var = import_var(&dep.module.request, dep.module.source_order.unwrap_or(0));
@@ -646,7 +644,7 @@ fn apply_import_dependency(
     dep: &ImportDependency,
     module_id: ModuleId,
     origin_block: Option<usize>,
-    dependency_index: Option<usize>,
+    dependency_id: Option<usize>,
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
     module_render_ids: &HashMap<ModuleId, String>,
@@ -655,11 +653,11 @@ fn apply_import_dependency(
     let Some(block_index) = origin_block else {
         return;
     };
-    let Some(dependency_index) = dependency_index else {
+    let Some(dependency_id) = dependency_id else {
         return;
     };
     let Some(target) =
-        module_graph.module_for_dependency(module_id, Some(block_index), dependency_index)
+        module_graph.module_for_dependency(module_id, Some(block_index), dependency_id)
     else {
         return;
     };

--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -94,7 +94,8 @@ pub(crate) fn create_assets(
     chunk_graph: &ChunkGraph,
     entries: &[ModuleId],
 ) -> Vec<Asset> {
-    let module_render_ids = module_render_ids(options.context.as_path(), module_graph);
+    let render_context = RenderPathContext::new(options.context.as_path());
+    let module_render_ids = module_render_ids(&render_context, module_graph);
     let mut assets = Vec::new();
 
     for (entry_index, group_id) in chunk_graph.entrypoints().iter().copied().enumerate() {
@@ -329,8 +330,8 @@ fn render_module_factory(
     let module_id = module.id();
     let module_render_id = &module_render_ids[&module_id];
     let mut source = ReplaceSource::new(OriginalSource::new(
-        module.source().to_string(),
-        module_render_id.to_string(),
+        module.source(),
+        module_render_id.as_str(),
     ));
     let mut init_fragments = Vec::new();
 
@@ -338,6 +339,7 @@ fn render_module_factory(
         apply_dependency_template(
             dependency,
             module_id,
+            None,
             None,
             module_graph,
             chunk_graph,
@@ -347,11 +349,12 @@ fn render_module_factory(
             &mut init_fragments,
         );
     }
-    for dependency in module.dependencies() {
+    for (dependency_index, dependency) in module.dependencies().iter().enumerate() {
         apply_dependency_template(
             dependency,
             module_id,
             None,
+            Some(dependency_index),
             module_graph,
             chunk_graph,
             module.exports_info(),
@@ -361,11 +364,12 @@ fn render_module_factory(
         );
     }
     for (block_index, block) in module.blocks().iter().enumerate() {
-        for dependency in block.dependencies() {
+        for (dependency_index, dependency) in block.dependencies().iter().enumerate() {
             apply_dependency_template(
                 dependency,
                 module_id,
                 Some(block_index),
+                Some(dependency_index),
                 module_graph,
                 chunk_graph,
                 module.exports_info(),
@@ -420,6 +424,7 @@ fn apply_dependency_template(
     dependency: &Dependency,
     module_id: ModuleId,
     origin_block: Option<usize>,
+    dependency_index: Option<usize>,
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
     exports_info: &ExportsInfo,
@@ -434,6 +439,7 @@ fn apply_dependency_template(
         Dependency::HarmonyImportSideEffect(dep) => apply_harmony_import_side_effect_dependency(
             dep,
             module_id,
+            dependency_index,
             module_graph,
             module_render_ids,
             init_fragments,
@@ -441,6 +447,7 @@ fn apply_dependency_template(
         Dependency::HarmonyImportSpecifier(dep) => apply_harmony_import_specifier_dependency(
             dep,
             module_id,
+            dependency_index,
             module_graph,
             module_render_ids,
             source,
@@ -455,6 +462,7 @@ fn apply_dependency_template(
             apply_harmony_export_imported_specifier_dependency(
                 dep,
                 module_id,
+                dependency_index,
                 module_graph,
                 exports_info,
                 module_render_ids,
@@ -465,6 +473,7 @@ fn apply_dependency_template(
             dep,
             module_id,
             origin_block,
+            dependency_index,
             module_graph,
             chunk_graph,
             module_render_ids,
@@ -493,15 +502,15 @@ fn apply_export_header_dependency(dep: &HarmonyExportHeaderDependency, source: &
 fn apply_harmony_import_side_effect_dependency(
     dep: &HarmonyImportSideEffectDependency,
     module_id: ModuleId,
+    dependency_index: Option<usize>,
     module_graph: &ModuleGraph,
     module_render_ids: &HashMap<ModuleId, String>,
     init_fragments: &mut Vec<InitFragment>,
 ) {
-    let Some(target) = module_graph.module_for_dependency(
-        module_id,
-        None,
-        &Dependency::HarmonyImportSideEffect(dep.clone()),
-    ) else {
+    let Some(dependency_index) = dependency_index else {
+        return;
+    };
+    let Some(target) = module_graph.module_for_dependency(module_id, None, dependency_index) else {
         return;
     };
     let import_var = import_var(&dep.module.request, dep.module.source_order.unwrap_or(0));
@@ -516,15 +525,16 @@ fn apply_harmony_import_side_effect_dependency(
 fn apply_harmony_import_specifier_dependency(
     dep: &HarmonyImportSpecifierDependency,
     module_id: ModuleId,
+    dependency_index: Option<usize>,
     module_graph: &ModuleGraph,
     module_render_ids: &HashMap<ModuleId, String>,
     source: &mut ReplaceSource,
 ) {
-    let Some(_target) = module_graph.module_for_dependency(
-        module_id,
-        None,
-        &Dependency::HarmonyImportSpecifier(dep.clone()),
-    ) else {
+    let Some(dependency_index) = dependency_index else {
+        return;
+    };
+    let Some(_target) = module_graph.module_for_dependency(module_id, None, dependency_index)
+    else {
         return;
     };
     let expression = import_expression(
@@ -595,13 +605,17 @@ fn apply_harmony_export_expression_dependency(
 fn apply_harmony_export_imported_specifier_dependency(
     dep: &HarmonyExportImportedSpecifierDependency,
     module_id: ModuleId,
+    dependency_index: Option<usize>,
     module_graph: &ModuleGraph,
     exports_info: &ExportsInfo,
     module_render_ids: &HashMap<ModuleId, String>,
     init_fragments: &mut Vec<InitFragment>,
 ) {
-    let dependency = Dependency::HarmonyExportImportedSpecifier(dep.clone());
-    let Some(_target) = module_graph.module_for_dependency(module_id, None, &dependency) else {
+    let Some(dependency_index) = dependency_index else {
+        return;
+    };
+    let Some(_target) = module_graph.module_for_dependency(module_id, None, dependency_index)
+    else {
         return;
     };
     let import_var = import_var(&dep.module.request, dep.module.source_order.unwrap_or(0));
@@ -632,6 +646,7 @@ fn apply_import_dependency(
     dep: &ImportDependency,
     module_id: ModuleId,
     origin_block: Option<usize>,
+    dependency_index: Option<usize>,
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
     module_render_ids: &HashMap<ModuleId, String>,
@@ -640,9 +655,11 @@ fn apply_import_dependency(
     let Some(block_index) = origin_block else {
         return;
     };
-    let dependency = Dependency::Import(dep.clone());
+    let Some(dependency_index) = dependency_index else {
+        return;
+    };
     let Some(target) =
-        module_graph.module_for_dependency(module_id, Some(block_index), &dependency)
+        module_graph.module_for_dependency(module_id, Some(block_index), dependency_index)
     else {
         return;
     };
@@ -674,7 +691,38 @@ fn replace(source: &mut ReplaceSource, range: SourceRange, content: String) {
     source.replace(range.start, range.end, content, None);
 }
 
-fn module_render_ids(context: &Path, module_graph: &ModuleGraph) -> HashMap<ModuleId, String> {
+#[derive(Debug, Clone)]
+struct RenderPathContext {
+    raw_context: PathBuf,
+    context: PathBuf,
+}
+
+impl RenderPathContext {
+    fn new(context: &Path) -> Self {
+        Self {
+            raw_context: context.to_path_buf(),
+            context: std::fs::canonicalize(context).unwrap_or_else(|_| context.to_path_buf()),
+        }
+    }
+
+    fn make_relative(&self, resource: &Path) -> String {
+        if let Ok(relative) = resource
+            .strip_prefix(&self.context)
+            .or_else(|_| resource.strip_prefix(&self.raw_context))
+        {
+            return normalize_path(relative);
+        }
+
+        let resource = std::fs::canonicalize(resource).unwrap_or_else(|_| PathBuf::from(resource));
+        let relative = resource.strip_prefix(&self.context).unwrap_or(&resource);
+        normalize_path(relative)
+    }
+}
+
+fn module_render_ids(
+    context: &RenderPathContext,
+    module_graph: &ModuleGraph,
+) -> HashMap<ModuleId, String> {
     module_graph
         .modules()
         .iter()
@@ -682,8 +730,8 @@ fn module_render_ids(context: &Path, module_graph: &ModuleGraph) -> HashMap<Modu
         .collect()
 }
 
-fn module_render_id(context: &Path, module: &Module) -> String {
-    let mut resource = make_relative(context, &module.identity().resource);
+fn module_render_id(context: &RenderPathContext, module: &Module) -> String {
+    let mut resource = context.make_relative(&module.identity().resource);
     if !resource.starts_with("./") {
         resource = format!("./{resource}");
     }
@@ -698,11 +746,8 @@ fn module_render_id(context: &Path, module: &Module) -> String {
     resource
 }
 
-fn make_relative(context: &Path, resource: &Path) -> String {
-    let context = std::fs::canonicalize(context).unwrap_or_else(|_| context.to_path_buf());
-    let resource = std::fs::canonicalize(resource).unwrap_or_else(|_| PathBuf::from(resource));
-    let relative = resource.strip_prefix(&context).unwrap_or(&resource);
-    relative.to_string_lossy().replace('\\', "/")
+fn normalize_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
 }
 
 fn render_chunk_filename_map(chunk_graph: &ChunkGraph) -> String {

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -103,9 +103,15 @@ impl Compilation {
             self.entries = std::mem::take(&mut state.entries).into_values().collect();
             self.errors = std::mem::take(&mut state.errors);
             self.watch_dependencies = WatchDependencies {
-                files: std::mem::take(&mut state.file_dependencies),
-                contexts: std::mem::take(&mut state.context_dependencies),
-                missing: std::mem::take(&mut state.missing_dependencies),
+                files: std::mem::take(&mut state.file_dependencies)
+                    .into_iter()
+                    .collect(),
+                contexts: std::mem::take(&mut state.context_dependencies)
+                    .into_iter()
+                    .collect(),
+                missing: std::mem::take(&mut state.missing_dependencies)
+                    .into_iter()
+                    .collect(),
             };
 
             if result.is_ok() {

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -23,9 +23,9 @@ pub(crate) struct MakeState {
     pub module_graph: ModuleGraph,
     pub entries: BTreeMap<usize, ModuleId>,
     pub errors: Vec<Error>,
-    pub file_dependencies: BTreeSet<PathBuf>,
-    pub context_dependencies: BTreeSet<PathBuf>,
-    pub missing_dependencies: BTreeSet<PathBuf>,
+    pub file_dependencies: HashSet<PathBuf>,
+    pub context_dependencies: HashSet<PathBuf>,
+    pub missing_dependencies: HashSet<PathBuf>,
     modules_by_identity: HashMap<ModuleIdentity, ModuleId>,
 }
 
@@ -86,6 +86,7 @@ struct ProcessDependenciesTask {
 struct QueuedDependency {
     entry_index: Option<usize>,
     origin_block: Option<usize>,
+    origin_dependency_index: Option<usize>,
     dependency: Dependency,
 }
 
@@ -145,6 +146,7 @@ pub(crate) async fn run(
                 dependencies: vec![QueuedDependency {
                     entry_index: Some(entry_index),
                     origin_block: None,
+                    origin_dependency_index: None,
                     dependency: Dependency::new(DependencyKind::Entry, entry.request.clone()),
                 }],
             }),
@@ -303,7 +305,6 @@ impl AddTask {
                     state
                         .missing_dependencies
                         .extend(factorized.missing_dependencies.iter().cloned());
-                    state.file_dependencies.insert(resource.clone());
                     state.add_or_connect(self.origin_module, self.dependencies, identity.clone())
                 };
 
@@ -496,21 +497,24 @@ fn process_dependencies_task(
         .dependencies
         .iter()
         .cloned()
-        .map(|dependency| QueuedDependency {
+        .enumerate()
+        .map(|(dependency_index, dependency)| QueuedDependency {
             entry_index: None,
             origin_block: None,
+            origin_dependency_index: Some(dependency_index),
             dependency,
         })
         .collect::<Vec<_>>();
 
     for (block_index, block) in parsed.blocks.iter().enumerate() {
-        dependencies.extend(block.dependencies().iter().cloned().map(|dependency| {
-            QueuedDependency {
+        dependencies.extend(block.dependencies().iter().cloned().enumerate().map(
+            |(dependency_index, dependency)| QueuedDependency {
                 entry_index: None,
                 origin_block: Some(block_index),
+                origin_dependency_index: Some(dependency_index),
                 dependency,
-            }
-        }));
+            },
+        ));
     }
 
     if dependencies.is_empty() {
@@ -588,6 +592,7 @@ impl MakeState {
             self.module_graph.connect(
                 origin_module,
                 dependency.origin_block,
+                dependency.origin_dependency_index,
                 dependency.dependency,
                 module_id,
             );

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -86,7 +86,7 @@ struct ProcessDependenciesTask {
 struct QueuedDependency {
     entry_index: Option<usize>,
     origin_block: Option<usize>,
-    origin_dependency_index: Option<usize>,
+    origin_dependency_id: Option<usize>,
     dependency: Dependency,
 }
 
@@ -146,7 +146,7 @@ pub(crate) async fn run(
                 dependencies: vec![QueuedDependency {
                     entry_index: Some(entry_index),
                     origin_block: None,
-                    origin_dependency_index: None,
+                    origin_dependency_id: None,
                     dependency: Dependency::new(DependencyKind::Entry, entry.request.clone()),
                 }],
             }),
@@ -498,20 +498,20 @@ fn process_dependencies_task(
         .iter()
         .cloned()
         .enumerate()
-        .map(|(dependency_index, dependency)| QueuedDependency {
+        .map(|(dependency_id, dependency)| QueuedDependency {
             entry_index: None,
             origin_block: None,
-            origin_dependency_index: Some(dependency_index),
+            origin_dependency_id: Some(dependency_id),
             dependency,
         })
         .collect::<Vec<_>>();
 
     for (block_index, block) in parsed.blocks.iter().enumerate() {
         dependencies.extend(block.dependencies().iter().cloned().enumerate().map(
-            |(dependency_index, dependency)| QueuedDependency {
+            |(dependency_id, dependency)| QueuedDependency {
                 entry_index: None,
                 origin_block: Some(block_index),
-                origin_dependency_index: Some(dependency_index),
+                origin_dependency_id: Some(dependency_id),
                 dependency,
             },
         ));
@@ -592,7 +592,7 @@ impl MakeState {
             self.module_graph.connect(
                 origin_module,
                 dependency.origin_block,
-                dependency.origin_dependency_index,
+                dependency.origin_dependency_id,
                 dependency.dependency,
                 module_id,
             );

--- a/crates/unpack_core/src/module_graph.rs
+++ b/crates/unpack_core/src/module_graph.rs
@@ -29,7 +29,7 @@ impl ModuleGraph {
         &mut self,
         origin_module: Option<ModuleId>,
         origin_block: Option<usize>,
-        origin_dependency_index: Option<usize>,
+        origin_dependency_id: Option<usize>,
         dependency: Dependency,
         module: ModuleId,
     ) {
@@ -37,17 +37,17 @@ impl ModuleGraph {
         self.connections.push(ModuleGraphConnection {
             origin_module,
             origin_block,
-            origin_dependency_index,
+            origin_dependency_id,
             dependency,
             module,
         });
         if let Some(origin_module) = origin_module {
             self.outgoing[origin_module.index()].push(connection_id);
-            if let Some(dependency_index) = origin_dependency_index {
+            if let Some(dependency_id) = origin_dependency_id {
                 self.outgoing_by_location[origin_module.index()].insert(
                     DependencyLocation {
                         block: origin_block,
-                        index: dependency_index,
+                        dependency_id,
                     },
                     connection_id,
                 );
@@ -90,11 +90,11 @@ impl ModuleGraph {
         &self,
         origin_module: ModuleId,
         origin_block: Option<usize>,
-        dependency_index: usize,
+        dependency_id: usize,
     ) -> Option<ModuleId> {
         let location = DependencyLocation {
             block: origin_block,
-            index: dependency_index,
+            dependency_id,
         };
         self.outgoing_by_location
             .get(origin_module.index())?
@@ -106,14 +106,14 @@ impl ModuleGraph {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct DependencyLocation {
     block: Option<usize>,
-    index: usize,
+    dependency_id: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModuleGraphConnection {
     pub origin_module: Option<ModuleId>,
     pub origin_block: Option<usize>,
-    pub origin_dependency_index: Option<usize>,
+    pub origin_dependency_id: Option<usize>,
     pub dependency: Dependency,
     pub module: ModuleId,
 }

--- a/crates/unpack_core/src/module_graph.rs
+++ b/crates/unpack_core/src/module_graph.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::{Dependency, Module, ModuleId, ModuleIdentity};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -6,6 +8,7 @@ pub struct ModuleGraph {
     connections: Vec<ModuleGraphConnection>,
     outgoing: Vec<Vec<usize>>,
     incoming: Vec<Vec<usize>>,
+    outgoing_by_location: Vec<HashMap<DependencyLocation, usize>>,
 }
 
 impl ModuleGraph {
@@ -14,6 +17,7 @@ impl ModuleGraph {
         self.modules.push(Module::new(id, identity));
         self.outgoing.push(Vec::new());
         self.incoming.push(Vec::new());
+        self.outgoing_by_location.push(HashMap::new());
         id
     }
 
@@ -25,6 +29,7 @@ impl ModuleGraph {
         &mut self,
         origin_module: Option<ModuleId>,
         origin_block: Option<usize>,
+        origin_dependency_index: Option<usize>,
         dependency: Dependency,
         module: ModuleId,
     ) {
@@ -32,11 +37,21 @@ impl ModuleGraph {
         self.connections.push(ModuleGraphConnection {
             origin_module,
             origin_block,
+            origin_dependency_index,
             dependency,
             module,
         });
         if let Some(origin_module) = origin_module {
             self.outgoing[origin_module.index()].push(connection_id);
+            if let Some(dependency_index) = origin_dependency_index {
+                self.outgoing_by_location[origin_module.index()].insert(
+                    DependencyLocation {
+                        block: origin_block,
+                        index: dependency_index,
+                    },
+                    connection_id,
+                );
+            }
         }
         self.incoming[module.index()].push(connection_id);
     }
@@ -75,20 +90,30 @@ impl ModuleGraph {
         &self,
         origin_module: ModuleId,
         origin_block: Option<usize>,
-        dependency: &Dependency,
+        dependency_index: usize,
     ) -> Option<ModuleId> {
-        self.outgoing_connections(origin_module)
-            .find(|connection| {
-                connection.origin_block == origin_block && &connection.dependency == dependency
-            })
-            .map(|connection| connection.module)
+        let location = DependencyLocation {
+            block: origin_block,
+            index: dependency_index,
+        };
+        self.outgoing_by_location
+            .get(origin_module.index())?
+            .get(&location)
+            .map(|connection_id| self.connections[*connection_id].module)
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct DependencyLocation {
+    block: Option<usize>,
+    index: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModuleGraphConnection {
     pub origin_module: Option<ModuleId>,
     pub origin_block: Option<usize>,
+    pub origin_dependency_index: Option<usize>,
     pub dependency: Dependency,
     pub module: ModuleId,
 }

--- a/crates/unpack_core/src/normal_module_factory.rs
+++ b/crates/unpack_core/src/normal_module_factory.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeSet, HashMap, HashSet},
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
@@ -112,9 +112,18 @@ impl NormalModuleFactory {
         let record = ResolveRecord::new(
             identity,
             resource,
-            resolved.file_dependencies,
-            resolved.context_dependencies,
-            resolved.missing_dependencies,
+            resolved
+                .file_dependencies
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+            resolved
+                .context_dependencies
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+            resolved
+                .missing_dependencies
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
             &self.file_system_info,
             self.resolve_snapshot_strategy,
         )
@@ -129,9 +138,9 @@ impl NormalModuleFactory {
 pub struct FactorizedModule {
     pub identity: ModuleIdentity,
     pub resource: PathBuf,
-    pub file_dependencies: BTreeSet<PathBuf>,
-    pub context_dependencies: BTreeSet<PathBuf>,
-    pub missing_dependencies: BTreeSet<PathBuf>,
+    pub file_dependencies: HashSet<PathBuf>,
+    pub context_dependencies: HashSet<PathBuf>,
+    pub missing_dependencies: HashSet<PathBuf>,
 }
 
 impl FactorizedModule {
@@ -139,9 +148,9 @@ impl FactorizedModule {
         Self {
             identity: record.identity().clone(),
             resource: record.resource().to_path_buf(),
-            file_dependencies: record.file_dependencies().clone(),
-            context_dependencies: record.context_dependencies().clone(),
-            missing_dependencies: record.missing_dependencies().clone(),
+            file_dependencies: record.file_dependencies().iter().cloned().collect(),
+            context_dependencies: record.context_dependencies().iter().cloned().collect(),
+            missing_dependencies: record.missing_dependencies().iter().cloned().collect(),
         }
     }
 }

--- a/crates/unpack_core/src/resolver.rs
+++ b/crates/unpack_core/src/resolver.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeSet,
+    collections::HashSet,
     fs,
     path::{Path, PathBuf},
     sync::Arc,
@@ -43,12 +43,12 @@ impl UnpackResolver {
             .file_dependencies
             .into_iter()
             .map(|path| normalize_resolver_dependency(path.as_path()))
-            .collect::<BTreeSet<_>>();
+            .collect::<HashSet<_>>();
         let missing_dependencies = context
             .missing_dependencies
             .into_iter()
             .map(|path| normalize_resolver_dependency(path.as_path()))
-            .collect::<BTreeSet<_>>();
+            .collect::<HashSet<_>>();
         let context_dependencies =
             context_dependencies(directory, &file_dependencies, &missing_dependencies);
 
@@ -68,9 +68,9 @@ impl UnpackResolver {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolveResult {
     pub resource: ResolvedResource,
-    pub file_dependencies: BTreeSet<PathBuf>,
-    pub context_dependencies: BTreeSet<PathBuf>,
-    pub missing_dependencies: BTreeSet<PathBuf>,
+    pub file_dependencies: HashSet<PathBuf>,
+    pub context_dependencies: HashSet<PathBuf>,
+    pub missing_dependencies: HashSet<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -90,28 +90,37 @@ impl From<ResolvedResource> for ModuleIdentity {
 }
 
 fn normalize_resolver_dependency(path: &Path) -> PathBuf {
-    if let Ok(canonical) = fs::canonicalize(path) {
-        return canonical;
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir if normalized.pop() => {}
+            _ => normalized.push(component.as_os_str()),
+        }
     }
+    normalize_platform_path(normalized)
+}
 
-    let Some(parent) = path.parent() else {
-        return path.to_path_buf();
-    };
-    let Ok(canonical_parent) = fs::canonicalize(parent) else {
-        return path.to_path_buf();
-    };
-    match path.file_name() {
-        Some(file_name) => canonical_parent.join(file_name),
-        None => canonical_parent,
+#[cfg(target_os = "macos")]
+fn normalize_platform_path(path: PathBuf) -> PathBuf {
+    if let Ok(relative) = path.strip_prefix("/var") {
+        return PathBuf::from("/private/var").join(relative);
     }
+    path
+}
+
+#[cfg(not(target_os = "macos"))]
+fn normalize_platform_path(path: PathBuf) -> PathBuf {
+    path
 }
 
 fn context_dependencies(
     search_directory: &Path,
-    file_dependencies: &BTreeSet<PathBuf>,
-    missing_dependencies: &BTreeSet<PathBuf>,
-) -> BTreeSet<PathBuf> {
-    let search_directory = normalize_resolver_dependency(search_directory);
+    file_dependencies: &HashSet<PathBuf>,
+    missing_dependencies: &HashSet<PathBuf>,
+) -> HashSet<PathBuf> {
+    let search_directory = fs::canonicalize(search_directory)
+        .unwrap_or_else(|_| normalize_resolver_dependency(search_directory));
     file_dependencies
         .iter()
         .chain(missing_dependencies.iter())


### PR DESCRIPTION
## Summary

- Replace codegen dependency target lookup with a module graph index keyed by dependency location, avoiding cloned `Dependency` structural scans.
- Keep resolver and make dependency aggregation in hash sets on the hot path, while preserving ordered watch/cache boundaries.
- Cache render path context for module and chunk render ids to avoid repeated context canonicalization.

## Why

Callgrind showed no-cache build time dominated by path comparison/canonicalization and dependency graph lookup overhead. Rspack avoids these costs with id/hash-oriented lookup structures; this change applies the same direction within the current Unpack model.

## Validation

- `cargo fmt --check`
- `cargo test -p unpack_core`
- `pnpm test`
- `UNPACK_NATIVE_PROFILE=release pnpm benchmark:bundlers -- --workspace .benchmark-work/opt-final --fixtures small,medium,large --bundlers unpack,rspack --output-json .benchmark-work/opt-final/report.json`

## Benchmark

Baseline -> final no-cache build time:

| fixture | unpack baseline | unpack final | rspack final |
| --- | ---: | ---: | ---: |
| small | 8.935ms | 5.534ms | 7.665ms |
| medium | 51.717ms | 11.303ms | 14.588ms |
| large | 311.490ms | 103.998ms | 92.444ms |
