### PR TITLE
Store cache records behind Arc

### DIFF
--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -120,7 +120,7 @@ struct BuildCacheInner {
 
 #[derive(Debug)]
 struct CacheStore<K, V> {
-    records: HashMap<K, V>,
+    records: HashMap<K, Arc<V>>,
     hits: usize,
     misses: usize,
 }
@@ -138,9 +138,8 @@ impl<K, V> Default for CacheStore<K, V> {
 impl<K, V> CacheStore<K, V>
 where
     K: Eq + Hash,
-    V: Clone,
 {
-    fn get(&mut self, key: &K) -> Option<V> {
+    fn get(&mut self, key: &K) -> Option<Arc<V>> {
         let record = self.records.get(key).cloned();
         if record.is_some() {
             self.hits += 1;
@@ -151,7 +150,7 @@ where
     }
 
     fn store(&mut self, key: K, value: V) {
-        self.records.insert(key, value);
+        self.records.insert(key, Arc::new(value));
     }
 
     #[cfg(test)]
@@ -264,8 +263,8 @@ impl ModuleBuildRecord {
         &self.parsed
     }
 
-    pub(crate) fn into_parts(self) -> (ParsedModule, String) {
-        (self.parsed, self.source)
+    pub(crate) fn cloned_parts(&self) -> (ParsedModule, String) {
+        (self.parsed.clone(), self.source.clone())
     }
 
     pub(crate) async fn is_valid(
@@ -357,13 +356,12 @@ impl BuildCache {
 impl<K, V> CacheFacade<K, V>
 where
     K: Eq + Hash,
-    V: Clone,
 {
     pub(crate) fn is_enabled(&self) -> bool {
         self.build_cache.options.kind != CacheKind::Disabled
     }
 
-    pub(crate) fn get(&self, key: &K) -> Option<V> {
+    pub(crate) fn get(&self, key: &K) -> Option<Arc<V>> {
         if !self.is_enabled() {
             return None;
         }
@@ -419,14 +417,22 @@ impl BuildCache {
             .inner
             .lock()
             .expect("build cache mutex should not be poisoned");
-        inner.resolve_records.records = pack.resolve_records.into_iter().collect();
-        inner.module_builds.records = pack.module_builds.into_iter().collect();
+        inner.resolve_records.records = pack
+            .resolve_records
+            .into_iter()
+            .map(|(request, record)| (request, Arc::new(record)))
+            .collect();
+        inner.module_builds.records = pack
+            .module_builds
+            .into_iter()
+            .map(|(identity, record)| (identity, Arc::new(record)))
+            .collect();
     }
 
     fn write_filesystem_cache(
         &self,
-        resolve_records: &HashMap<ResolveRequest, ResolveRecord>,
-        module_builds: &HashMap<ModuleIdentity, ModuleBuildRecord>,
+        resolve_records: &HashMap<ResolveRequest, Arc<ResolveRecord>>,
+        module_builds: &HashMap<ModuleIdentity, Arc<ModuleBuildRecord>>,
     ) -> io::Result<()> {
         let Some(cache_location) = &self.options.cache_location else {
             return Ok(());
@@ -444,11 +450,11 @@ impl BuildCache {
             cache_version: cache_version.clone(),
             resolve_records: resolve_records
                 .iter()
-                .map(|(request, record)| (request.clone(), record.clone()))
+                .map(|(request, record)| (request.clone(), (**record).clone()))
                 .collect(),
             module_builds: module_builds
                 .iter()
-                .map(|(identity, record)| (identity.clone(), record.clone()))
+                .map(|(identity, record)| (identity.clone(), (**record).clone()))
                 .collect(),
         };
         let pack_payload = cbor4ii::serde::to_vec(Vec::new(), &pack)

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -365,7 +365,7 @@ impl BuildTask {
             {
                 let process_dependencies =
                     process_dependencies_task(self.module_id, &issuer_context, record.parsed());
-                let (parsed, source) = record.into_parts();
+                let (parsed, source) = record.cloned_parts();
                 state
                     .lock()
                     .await

--- a/crates/unpack_core/src/normal_module_factory.rs
+++ b/crates/unpack_core/src/normal_module_factory.rs
@@ -55,7 +55,7 @@ impl NormalModuleFactory {
                 .is_valid(&self.file_system_info, self.resolve_snapshot_strategy)
                 .await
             {
-                return Ok(FactorizedModule::from_resolve_record(record));
+                return Ok(FactorizedModule::from_resolve_record(&record));
             }
         }
 
@@ -128,9 +128,10 @@ impl NormalModuleFactory {
             self.resolve_snapshot_strategy,
         )
         .await?;
-        self.cache.store(resolve_request, record.clone());
+        let factorized = FactorizedModule::from_resolve_record(&record);
+        self.cache.store(resolve_request, record);
 
-        Ok(FactorizedModule::from_resolve_record(record))
+        Ok(factorized)
     }
 }
 
@@ -144,7 +145,7 @@ pub struct FactorizedModule {
 }
 
 impl FactorizedModule {
-    fn from_resolve_record(record: ResolveRecord) -> Self {
+    fn from_resolve_record(record: &ResolveRecord) -> Self {
         Self {
             identity: record.identity().clone(),
             resource: record.resource().to_path_buf(),


### PR DESCRIPTION
## Summary

- Store in-memory build cache records as `Arc<V>` so cache hits clone a shared pointer instead of cloning the whole record.
- Keep `ResolveRecord`, `ModuleBuildRecord`, and persistent cache DTOs as ordinary value types.
- Convert restored persistent cache records into `Arc` at the memory-cache boundary and clone values back only when writing cache packs.

## Impact

This reduces clone work on memory cache lookup, especially for invalid hits and validation paths, without changing persistent cache schema or making compilations share module graph data.

## Validation

- `cargo fmt --check`
- `cargo test -p unpack_core`
- `cargo test --workspace`