### PR TITLE
Cache snapshot filesystem reads during make

### DIFF
--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -309,13 +309,14 @@ impl ModuleBuildRecord {
         (self.parsed.clone(), self.source.clone())
     }
 
-    pub(crate) async fn is_valid(
+    pub(crate) async fn is_valid_with_cache(
         &self,
         file_system_info: &FileSystemInfo,
         strategy: SnapshotStrategy,
+        snapshot_cache: &SnapshotCache,
     ) -> bool {
         file_system_info
-            .is_snapshot_valid(&self.snapshot, strategy)
+            .is_snapshot_valid_with_cache(&self.snapshot, strategy, snapshot_cache)
             .await
     }
 }

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -15,7 +15,7 @@ use crate::{
     ModuleIdentity, NormalModuleFactory, Result, SnapshotStrategy, UnpackResolver,
     build_cache::{BuildCache, ModuleBuildCache, ModuleBuildRecord},
     parser::{ParsedModule, parse_module_dependencies},
-    snapshot::FileSystemInfo,
+    snapshot::{FileSystemInfo, SnapshotCache},
 };
 
 #[derive(Debug, Default)]
@@ -35,6 +35,7 @@ struct MakeServices {
     module_build_cache: ModuleBuildCache,
     module_snapshot_strategy: SnapshotStrategy,
     file_system_info: FileSystemInfo,
+    snapshot_cache: SnapshotCache,
     semaphore: Arc<Semaphore>,
 }
 
