### PR TITLE
Cache generated assets for warm builds

### DIFF
--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -9,6 +9,8 @@ use std::{
 
 use crate::{
     ModuleIdentity, SnapshotOptions, SnapshotStrategy,
+    cache_hash::stable_hash,
+    code_generation::Asset,
     parser::ParsedModule,
     snapshot::{FileSystemInfo, Snapshot, SnapshotCache},
 };
@@ -36,6 +38,7 @@ pub(crate) struct CacheFacade<K, V> {
 
 pub(crate) type NormalModuleFactoryCache = CacheFacade<ResolveRequest, ResolveRecord>;
 pub(crate) type ModuleBuildCache = CacheFacade<ModuleIdentity, ModuleBuildRecord>;
+pub(crate) type AssetGenerationCache = CacheFacade<AssetGenerationKey, AssetGenerationRecord>;
 
 type CacheStoreAccessor<K, V> = for<'a> fn(&'a mut BuildCacheInner) -> &'a mut CacheStore<K, V>;
 
@@ -119,6 +122,7 @@ pub struct BuildDependency {
 struct BuildCacheInner {
     resolve_records: CacheStore<ResolveRequest, ResolveRecord>,
     module_builds: CacheStore<ModuleIdentity, ModuleBuildRecord>,
+    asset_generations: CacheStore<AssetGenerationKey, AssetGenerationRecord>,
     dirty: bool,
 }
 
@@ -293,14 +297,18 @@ impl ResolveRecord {
 pub(crate) struct ModuleBuildRecord {
     parsed: ParsedModule,
     source: String,
+    #[serde(default)]
+    source_hash: Option<u64>,
     snapshot: Snapshot,
 }
 
 impl ModuleBuildRecord {
     pub(crate) fn new(parsed: ParsedModule, source: String, snapshot: Snapshot) -> Self {
+        let source_hash = Some(stable_hash(&source));
         Self {
             parsed,
             source,
+            source_hash,
             snapshot,
         }
     }
@@ -309,8 +317,12 @@ impl ModuleBuildRecord {
         &self.parsed
     }
 
-    pub(crate) fn cloned_parts(&self) -> (ParsedModule, String) {
-        (self.parsed.clone(), self.source.clone())
+    pub(crate) fn cloned_parts(&self) -> (ParsedModule, String, Option<u64>) {
+        (self.parsed.clone(), self.source.clone(), self.source_hash)
+    }
+
+    pub(crate) fn source_hash(&self) -> Option<u64> {
+        self.source_hash
     }
 
     pub(crate) async fn is_valid(
@@ -321,6 +333,32 @@ impl ModuleBuildRecord {
         file_system_info
             .is_snapshot_valid(&self.snapshot, strategy)
             .await
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) struct AssetGenerationKey {
+    digest: u64,
+}
+
+impl AssetGenerationKey {
+    pub(crate) fn new(digest: u64) -> Self {
+        Self { digest }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct AssetGenerationRecord {
+    assets: Vec<Asset>,
+}
+
+impl AssetGenerationRecord {
+    pub(crate) fn new(assets: Vec<Asset>) -> Self {
+        Self { assets }
+    }
+
+    pub(crate) fn assets(&self) -> &[Asset] {
+        &self.assets
     }
 }
 
@@ -354,12 +392,19 @@ impl BuildCache {
         }
     }
 
+    pub(crate) fn asset_generations(&self) -> AssetGenerationCache {
+        CacheFacade {
+            build_cache: self.clone(),
+            store: asset_generations,
+        }
+    }
+
     pub(crate) fn flush_to_filesystem(&self) -> io::Result<()> {
         if self.options.kind != CacheKind::Filesystem || self.options.readonly {
             return Ok(());
         }
 
-        let (resolve_records, module_builds) = {
+        let (resolve_records, module_builds, asset_generations) = {
             let inner = self
                 .inner
                 .lock()
@@ -370,10 +415,11 @@ impl BuildCache {
             (
                 inner.resolve_records.records.clone(),
                 inner.module_builds.records.clone(),
+                inner.asset_generations.records.clone(),
             )
         };
 
-        self.write_filesystem_cache(&resolve_records, &module_builds)?;
+        self.write_filesystem_cache(&resolve_records, &module_builds, &asset_generations)?;
 
         self.inner
             .lock()
@@ -395,6 +441,9 @@ impl BuildCache {
             module_entries: inner.module_builds.entries(),
             module_hits: inner.module_builds.hits,
             module_misses: inner.module_builds.misses,
+            asset_entries: inner.asset_generations.entries(),
+            asset_hits: inner.asset_generations.hits,
+            asset_misses: inner.asset_generations.misses,
         }
     }
 }
@@ -475,12 +524,18 @@ impl BuildCache {
             .into_iter()
             .map(|(identity, record)| (identity, Arc::new(record)))
             .collect();
+        inner.asset_generations.records = pack
+            .asset_generations
+            .into_iter()
+            .map(|(key, record)| (key, Arc::new(record)))
+            .collect();
     }
 
     fn write_filesystem_cache(
         &self,
         resolve_records: &HashMap<ResolveRequest, Arc<ResolveRecord>>,
         module_builds: &HashMap<ModuleIdentity, Arc<ModuleBuildRecord>>,
+        asset_generations: &HashMap<AssetGenerationKey, Arc<AssetGenerationRecord>>,
     ) -> io::Result<()> {
         let Some(cache_location) = &self.options.cache_location else {
             return Ok(());
@@ -503,6 +558,10 @@ impl BuildCache {
             module_builds: module_builds
                 .iter()
                 .map(|(identity, record)| (identity.clone(), (**record).clone()))
+                .collect(),
+            asset_generations: asset_generations
+                .iter()
+                .map(|(key, record)| (*key, (**record).clone()))
                 .collect(),
         };
         let pack_payload = cbor4ii::serde::to_vec(Vec::new(), &pack)
@@ -605,6 +664,8 @@ struct CachePackDto {
     cache_version: String,
     resolve_records: Vec<(ResolveRequest, ResolveRecord)>,
     module_builds: Vec<(ModuleIdentity, ModuleBuildRecord)>,
+    #[serde(default)]
+    asset_generations: Vec<(AssetGenerationKey, AssetGenerationRecord)>,
 }
 
 #[cfg(test)]
@@ -616,6 +677,9 @@ pub(crate) struct BuildCacheStats {
     pub module_entries: usize,
     pub module_hits: usize,
     pub module_misses: usize,
+    pub asset_entries: usize,
+    pub asset_hits: usize,
+    pub asset_misses: usize,
 }
 
 fn resolve_records(inner: &mut BuildCacheInner) -> &mut CacheStore<ResolveRequest, ResolveRecord> {
@@ -631,6 +695,32 @@ mod tests {
 
     use super::*;
     use crate::{ModuleIdentity, snapshot::FileSystemInfo};
+
+    #[test]
+    fn cache_pack_without_asset_generations_deserializes_with_empty_asset_cache()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        #[derive(Serialize)]
+        struct OldCachePackDto {
+            magic: String,
+            cache_version: String,
+            resolve_records: Vec<(ResolveRequest, ResolveRecord)>,
+            module_builds: Vec<(ModuleIdentity, ModuleBuildRecord)>,
+        }
+
+        let old_pack = OldCachePackDto {
+            magic: CACHE_MAGIC.to_string(),
+            cache_version: "old".to_string(),
+            resolve_records: Vec::new(),
+            module_builds: Vec::new(),
+        };
+        let payload = cbor4ii::serde::to_vec(Vec::new(), &old_pack)?;
+        let pack: CachePackDto = cbor4ii::serde::from_slice(&payload)?;
+
+        assert_eq!(pack.magic, CACHE_MAGIC);
+        assert!(pack.asset_generations.is_empty());
+
+        Ok(())
+    }
 
     #[tokio::test]
     async fn resolve_record_context_snapshot_invalidates_directory_entry_changes()
@@ -677,4 +767,10 @@ fn module_builds(
     inner: &mut BuildCacheInner,
 ) -> &mut CacheStore<ModuleIdentity, ModuleBuildRecord> {
     &mut inner.module_builds
+}
+
+fn asset_generations(
+    inner: &mut BuildCacheInner,
+) -> &mut CacheStore<AssetGenerationKey, AssetGenerationRecord> {
+    &mut inner.asset_generations
 }

--- a/crates/unpack_core/src/cache_hash.rs
+++ b/crates/unpack_core/src/cache_hash.rs
@@ -1,0 +1,81 @@
+use std::hash::{Hash, Hasher};
+
+pub(crate) fn stable_hash<T: Hash + ?Sized>(value: &T) -> u64 {
+    let mut hasher = StableHasher::default();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct StableHasher {
+    state: u64,
+}
+
+impl Default for StableHasher {
+    fn default() -> Self {
+        Self {
+            state: 14_695_981_039_346_656_037,
+        }
+    }
+}
+
+impl Hasher for StableHasher {
+    fn finish(&self) -> u64 {
+        self.state
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            self.state ^= u64::from(*byte);
+            self.state = self.state.wrapping_mul(1_099_511_628_211);
+        }
+    }
+
+    fn write_u8(&mut self, i: u8) {
+        self.write(&[i]);
+    }
+
+    fn write_u16(&mut self, i: u16) {
+        self.write(&i.to_le_bytes());
+    }
+
+    fn write_u32(&mut self, i: u32) {
+        self.write(&i.to_le_bytes());
+    }
+
+    fn write_u64(&mut self, i: u64) {
+        self.write(&i.to_le_bytes());
+    }
+
+    fn write_u128(&mut self, i: u128) {
+        self.write(&i.to_le_bytes());
+    }
+
+    fn write_usize(&mut self, i: usize) {
+        self.write_u64(i as u64);
+    }
+
+    fn write_i8(&mut self, i: i8) {
+        self.write_u8(i as u8);
+    }
+
+    fn write_i16(&mut self, i: i16) {
+        self.write(&i.to_le_bytes());
+    }
+
+    fn write_i32(&mut self, i: i32) {
+        self.write(&i.to_le_bytes());
+    }
+
+    fn write_i64(&mut self, i: i64) {
+        self.write(&i.to_le_bytes());
+    }
+
+    fn write_i128(&mut self, i: i128) {
+        self.write(&i.to_le_bytes());
+    }
+
+    fn write_isize(&mut self, i: isize) {
+        self.write_i64(i as i64);
+    }
+}

--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -1,9 +1,11 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
 use rspack_sources::{
     ConcatSource, MapOptions, ObjectPool, OriginalSource, RawStringSource, ReplaceSource, Source,
 };
+use serde::{Deserialize, Serialize};
 
 use crate::{
     AsyncBlockOrigin, Chunk, ChunkGraph, ChunkGroupKind, CompilerOptions, ConstDependency,
@@ -11,9 +13,11 @@ use crate::{
     HarmonyExportHeaderDependency, HarmonyExportImportedSpecifierDependency,
     HarmonyExportSpecifierDependency, HarmonyImportSideEffectDependency,
     HarmonyImportSpecifierDependency, ImportDependency, Module, ModuleGraph, ModuleId, SourceRange,
+    build_cache::{AssetGenerationCache, AssetGenerationKey, AssetGenerationRecord},
+    cache_hash::StableHasher,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Asset {
     pub filename: String,
     pub source: String,
@@ -93,9 +97,46 @@ pub(crate) fn create_assets(
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
     entries: &[ModuleId],
+    asset_cache: &AssetGenerationCache,
 ) -> Vec<Asset> {
     let render_context = RenderPathContext::new(options.context.as_path());
     let module_render_ids = module_render_ids(&render_context, module_graph);
+
+    let cache_key = asset_cache.is_enabled().then(|| {
+        asset_generation_key(
+            options,
+            module_graph,
+            chunk_graph,
+            entries,
+            &module_render_ids,
+        )
+    });
+    if let Some(key) = cache_key {
+        if let Some(record) = asset_cache.get(&key) {
+            return record.assets().to_vec();
+        }
+    }
+
+    let assets = render_assets(
+        options,
+        module_graph,
+        chunk_graph,
+        entries,
+        &module_render_ids,
+    );
+    if let Some(key) = cache_key {
+        asset_cache.store(key, AssetGenerationRecord::new(assets.clone()));
+    }
+    assets
+}
+
+fn render_assets(
+    options: &CompilerOptions,
+    module_graph: &ModuleGraph,
+    chunk_graph: &ChunkGraph,
+    entries: &[ModuleId],
+    module_render_ids: &HashMap<ModuleId, String>,
+) -> Vec<Asset> {
     let mut assets = Vec::new();
 
     for (entry_index, group_id) in chunk_graph.entrypoints().iter().copied().enumerate() {
@@ -141,6 +182,85 @@ pub(crate) fn create_assets(
     }
 
     assets
+}
+
+fn asset_generation_key(
+    options: &CompilerOptions,
+    module_graph: &ModuleGraph,
+    chunk_graph: &ChunkGraph,
+    entries: &[ModuleId],
+    module_render_ids: &HashMap<ModuleId, String>,
+) -> AssetGenerationKey {
+    let mut hasher = StableHasher::default();
+    "unpack.asset_generation.v1".hash(&mut hasher);
+    options.context.hash(&mut hasher);
+    options.sourcemap.hash(&mut hasher);
+    options.entries.len().hash(&mut hasher);
+    for entry in &options.entries {
+        entry.name.hash(&mut hasher);
+        entry.request.hash(&mut hasher);
+    }
+    entries.hash(&mut hasher);
+
+    for module in module_graph.modules() {
+        module.id().hash(&mut hasher);
+        module.identity().hash(&mut hasher);
+        module_render_ids.get(&module.id()).hash(&mut hasher);
+        module.source_hash().hash(&mut hasher);
+        module.source_len().hash(&mut hasher);
+        module.dependencies().hash(&mut hasher);
+        module.presentational_dependencies().hash(&mut hasher);
+        module.blocks().hash(&mut hasher);
+        for export in module.exports_info().provided_exports() {
+            export.hash(&mut hasher);
+        }
+        module
+            .build_error()
+            .map(ToString::to_string)
+            .hash(&mut hasher);
+    }
+
+    for connection in module_graph.connections() {
+        connection.origin_module.hash(&mut hasher);
+        connection
+            .origin_module
+            .and_then(|module_id| module_graph.module(module_id))
+            .map(Module::identity)
+            .hash(&mut hasher);
+        connection.origin_block.hash(&mut hasher);
+        connection.origin_dependency_id.hash(&mut hasher);
+        connection.dependency.hash(&mut hasher);
+        connection.module.hash(&mut hasher);
+        module_graph
+            .module(connection.module)
+            .map(Module::identity)
+            .hash(&mut hasher);
+    }
+
+    chunk_graph.entrypoints().hash(&mut hasher);
+    for group in chunk_graph.chunk_groups() {
+        group.id().hash(&mut hasher);
+        match group.kind() {
+            ChunkGroupKind::Entrypoint { name } => {
+                0u8.hash(&mut hasher);
+                name.hash(&mut hasher);
+            }
+            ChunkGroupKind::Async => 1u8.hash(&mut hasher),
+        }
+        group.chunks().hash(&mut hasher);
+        group.parents().hash(&mut hasher);
+        group.children().hash(&mut hasher);
+        group.origin().hash(&mut hasher);
+    }
+    for chunk in chunk_graph.chunks() {
+        chunk.id().hash(&mut hasher);
+        chunk.render_id().hash(&mut hasher);
+        chunk.filename().hash(&mut hasher);
+        chunk.groups().hash(&mut hasher);
+        chunk_graph.chunk_modules(chunk.id()).hash(&mut hasher);
+    }
+
+    AssetGenerationKey::new(hasher.finish())
 }
 
 fn emit_asset(filename: String, mut source: ConcatSource, sourcemap: bool) -> Vec<Asset> {

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -157,6 +157,7 @@ impl Compilation {
             &self.module_graph,
             &self.chunk_graph,
             &self.entries,
+            &self.build_cache.asset_generations(),
         );
         self.log_infrastructure(
             InfrastructureLogLevel::Verbose,

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -248,6 +248,85 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn filesystem_cache_restores_asset_generation_records_for_later_compiler_instances()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write(
+            temp.path().join("index.js"),
+            r#"
+                import { value } from "./dep";
+                export const result = value;
+            "#,
+        )?;
+        write(temp.path().join("dep.js"), "export const value = 1;")?;
+        let cache_location = temp.path().join(".cache/unpack/default");
+
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache = CacheOptions::filesystem();
+        options.cache.cache_location = Some(cache_location);
+        options.cache.version = Some("asset-generation-cache-test".to_string());
+
+        let first_compiler = Compiler::new(options.clone());
+        let first = first_compiler.run().await?;
+        let first_cache = first_compiler.build_cache.stats();
+        assert_eq!(first_cache.asset_entries, 1);
+        assert_eq!(first_cache.asset_hits, 0);
+        assert_eq!(first_cache.asset_misses, 1);
+        first_compiler.flush_cache()?;
+
+        let second_compiler = Compiler::new(options);
+        assert_eq!(second_compiler.build_cache.stats().asset_entries, 1);
+
+        let second = second_compiler.run().await?;
+        let second_cache = second_compiler.build_cache.stats();
+        assert_eq!(second_cache.asset_hits, 1);
+        assert_eq!(second_cache.asset_misses, 0);
+        assert_eq!(asset_sources(&first), asset_sources(&second));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn asset_generation_cache_key_changes_when_module_source_changes()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let entry = temp.path().join("index.js");
+        write(&entry, "export const value = 'before';")?;
+
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.snapshot.module = crate::SnapshotStrategy::hash();
+        let compiler = Compiler::new(options);
+
+        let first = compiler.run().await?;
+        assert!(
+            asset_sources(&first)
+                .get("main.js")
+                .expect("main asset should exist")
+                .contains("before")
+        );
+        let first_cache = compiler.build_cache.stats();
+        assert_eq!(first_cache.asset_entries, 1);
+        assert_eq!(first_cache.asset_hits, 0);
+        assert_eq!(first_cache.asset_misses, 1);
+
+        write(&entry, "export const value = 'after';")?;
+
+        let second = compiler.run().await?;
+        assert!(
+            asset_sources(&second)
+                .get("main.js")
+                .expect("main asset should exist")
+                .contains("after")
+        );
+        let second_cache = compiler.build_cache.stats();
+        assert_eq!(second_cache.asset_entries, 2);
+        assert_eq!(second_cache.asset_hits, 0);
+        assert_eq!(second_cache.asset_misses, 2);
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn filesystem_cache_readonly_restores_but_skips_persistent_updates()
     -> std::result::Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -1,4 +1,5 @@
 mod build_cache;
+mod cache_hash;
 mod chunk_graph;
 mod code_generation;
 mod compilation;

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -14,6 +14,7 @@ use crate::{
     CompilerOptions, Dependency, DependencyKind, Error, FactorizedModule, ModuleGraph, ModuleId,
     ModuleIdentity, NormalModuleFactory, Result, SnapshotStrategy, UnpackResolver,
     build_cache::{BuildCache, ModuleBuildCache, ModuleBuildRecord},
+    cache_hash::stable_hash,
     parser::{ParsedModule, parse_module_dependencies},
     snapshot::FileSystemInfo,
 };
@@ -365,11 +366,11 @@ impl BuildTask {
             {
                 let process_dependencies =
                     process_dependencies_task(self.module_id, &issuer_context, record.parsed());
-                let (parsed, source) = record.cloned_parts();
+                let (parsed, source, source_hash) = record.cloned_parts();
                 state
                     .lock()
                     .await
-                    .finish_build(self.module_id, parsed, source)?;
+                    .finish_build(self.module_id, parsed, source, source_hash)?;
                 return Ok(process_dependencies.into_iter().collect());
             }
         }
@@ -403,7 +404,7 @@ impl BuildTask {
             state
                 .lock()
                 .await
-                .finish_build(self.module_id, parsed, source)?;
+                .finish_build(self.module_id, parsed, source, None)?;
             return Ok(process_dependencies.into_iter().collect());
         }
 
@@ -412,11 +413,12 @@ impl BuildTask {
             .create_file_snapshot(&self.resource, &source, services.module_snapshot_strategy)
             .await?;
         let record = ModuleBuildRecord::new(parsed.clone(), source.clone(), snapshot);
+        let source_hash = record.source_hash();
 
         state
             .lock()
             .await
-            .finish_build(self.module_id, parsed, source)?;
+            .finish_build(self.module_id, parsed, source, source_hash)?;
         services.module_build_cache.store(self.identity, record);
 
         Ok(process_dependencies.into_iter().collect())
@@ -606,16 +608,19 @@ impl MakeState {
         module_id: ModuleId,
         parsed: ParsedModule,
         source: String,
+        source_hash: Option<u64>,
     ) -> Result<()> {
         let module = self
             .module_graph
             .module_mut(module_id)
             .ok_or(Error::MissingModule(module_id))?;
+        let source_hash = source_hash.unwrap_or_else(|| stable_hash(&source));
         module.finish_build(
             parsed.dependencies,
             parsed.blocks,
             parsed.presentational_dependencies,
             source,
+            source_hash,
         );
         Ok(())
     }

--- a/crates/unpack_core/src/module.rs
+++ b/crates/unpack_core/src/module.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{AsyncDependenciesBlock, Dependency, Error, ExportsInfo};
+use crate::{AsyncDependenciesBlock, Dependency, Error, ExportsInfo, cache_hash::stable_hash};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ModuleId(usize);
@@ -27,6 +27,7 @@ pub struct Module {
     exports_info: ExportsInfo,
     source: String,
     source_len: usize,
+    source_hash: u64,
     build_error: Option<Error>,
 }
 
@@ -41,6 +42,7 @@ impl Module {
             exports_info: ExportsInfo::default(),
             source: String::new(),
             source_len: 0,
+            source_hash: stable_hash(""),
             build_error: None,
         }
     }
@@ -77,6 +79,10 @@ impl Module {
         self.source_len
     }
 
+    pub fn source_hash(&self) -> u64 {
+        self.source_hash
+    }
+
     pub fn build_error(&self) -> Option<&Error> {
         self.build_error.as_ref()
     }
@@ -87,9 +93,11 @@ impl Module {
         blocks: Vec<AsyncDependenciesBlock>,
         presentational_dependencies: Vec<Dependency>,
         source: String,
+        source_hash: u64,
     ) {
         self.exports_info = ExportsInfo::from_dependencies(&dependencies);
         self.source_len = source.len();
+        self.source_hash = source_hash;
         self.source = source;
         self.dependencies = dependencies;
         self.blocks = blocks;
@@ -100,6 +108,7 @@ impl Module {
     pub(crate) fn fail_build(&mut self, error: Error, source: String) {
         self.exports_info = ExportsInfo::default();
         self.source_len = source.len();
+        self.source_hash = stable_hash(&source);
         self.source = source;
         self.dependencies.clear();
         self.blocks.clear();


### PR DESCRIPTION
## Summary

Adds a persistent asset-generation cache on top of the existing resolve and module build records. Warm builds now restore generated asset output from the filesystem cache when the module graph, chunk graph, entry configuration, and source hashes match.

## Why

The warm-build profile showed that Unpack could restore resolve and module build records but still paid the final asset/code generation cost on every warm run. Webpack avoids more of that work with deeper codegen/assets caching, so this adds the first comparable cache boundary in Unpack.

## Impact

Large benchmark fixtures now benefit from warm asset reuse. Smaller fixtures can still be dominated by fixed restore and snapshot-validation overhead, so this does not claim full webpack parity yet.

## Validation

- `cargo test --workspace`
- `pnpm --filter @unpack-js/core test`
- `pnpm --filter @unpack-js/benchmarks test`
- `UNPACK_NATIVE_PROFILE=release pnpm --filter @unpack-js/core build && pnpm --filter @unpack-js/benchmarks bench -- --bundlers unpack --fixtures small,medium,large`