### PR TITLE
Support readonly filesystem cache for warm benchmarks

### DIFF
--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -49,6 +49,7 @@ pub struct CacheOptions {
     pub build_dependencies: Vec<BuildDependency>,
     pub max_memory_generations: Option<u32>,
     pub idle_timeout: Option<u32>,
+    pub readonly: bool,
 }
 
 impl Default for CacheOptions {
@@ -68,6 +69,7 @@ impl CacheOptions {
             build_dependencies: Vec::new(),
             max_memory_generations: None,
             idle_timeout: None,
+            readonly: false,
         }
     }
 
@@ -81,6 +83,7 @@ impl CacheOptions {
             build_dependencies: Vec::new(),
             max_memory_generations: None,
             idle_timeout: None,
+            readonly: false,
         }
     }
 
@@ -94,6 +97,7 @@ impl CacheOptions {
             build_dependencies: Vec::new(),
             max_memory_generations: None,
             idle_timeout: None,
+            readonly: false,
         }
     }
 }
@@ -351,7 +355,7 @@ impl BuildCache {
     }
 
     pub(crate) fn flush_to_filesystem(&self) -> io::Result<()> {
-        if self.options.kind != CacheKind::Filesystem {
+        if self.options.kind != CacheKind::Filesystem || self.options.readonly {
             return Ok(());
         }
 
@@ -427,7 +431,9 @@ where
             .lock()
             .expect("build cache mutex should not be poisoned");
         (self.store)(&mut inner).store(key, value);
-        if self.build_cache.options.kind == CacheKind::Filesystem {
+        if self.build_cache.options.kind == CacheKind::Filesystem
+            && !self.build_cache.options.readonly
+        {
             inner.dirty = true;
         }
     }

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -248,6 +248,77 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn filesystem_cache_readonly_restores_but_skips_persistent_updates()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write(
+            temp.path().join("index.js"),
+            r#"
+                import { value } from "./dep";
+                export const result = value;
+            "#,
+        )?;
+        write(temp.path().join("dep.js"), "export const value = 'before';")?;
+        let cache_location = temp.path().join(".cache/unpack/default");
+
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache = CacheOptions::filesystem();
+        options.cache.cache_location = Some(cache_location.clone());
+        options.snapshot.module = crate::SnapshotStrategy::hash();
+
+        let first_compiler = Compiler::new(options.clone());
+        first_compiler.run().await?;
+        first_compiler.flush_cache()?;
+        let manifest_path = cache_location.join("container.json");
+        let pack_path = cache_location.join("packs/modules.cbor");
+        let manifest_before = fs::read(&manifest_path)?;
+        let pack_before = fs::read(&pack_path)?;
+
+        write(temp.path().join("dep.js"), "export const value = 'after';")?;
+
+        let mut readonly_options = options;
+        readonly_options.cache.readonly = true;
+        let readonly_compiler = Compiler::new(readonly_options);
+        assert_eq!(readonly_compiler.build_cache.stats().resolve_entries, 2);
+        assert_eq!(readonly_compiler.build_cache.stats().module_entries, 2);
+
+        let second = readonly_compiler.run().await?;
+        readonly_compiler.flush_cache()?;
+        assert!(
+            asset_sources(&second)
+                .get("main.js")
+                .expect("main asset should exist")
+                .contains("after")
+        );
+        assert_eq!(fs::read(&manifest_path)?, manifest_before);
+        assert_eq!(fs::read(&pack_path)?, pack_before);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn filesystem_cache_readonly_does_not_create_persistent_cache()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write(temp.path().join("index.js"), "export const value = 1;")?;
+        let cache_location = temp.path().join(".cache/unpack/default");
+
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache = CacheOptions::filesystem();
+        options.cache.cache_location = Some(cache_location.clone());
+        options.cache.readonly = true;
+
+        let compiler = Compiler::new(options);
+        compiler.run().await?;
+        compiler.flush_cache()?;
+
+        assert!(!cache_location.join("container.json").exists());
+        assert!(!cache_location.join("packs/modules.cbor").exists());
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn filesystem_cache_rejects_invalid_build_dependency_snapshots()
     -> std::result::Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -74,6 +74,8 @@ pub struct NativeCacheOptions {
     pub max_memory_generations: Option<u32>,
     #[napi(js_name = "idleTimeout")]
     pub idle_timeout: Option<u32>,
+    #[napi(js_name = "readonly")]
+    pub readonly: Option<bool>,
 }
 
 #[napi(object)]
@@ -254,6 +256,7 @@ fn cache_options_from_native(options: NativeCacheOptions) -> CacheOptions {
         .collect();
     cache.max_memory_generations = options.max_memory_generations;
     cache.idle_timeout = options.idle_timeout;
+    cache.readonly = options.readonly.unwrap_or(false);
     cache
 }
 

--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -14,7 +14,7 @@ export const adapters = {
   unpack: {
     name: "unpack",
     versionSource: () => `@unpack-js/core@${packageVersion("@unpack-js/core")}`,
-    async build({ fixture, outputDir, cacheDir, persistentCache = true }) {
+    async build({ fixture, outputDir, cacheDir, persistentCache = true, cacheReadonly = false }) {
       const { default: unpack } = await import("@unpack-js/core");
       const compiler = unpack({
         mode: "none",
@@ -26,7 +26,8 @@ export const adapters = {
           ? {
               type: "filesystem",
               cacheLocation: cacheDir,
-              idleTimeout: 0
+              idleTimeout: 0,
+              readonly: cacheReadonly
             }
           : false
       });
@@ -51,7 +52,7 @@ export const adapters = {
   webpack: {
     name: "webpack",
     versionSource: () => `webpack@${packageVersion("webpack")}`,
-    async build({ fixture, outputDir, cacheDir, persistentCache = true }) {
+    async build({ fixture, outputDir, cacheDir, persistentCache = true, cacheReadonly = false }) {
       const webpackModule = await import("webpack");
       const webpack = webpackModule.default ?? webpackModule;
       const compiler = webpack({
@@ -59,7 +60,8 @@ export const adapters = {
         cache: persistentCache
           ? {
               type: "filesystem",
-              cacheDirectory: cacheDir
+              cacheDirectory: cacheDir,
+              readonly: cacheReadonly
             }
           : false
       });

--- a/packages/benchmarks/src/runner.mjs
+++ b/packages/benchmarks/src/runner.mjs
@@ -124,6 +124,7 @@ async function runBundlerBenchmark({ adapter, bundler, fixture, workspaceDir, op
     outputDir,
     cacheDir,
     persistentCache: true,
+    cacheReadonly: false,
     options
   });
   if (cold.status !== "success") {
@@ -137,6 +138,7 @@ async function runBundlerBenchmark({ adapter, bundler, fixture, workspaceDir, op
     outputDir,
     cacheDir,
     persistentCache: true,
+    cacheReadonly: true,
     options
   });
 
@@ -151,6 +153,7 @@ async function runBundlerBenchmark({ adapter, bundler, fixture, workspaceDir, op
     outputDir: noCacheOutputDir,
     cacheDir: noCacheCacheDir,
     persistentCache: false,
+    cacheReadonly: false,
     options
   });
 
@@ -164,6 +167,7 @@ async function timedBuild({
   outputDir,
   cacheDir,
   persistentCache,
+  cacheReadonly = false,
   options
 }) {
   if (phase === "cold" || phase === "no-cache") {
@@ -182,6 +186,7 @@ async function timedBuild({
       cacheDir,
       phase,
       persistentCache,
+      cacheReadonly,
       options
     });
   } catch (error) {

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -39,11 +39,15 @@ test("runner emits persistent-cache and no-cache measurements for a verified bun
     assert.equal(typeof report.results[0].no_cache_build_ms, "number");
     assert.ok(report.results[0].output_bytes > 0);
     assert.deepEqual(
-      calls.map(({ phase, persistentCache }) => ({ phase, persistentCache })),
+      calls.map(({ phase, persistentCache, cacheReadonly }) => ({
+        phase,
+        persistentCache,
+        cacheReadonly
+      })),
       [
-        { phase: "cold", persistentCache: true },
-        { phase: "warm", persistentCache: true },
-        { phase: "no-cache", persistentCache: false }
+        { phase: "cold", persistentCache: true, cacheReadonly: false },
+        { phase: "warm", persistentCache: true, cacheReadonly: true },
+        { phase: "no-cache", persistentCache: false, cacheReadonly: false }
       ]
     );
     const summary = toSummaryMarkdown(report);
@@ -229,8 +233,8 @@ function fakeAdapter({ checksumOffset = 0, error, calls } = {}) {
   return {
     name: "fake",
     versionSource: () => "fake@1.0.0",
-    async build({ fixture, outputDir, phase, persistentCache }) {
-      calls?.push({ phase, persistentCache });
+    async build({ fixture, outputDir, phase, persistentCache, cacheReadonly }) {
+      calls?.push({ phase, persistentCache, cacheReadonly });
       if (error) {
         throw error;
       }

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -28,6 +28,7 @@ export type CacheOptions =
       buildDependencies?: Record<string, string[]>;
       maxMemoryGenerations?: number;
       idleTimeout?: number;
+      readonly?: boolean;
     };
 
 export interface SnapshotOptions {
@@ -138,6 +139,7 @@ interface NormalizedCacheOptions {
   buildDependencies: NormalizedBuildDependency[];
   maxMemoryGenerations?: number;
   idleTimeout?: number;
+  readonly: boolean;
 }
 
 interface NormalizedBuildDependency {
@@ -262,14 +264,15 @@ class CompilerImpl implements Compiler {
   #watching: WatchingImpl | undefined;
   #idleFlushTimer: ReturnType<typeof setTimeout> | undefined;
   #pendingCacheFlush: Promise<NativeFlushResult> | undefined;
-  readonly #filesystemCache: boolean;
+  readonly #writableFilesystemCache: boolean;
   readonly #cacheIdleTimeout: number;
   readonly #infrastructureLoggingLevel: InfrastructureLoggingLevel;
   readonly #nativeCompiler: NativeCompiler;
 
   constructor(options: NormalizedOptions) {
     this.#nativeCompiler = native.createCompiler(options);
-    this.#filesystemCache = options.cache.type === "filesystem";
+    this.#writableFilesystemCache =
+      options.cache.type === "filesystem" && !options.cache.readonly;
     this.#cacheIdleTimeout = options.cache.idleTimeout ?? 0;
     this.#infrastructureLoggingLevel = options.infrastructureLogging.level;
   }
@@ -465,7 +468,7 @@ class CompilerImpl implements Compiler {
   }
 
   #scheduleIdleCacheFlush(): void {
-    if (!this.#filesystemCache || this.#closed) {
+    if (!this.#writableFilesystemCache || this.#closed) {
       return;
     }
 
@@ -484,7 +487,7 @@ class CompilerImpl implements Compiler {
   }
 
   async #flushCacheNow(): Promise<Error | null> {
-    if (!this.#filesystemCache) {
+    if (!this.#writableFilesystemCache) {
       return null;
     }
 
@@ -881,14 +884,16 @@ function normalizeCacheOptions(
   if (cache === undefined || cache === true) {
     return {
       type: "memory",
-      buildDependencies: []
+      buildDependencies: [],
+      readonly: false
     };
   }
 
   if (cache === false) {
     return {
       type: "disabled",
-      buildDependencies: []
+      buildDependencies: [],
+      readonly: false
     };
   }
 
@@ -906,7 +911,8 @@ function normalizeCacheOptions(
       "version",
       "buildDependencies",
       "maxMemoryGenerations",
-      "idleTimeout"
+      "idleTimeout",
+      "readonly"
     ],
     "options.cache"
   );
@@ -926,6 +932,10 @@ function normalizeCacheOptions(
         ? resolve(cacheDirectory, name ?? "default")
         : undefined
       : normalizePath(cache.cacheLocation, "options.cache.cacheLocation", context);
+  const readonly =
+    cache.readonly === undefined
+      ? false
+      : assertBoolean(cache.readonly, "options.cache.readonly");
 
   return {
     type,
@@ -951,7 +961,8 @@ function normalizeCacheOptions(
             cache.idleTimeout,
             "options.cache.idleTimeout"
           )
-        })
+        }),
+    readonly
   };
 }
 

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -499,7 +499,8 @@ test("accepts filesystem cache option shape", async () => {
       config: ["./config/build.js"]
     },
     maxMemoryGenerations: 2,
-    idleTimeout: 10
+    idleTimeout: 10,
+    readonly: false
   };
   const snapshot = {
     module: { timestamp: true, hash: false },
@@ -601,6 +602,35 @@ test("compiler close waits for pending filesystem cache flush", async () => {
       await readFile(join(cacheLocation, "container.json"), "utf8"),
       /UNPACK_PERSISTENT_CACHE/
     );
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("filesystem cache readonly skips persistent writes", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const cacheLocation = join(fixture, ".cache/unpack/readonly");
+  const compiler = unpack({
+    context: fixture,
+    entry: "./src/index.js",
+    cache: {
+      type: "filesystem",
+      cacheLocation,
+      idleTimeout: 0,
+      readonly: true
+    }
+  });
+
+  try {
+    const result = await runExistingCompiler(compiler);
+    assert.equal(result.err, null);
+    await delay(50);
+
+    await closeCompiler(compiler);
+    await assert.rejects(readFile(join(cacheLocation, "container.json"), "utf8"));
+    await assert.rejects(readFile(join(cacheLocation, "packs/modules.cbor"), "utf8"));
   } finally {
     await rm(fixture, { recursive: true, force: true });
   }
@@ -1053,6 +1083,18 @@ test("cache and snapshot option validation throws synchronously", () => {
         }
       }),
     /options.cache contains unknown option 'unknown'/
+  );
+  assert.throws(
+    () =>
+      unpack({
+        entry: "./src/index.js",
+        cache: {
+          type: "filesystem",
+          // @ts-expect-error intentionally testing runtime validation
+          readonly: "yes"
+        }
+      }),
+    /options.cache.readonly must be a boolean/
   );
   assert.throws(
     () =>


### PR DESCRIPTION
## Summary

Adds `cache.readonly` support for Unpack's persistent filesystem cache and enables readonly persistent cache during benchmark warm builds.

## Details

- Accepts and validates `cache.readonly` in the JavaScript API.
- Passes the option through the native binding into Rust `CacheOptions`.
- Allows filesystem cache restores while skipping dirty marking and persistent flush writes when readonly is enabled.
- Marks benchmark warm builds with `cacheReadonly: true` and maps that to Unpack and webpack cache configuration.

## Validation

- `cargo test --workspace`
- `pnpm --filter @unpack-js/core typecheck`
- `pnpm --filter @unpack-js/core test`
- `pnpm --filter @unpack-js/benchmarks test`
- `git diff --check`