@@ -122,16 +123,19 @@ pub(crate) async fn run(
     file_system_info: FileSystemInfo,
     state: Arc<Mutex<MakeState>>,
 ) -> Result<()> {
+    let snapshot_cache = SnapshotCache::default();
     let services = MakeServices {
         normal_module_factory: NormalModuleFactory::new(
             resolver,
             build_cache.normal_module_factory(),
             file_system_info.clone(),
             options.snapshot.resolve,
+            snapshot_cache.clone(),
         ),
         module_build_cache: build_cache.module_builds(),
         file_system_info,
         module_snapshot_strategy: options.snapshot.module,
+        snapshot_cache,
         semaphore: Arc::new(Semaphore::new(options.parallelism.max(1))),
     };
 
@@ -357,9 +361,10 @@ impl BuildTask {
 
         if let Some(record) = services.module_build_cache.get(&self.identity) {
             if record
-                .is_valid(
+                .is_valid_with_cache(
                     &services.file_system_info,
                     services.module_snapshot_strategy,
+                    &services.snapshot_cache,
                 )
                 .await
             {

--- a/crates/unpack_core/src/normal_module_factory.rs
+++ b/crates/unpack_core/src/normal_module_factory.rs
@@ -32,6 +32,7 @@ impl NormalModuleFactory {
         cache: NormalModuleFactoryCache,
         file_system_info: FileSystemInfo,
         resolve_snapshot_strategy: SnapshotStrategy,
+        snapshot_cache: SnapshotCache,
     ) -> Self {
         Self {
             resolver,
@@ -39,7 +40,7 @@ impl NormalModuleFactory {
             file_system_info,
             resolve_snapshot_strategy,
             runtime_factorize_cache: Arc::new(Mutex::new(HashMap::new())),
-            snapshot_cache: SnapshotCache::default(),
+            snapshot_cache,
         }
     }
 
@@ -190,6 +191,7 @@ mod tests {
             build_cache.normal_module_factory(),
             FileSystemInfo::new(),
             SnapshotStrategy::timestamp(),
+            SnapshotCache::default(),
         );
         let dependency = Dependency::new(DependencyKind::StaticImport, "./dep");
 

--- a/crates/unpack_core/src/snapshot.rs
+++ b/crates/unpack_core/src/snapshot.rs
@@ -119,8 +119,73 @@ pub(crate) struct FileSystemInfo {
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SnapshotCache {
+    file_metadata: Arc<Mutex<HashMap<PathBuf, CachedFileMetadata>>>,
+    file_hashes: Arc<Mutex<HashMap<PathBuf, CachedFileHash>>>,
     context_timestamp_hashes: Arc<Mutex<HashMap<PathBuf, DirectoryTimestampHash>>>,
     context_content_hashes: Arc<Mutex<HashMap<PathBuf, u64>>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CachedFileMetadata {
+    Missing,
+    Present { modified: SystemTime },
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CachedFileHash {
+    Hash(u64),
+    Error,
+}
+
+impl SnapshotCache {
+    async fn file_metadata(&self, path: &Path) -> CachedFileMetadata {
+        if let Some(metadata) = self
+            .file_metadata
+            .lock()
+            .expect("snapshot cache mutex should not be poisoned")
+            .get(path)
+            .copied()
+        {
+            return metadata;
+        }
+
+        let metadata = match tokio::fs::metadata(path).await {
+            Ok(metadata) => metadata
+                .modified()
+                .map(|modified| CachedFileMetadata::Present { modified })
+                .unwrap_or(CachedFileMetadata::Error),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => CachedFileMetadata::Missing,
+            Err(_) => CachedFileMetadata::Error,
+        };
+        self.file_metadata
+            .lock()
+            .expect("snapshot cache mutex should not be poisoned")
+            .insert(path.to_path_buf(), metadata);
+        metadata
+    }
+
+    async fn file_hash(&self, path: &Path) -> CachedFileHash {
+        if let Some(hash) = self
+            .file_hashes
+            .lock()
+            .expect("snapshot cache mutex should not be poisoned")
+            .get(path)
+            .copied()
+        {
+            return hash;
+        }
+
+        let hash = match tokio::fs::read(path).await {
+            Ok(source) => CachedFileHash::Hash(hash_bytes(&source)),
+            Err(_) => CachedFileHash::Error,
+        };
+        self.file_hashes
+            .lock()
+            .expect("snapshot cache mutex should not be poisoned")
+            .insert(path.to_path_buf(), hash);
+        hash
+    }
 }
 
 impl FileSystemInfo {
@@ -184,6 +249,7 @@ impl FileSystemInfo {
         Snapshot::create_sync(paths, strategy, self)
     }
 
+    #[cfg(test)]
     pub(crate) async fn is_snapshot_valid(
         &self,
         snapshot: &Snapshot,
@@ -502,7 +568,7 @@ impl SnapshotEntry {
         match self {
             Self::File(file) => {
                 file_system_info.ordinary_snapshot_applies(&file.path)
-                    && file.snapshot.is_valid(&file.path, strategy).await
+                    && file.snapshot.is_valid(&file.path, strategy, cache).await
             }
             Self::Context(context) => {
                 file_system_info.ordinary_snapshot_applies(&context.path)
@@ -513,7 +579,7 @@ impl SnapshotEntry {
             }
             Self::MissingExistence { path } => {
                 file_system_info.ordinary_snapshot_applies(path)
-                    && MissingExistenceSnapshot::is_valid(path).await
+                    && MissingExistenceSnapshot::is_valid(path, cache).await
             }
             Self::ImmutablePath { path } => {
                 file_system_info.classify_path(path) == SnapshotPathClassification::Immutable
@@ -670,7 +736,10 @@ impl ContextSnapshot {
 struct MissingExistenceSnapshot;
 
 impl MissingExistenceSnapshot {
-    async fn is_valid(path: &Path) -> bool {
+    async fn is_valid(path: &Path, cache: Option<&SnapshotCache>) -> bool {
+        if let Some(cache) = cache {
+            return matches!(cache.file_metadata(path).await, CachedFileMetadata::Missing);
+        }
         Self::is_valid_sync(path)
     }
 
@@ -750,21 +819,42 @@ impl FileSnapshot {
         })
     }
 
-    pub(crate) async fn is_valid(&self, path: &Path, strategy: SnapshotStrategy) -> bool {
+    pub(crate) async fn is_valid(
+        &self,
+        path: &Path,
+        strategy: SnapshotStrategy,
+        cache: Option<&SnapshotCache>,
+    ) -> bool {
         if !self.exists {
             return !strategy.timestamp && !strategy.hash
-                || matches!(
-                    tokio::fs::metadata(path).await,
-                    Err(error) if error.kind() == io::ErrorKind::NotFound
-                );
+                || match cache {
+                    Some(cache) => {
+                        matches!(cache.file_metadata(path).await, CachedFileMetadata::Missing)
+                    }
+                    None => {
+                        matches!(
+                            tokio::fs::metadata(path).await,
+                            Err(error) if error.kind() == io::ErrorKind::NotFound
+                        )
+                    }
+                };
         }
 
         if strategy.timestamp {
-            let Ok(metadata) = tokio::fs::metadata(path).await else {
-                return false;
-            };
-            let Ok(modified) = metadata.modified() else {
-                return false;
+            let modified = match cache {
+                Some(cache) => match cache.file_metadata(path).await {
+                    CachedFileMetadata::Present { modified } => modified,
+                    CachedFileMetadata::Missing | CachedFileMetadata::Error => return false,
+                },
+                None => {
+                    let Ok(metadata) = tokio::fs::metadata(path).await else {
+                        return false;
+                    };
+                    let Ok(modified) = metadata.modified() else {
+                        return false;
+                    };
+                    modified
+                }
             };
             if Some(modified) != self.modified {
                 return false;
@@ -772,10 +862,19 @@ impl FileSnapshot {
         }
 
         if strategy.hash {
-            let Ok(source) = tokio::fs::read(path).await else {
-                return false;
+            let source_hash = match cache {
+                Some(cache) => match cache.file_hash(path).await {
+                    CachedFileHash::Hash(hash) => hash,
+                    CachedFileHash::Error => return false,
+                },
+                None => {
+                    let Ok(source) = tokio::fs::read(path).await else {
+                        return false;
+                    };
+                    hash_bytes(&source)
+                }
             };
-            if Some(hash_bytes(&source)) != self.source_hash {
+            if Some(source_hash) != self.source_hash {
                 return false;
             }
         }


### PR DESCRIPTION
## Summary

- Add per-make filesystem metadata and hash caching to `SnapshotCache`.
- Reuse the same snapshot cache for resolver cache-hit validation and module build cache-hit validation.
- Keep the change scoped to filesystem reads; this does not add resolve positive-result caching or snapshot validity result caching.

## Why

Warm builds still spend time validating cached resolve and module build records. The first incremental step is to avoid repeated `metadata` and file-read work for the same path during a single make pass while preserving existing validation behavior.

## Validation

- `cargo fmt --check`
- `cargo test --workspace`
- `UNPACK_NATIVE_PROFILE=release pnpm --filter @unpack-js/core build`
- `UNPACK_NATIVE_PROFILE=release pnpm --filter @unpack-js/core test`
- `pnpm --filter @unpack-js/benchmarks test`

## Benchmark

Large fixture, release native addon, 5-run average after this change:

- unpack warm: `74.123ms` (`71.767-80.181ms`)
- rspack warm: `47.921ms` (`39.990-64.916ms`)

This shows path-level filesystem caching alone is not the main remaining warm-build bottleneck; follow-up work should focus on snapshot/resolve validation result caching or avoiding hash reads when timestamp validation is sufficient.
