### PR TITLE
Measure warm builds after module edits

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -93,7 +93,7 @@ A benchmark measurement taken after clearing the output path and benchmark-owned
 _Avoid_: First run, clean test
 
 **Warm Build Measurement**:
-A benchmark measurement taken after a prior build in the same benchmark job while preserving benchmark-owned cache state that the tool under test can reuse.
+A benchmark measurement taken after a prior build in the same benchmark job and after applying a benchmark-owned source module change, while preserving benchmark-owned cache state that the tool under test can reuse.
 _Avoid_: Incremental rebuild, watch rebuild
 
 **Tracing**:

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -34,6 +34,11 @@ fixed checkout so `turbopack-cli build` explicitly stops TurboTasks before
 process exit. Turbopack build sessions use shutdown-time persistent cache
 storage, so this flushes the cold build cache for the warm measurement.
 
+After a successful cold build, the runner modifies one generated source module
+before starting the warm build timer. The warm measurement therefore captures a
+build that can reuse persistent cache state while responding to a small module
+edit.
+
 ## Result Shape
 
 The runner emits a Markdown summary and can write the raw JSON report with `--output-json`.
@@ -41,7 +46,7 @@ The runner emits a Markdown summary and can write the raw JSON report with `--ou
 Important fields:
 
 - `cold_build_ms`: build time after clearing benchmark-owned output and persistent cache state.
-- `warm_build_ms`: build time for the second run in the same job while preserving benchmark-owned persistent cache state.
+- `warm_build_ms`: build time after changing one generated source module while preserving benchmark-owned persistent cache state from the cold build.
 - `no_cache_build_ms`: build time for an additional clean build with persistent cache disabled. Bundlers without a persistent-cache option run this as a separate clean one-shot build.
 - `output_bytes`: bytes emitted under the benchmark output path, excluding runner metadata.
 - `version_source`: the npm package version or fixed source commit used for the bundler.

--- a/packages/benchmarks/src/fixture.mjs
+++ b/packages/benchmarks/src/fixture.mjs
@@ -1,5 +1,8 @@
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, rm, utimes, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+
+const WARM_BUILD_MUTATION_FEATURE = 0;
+const WARM_BUILD_MUTATION_DELTA = 1000;
 
 export const FIXTURE_SHAPES = {
   small: {
@@ -63,6 +66,30 @@ export async function createBenchmarkFixture(rootDir, shape) {
   };
 }
 
+export async function applyWarmBuildMutation(fixture) {
+  if (fixture.warmBuildMutation) {
+    return fixture;
+  }
+
+  const feature = WARM_BUILD_MUTATION_FEATURE;
+  const path = join(fixture.context, `src/features/leaf${feature}.js`);
+  await writeSource(
+    path,
+    leafSource(feature, feature + 1 + WARM_BUILD_MUTATION_DELTA)
+  );
+
+  const modifiedAt = new Date(Date.now() + 1000);
+  await utimes(path, modifiedAt, modifiedAt);
+
+  return {
+    ...fixture,
+    expectedChecksum: fixture.expectedChecksum + WARM_BUILD_MUTATION_DELTA * 2,
+    warmBuildMutation: {
+      path
+    }
+  };
+}
+
 function entrySource(shape) {
   const source = [];
   for (let feature = 0; feature < shape.featureModules; feature += 1) {
@@ -115,8 +142,8 @@ function sharedSource(shared) {
   return `export const shared${shared} = ${shared + 1};\nexport const sharedValue${shared} = shared${shared} * 2;\n`;
 }
 
-function leafSource(feature) {
-  return `export const leaf${feature} = ${feature + 1};\n`;
+function leafSource(feature, value = feature + 1) {
+  return `export const leaf${feature} = ${value};\n`;
 }
 
 function reexportSource(feature) {

--- a/packages/benchmarks/src/runner.mjs
+++ b/packages/benchmarks/src/runner.mjs
@@ -3,7 +3,11 @@ import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { performance } from "node:perf_hooks";
 import { dirname, join, resolve, sep } from "node:path";
 
-import { createBenchmarkFixture, FIXTURE_SHAPES } from "./fixture.mjs";
+import {
+  applyWarmBuildMutation,
+  createBenchmarkFixture,
+  FIXTURE_SHAPES
+} from "./fixture.mjs";
 
 const require = createRequire(import.meta.url);
 
@@ -36,8 +40,8 @@ export async function runBenchmark(options = {}) {
   const results = [];
 
   for (const shape of shapes) {
-    const fixture = await createBenchmarkFixture(fixtureRoot, shape);
     for (const bundler of bundlerNames) {
+      const fixture = await createBenchmarkFixture(fixtureRoot, shape);
       const adapter = adapters[bundler];
       results.push(
         await runBundlerBenchmark({
@@ -130,10 +134,29 @@ async function runBundlerBenchmark({ adapter, bundler, fixture, workspaceDir, op
     return resultFromPhases({ fixture, bundler, versionSource, cold });
   }
 
+  let warmFixture;
+  try {
+    warmFixture = await applyWarmBuildMutation(fixture);
+  } catch (error) {
+    return resultFromPhases({
+      fixture,
+      bundler,
+      versionSource,
+      cold,
+      warm: {
+        status: "build_failed",
+        build_ms: null,
+        output_bytes: await outputBytes(outputDir),
+        verify_ms: null,
+        message: `failed to modify warm build fixture: ${errorMessage(error)}`
+      }
+    });
+  }
+
   const warm = await timedBuild({
     adapter,
     phase: "warm",
-    fixture,
+    fixture: warmFixture,
     outputDir,
     cacheDir,
     persistentCache: true,
@@ -141,20 +164,27 @@ async function runBundlerBenchmark({ adapter, bundler, fixture, workspaceDir, op
   });
 
   if (warm.status !== "success") {
-    return resultFromPhases({ fixture, bundler, versionSource, cold, warm });
+    return resultFromPhases({ fixture: warmFixture, bundler, versionSource, cold, warm });
   }
 
   const noCache = await timedBuild({
     adapter,
     phase: "no-cache",
-    fixture,
+    fixture: warmFixture,
     outputDir: noCacheOutputDir,
     cacheDir: noCacheCacheDir,
     persistentCache: false,
     options
   });
 
-  return resultFromPhases({ fixture, bundler, versionSource, cold, warm, noCache });
+  return resultFromPhases({
+    fixture: warmFixture,
+    bundler,
+    versionSource,
+    cold,
+    warm,
+    noCache
+  });
 }
 
 async function timedBuild({

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -11,7 +11,7 @@ import { runBenchmark, toSummaryMarkdown } from "../src/runner.mjs";
 
 const execFileAsync = promisify(execFile);
 
-test("runner emits persistent-cache and no-cache measurements for a verified bundle", async () => {
+test("runner emits warm-after-change and no-cache measurements for a verified bundle", async () => {
   const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
   const calls = [];
 
@@ -46,9 +46,44 @@ test("runner emits persistent-cache and no-cache measurements for a verified bun
         { phase: "no-cache", persistentCache: false }
       ]
     );
+    assert.match(calls[0].leaf0Source, /leaf0 = 1/);
+    assert.match(calls[1].leaf0Source, /leaf0 = 1001/);
+    assert.match(calls[2].leaf0Source, /leaf0 = 1001/);
+    assert.equal(calls[1].expectedChecksum - calls[0].expectedChecksum, 2000);
+    assert.equal(calls[2].expectedChecksum, calls[1].expectedChecksum);
     const summary = toSummaryMarkdown(report);
     assert.match(summary, /no_cache_build_ms/);
     assert.match(summary, /\\| small \\| fake \\| fake@1\\.0\\.0 \\|/);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("runner resets the fixture before each bundler benchmark", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
+  const firstCalls = [];
+  const secondCalls = [];
+
+  try {
+    const report = await runBenchmark({
+      workspaceDir: workspace,
+      fixtures: ["small"],
+      bundlers: ["first", "second"],
+      adapters: {
+        first: fakeAdapter({ calls: firstCalls }),
+        second: fakeAdapter({ calls: secondCalls })
+      }
+    });
+
+    assert.deepEqual(
+      report.results.map((result) => result.status),
+      ["success", "success"]
+    );
+    assert.match(firstCalls[0].leaf0Source, /leaf0 = 1/);
+    assert.match(firstCalls[1].leaf0Source, /leaf0 = 1001/);
+    assert.match(secondCalls[0].leaf0Source, /leaf0 = 1/);
+    assert.match(secondCalls[1].leaf0Source, /leaf0 = 1001/);
+    assert.equal(firstCalls[0].expectedChecksum, secondCalls[0].expectedChecksum);
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }
@@ -230,7 +265,16 @@ function fakeAdapter({ checksumOffset = 0, error, calls } = {}) {
     name: "fake",
     versionSource: () => "fake@1.0.0",
     async build({ fixture, outputDir, phase, persistentCache }) {
-      calls?.push({ phase, persistentCache });
+      const leaf0Source = await readFile(
+        join(fixture.context, "src", "features", "leaf0.js"),
+        "utf8"
+      );
+      calls?.push({
+        phase,
+        persistentCache,
+        expectedChecksum: fixture.expectedChecksum,
+        leaf0Source
+      });
       if (error) {
         throw error;
       }


### PR DESCRIPTION
## Summary

- Modify the cross-bundler benchmark warm phase so it edits a generated source module after the cold build and before the warm build timer starts.
- Update the fixture checksum used for warm and no-cache verification after that module edit.
- Regenerate the fixture for each bundler run so one bundler's warm edit cannot affect the next bundler's cold measurement.
- Document the updated warm build measurement semantics.

## Why

The previous warm build measured a second build with unchanged inputs. This did not represent the intended benchmark signal for a warm build after a source module change.

## Impact

`warm_build_ms` now reports a build that can reuse benchmark-owned persistent cache state while responding to a small module edit. `no_cache_build_ms` still measures a clean build, but now against the same modified fixture used by the warm phase.

## Validation

- `pnpm --filter @unpack-js/benchmarks test`
- `pnpm --filter @unpack-js/benchmarks bench -- --fixtures small --bundlers webpack,rspack,rolldown --workspace .benchmark-work/smoke-warm-mutation-2 --output-json .benchmark-work/smoke-warm-mutation-2/results.json`