### PR TITLE
Print Unpack phase timings in benchmark PR comments

### DIFF
--- a/.github/workflows/cross-bundler-benchmark.yml
+++ b/.github/workflows/cross-bundler-benchmark.yml
@@ -59,12 +59,22 @@ jobs:
         id: benchmark
         continue-on-error: true
         run: |
+          mkdir -p .benchmark-work/ci
           pnpm --filter @unpack-js/benchmarks bench -- \
             --workspace .benchmark-work/ci \
             --output-json .benchmark-work/ci/results.json \
             --summary-md .benchmark-work/ci/summary.md \
             --turbopack-repo .benchmark-tools/next.js \
-            --turbopack-commit "$TURBOPACK_NEXT_COMMIT"
+            --turbopack-commit "$TURBOPACK_NEXT_COMMIT" \
+            2> >(tee .benchmark-work/ci/unpack-tracing.log | sed -E '/^\[unpack tracing\]/d; / TRACE .*: .*: close time\.busy=/d' >&2)
+
+      - name: Format Unpack tracing summary
+        if: always()
+        run: |
+          mkdir -p .benchmark-work/ci
+          node packages/benchmarks/src/tracing-summary.mjs \
+            .benchmark-work/ci/unpack-tracing.log \
+            .benchmark-work/ci/unpack-tracing-summary.md
 
       - name: Publish benchmark summary
         if: always()
@@ -120,6 +130,33 @@ jobs:
               -f body="$(cat "$comment_file")"
           fi
 
+      - name: Comment Unpack phase timings on PR
+        if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          trace_summary_file=".benchmark-work/ci/unpack-tracing-summary.md"
+          comment_file=".benchmark-work/ci/tracing-comment.md"
+          mkdir -p "$(dirname "$comment_file")"
+
+          {
+            echo "## Unpack Phase Timings"
+            echo
+            echo "[Workflow run]($RUN_URL)"
+            echo
+            if [ -f "$trace_summary_file" ]; then
+              cat "$trace_summary_file"
+            else
+              echo "No Unpack tracing phase timings were captured. Check the workflow logs for setup or runner failures."
+            fi
+          } > "$comment_file"
+
+          gh api --method POST "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+            -f body="$(cat "$comment_file")"
+
       - name: Upload benchmark results
         if: always()
         uses: actions/upload-artifact@v4
@@ -128,4 +165,6 @@ jobs:
           path: |
             .benchmark-work/ci/results.json
             .benchmark-work/ci/summary.md
+            .benchmark-work/ci/unpack-tracing.log
+            .benchmark-work/ci/unpack-tracing-summary.md
           if-no-files-found: warn

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +546,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -660,6 +681,15 @@ name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "num-bigint"
@@ -945,6 +975,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,6 +1251,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1262,8 +1340,15 @@ dependencies = [
  "regex",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "unpack_core",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ tempfile = "3.23.0"
 thiserror = "2.0.17"
 tokio = { version = "1.48.0", features = ["fs", "macros", "rt", "rt-multi-thread", "sync"] }
 tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt"] }

--- a/crates/unpack_node/Cargo.toml
+++ b/crates/unpack_node/Cargo.toml
@@ -14,6 +14,7 @@ napi-derive = { workspace = true }
 regex = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 unpack_core = { path = "../unpack_core" }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -9,6 +9,7 @@ use std::{
 
 use napi::{Env, Result, Task, bindgen_prelude::AsyncTask};
 use napi_derive::napi;
+use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
 use unpack_core::{
     Asset, BuildDependency, CacheOptions, Compiler, CompilerOptions, Entry, Error as CoreError,
     InfrastructureLogEvent, InfrastructureLogLevel, InfrastructureLoggingOptions, SnapshotOptions,
@@ -20,6 +21,8 @@ use unpack_core::{
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 const MAX_BLOCKING_THREADS: usize = 4;
+const INTERNAL_TRACING_ENV: &str = "UNPACK_INTERNAL_TRACING";
+const DEFAULT_INTERNAL_TRACING_FILTER: &str = "unpack_core=trace,unpack_node=trace";
 
 #[cfg(not(target_family = "wasm"))]
 napi::ctor::declarative::ctor! {
@@ -180,6 +183,7 @@ pub struct NativeFlushResult {
 
 #[napi(js_name = "createCompiler")]
 pub fn create_compiler(options: NativeCompilerOptions) -> Result<NativeCompiler> {
+    init_internal_tracing_from_env();
     NativeCompiler::new(options)
 }
 
@@ -209,6 +213,38 @@ impl NativeCompiler {
     #[napi]
     pub fn close(&mut self) {
         self.compiler = None;
+    }
+}
+
+fn init_internal_tracing_from_env() {
+    let Some(filter) = internal_tracing_filter() else {
+        return;
+    };
+    let Ok(env_filter) = EnvFilter::try_new(&filter) else {
+        eprintln!("ignoring invalid {INTERNAL_TRACING_ENV} tracing filter: {filter}");
+        return;
+    };
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_span_events(FmtSpan::CLOSE)
+        .with_target(true)
+        .with_ansi(false)
+        .with_writer(std::io::stderr)
+        .finish();
+
+    let _ = tracing::subscriber::set_global_default(subscriber);
+}
+
+fn internal_tracing_filter() -> Option<String> {
+    let value = std::env::var(INTERNAL_TRACING_ENV).ok()?;
+    let value = value.trim();
+    match value {
+        "" | "0" | "false" | "False" | "FALSE" | "off" | "Off" | "OFF" | "none" | "None"
+        | "NONE" => None,
+        "1" | "true" | "True" | "TRUE" | "on" | "On" | "ON" => {
+            Some(DEFAULT_INTERNAL_TRACING_FILTER.to_string())
+        }
+        _ => Some(value.to_string()),
     }
 }
 

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -16,6 +16,13 @@ To run only the fast local smoke subset:
 pnpm --filter @unpack-js/benchmarks bench -- --fixtures small --bundlers unpack,webpack,rspack,rolldown
 ```
 
+The cross-bundler benchmark prints Unpack internal tracing details to stderr for
+each Unpack build phase. The default filter is
+`unpack_core=trace,unpack_node=trace`, which shows the coarse compiler spans and
+their close-time busy/idle durations. Pass `--no-unpack-tracing` for quiet
+benchmark logs, or `--unpack-tracing <filter>` to use a custom Rust
+`tracing-subscriber` filter.
+
 Turbopack requires a fixed Next.js checkout:
 
 ```sh
@@ -51,7 +58,7 @@ Runtime verification is separate from build timing. A Bundle that builds but doe
 
 ## CI
 
-The `Cross-Bundler Benchmarks` workflow runs on pushes to `main`, pull requests, and manual dispatch. It writes the table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, and uploads the JSON report as an artifact.
+The `Cross-Bundler Benchmarks` workflow runs on pushes to `main`, pull requests, and manual dispatch. It writes the table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, writes an Unpack phase timing summary to a new pull request issue comment, and uploads the JSON report, Markdown summary, tracing summary, and raw tracing log as artifacts.
 
 The workflow builds the Unpack native addon with `UNPACK_NATIVE_PROFILE=release` so benchmark results compare optimized native builds.
 

--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -9,12 +9,23 @@ import { DEFAULT_TURBOPACK_COMMIT } from "./runner.mjs";
 const execFile = promisify(execFileCallback);
 const require = createRequire(import.meta.url);
 const preparedTurbopackBuilds = new Set();
+const UNPACK_INTERNAL_TRACING_ENV = "UNPACK_INTERNAL_TRACING";
+const DEFAULT_UNPACK_TRACING_FILTER = "unpack_core=trace,unpack_node=trace";
 
 export const adapters = {
   unpack: {
     name: "unpack",
     versionSource: () => `@unpack-js/core@${packageVersion("@unpack-js/core")}`,
-    async build({ fixture, outputDir, cacheDir, persistentCache = true, cacheReadonly = false }) {
+    async build({
+      fixture,
+      outputDir,
+      cacheDir,
+      phase,
+      persistentCache = true,
+      cacheReadonly = false,
+      options
+    }) {
+      configureUnpackTracing({ fixture, phase, persistentCache, cacheReadonly, options });
       const { default: unpack } = await import("@unpack-js/core");
       const compiler = unpack({
         mode: "none",
@@ -355,6 +366,48 @@ function packageVersionFromResolvedEntry(packageName) {
     current = dirname(current);
   }
   return "unknown";
+}
+
+function configureUnpackTracing({ fixture, phase, persistentCache, cacheReadonly, options }) {
+  const filter = unpackTracingFilter(options);
+  if (!filter) {
+    process.env[UNPACK_INTERNAL_TRACING_ENV] = "off";
+    return;
+  }
+
+  process.env[UNPACK_INTERNAL_TRACING_ENV] = filter;
+  process.stderr.write(
+    [
+      "[unpack tracing]",
+      `fixture=${fixture.name}`,
+      `phase=${phase}`,
+      `persistent_cache=${persistentCache ? "on" : "off"}`,
+      `cache_readonly=${cacheReadonly ? "on" : "off"}`,
+      `filter=${filter}`
+    ].join(" ") + "\n"
+  );
+}
+
+function unpackTracingFilter(options) {
+  const value = options?.unpackTracing ?? DEFAULT_UNPACK_TRACING_FILTER;
+  if (value === false) {
+    return null;
+  }
+  const normalized = String(value).trim();
+  const lowered = normalized.toLowerCase();
+  if (
+    normalized === "" ||
+    normalized === "0" ||
+    lowered === "false" ||
+    lowered === "off" ||
+    lowered === "none"
+  ) {
+    return null;
+  }
+  if (normalized === "1" || lowered === "true" || lowered === "on") {
+    return DEFAULT_UNPACK_TRACING_FILTER;
+  }
+  return normalized;
 }
 
 function unsupported(message) {

--- a/packages/benchmarks/src/run.mjs
+++ b/packages/benchmarks/src/run.mjs
@@ -62,6 +62,12 @@ function parseArgs(args) {
       case "--summary-md":
         parsed.summaryMd = resolve(invocationCwd, value());
         break;
+      case "--unpack-tracing":
+        parsed.unpackTracing = value();
+        break;
+      case "--no-unpack-tracing":
+        parsed.unpackTracing = false;
+        break;
       case "--turbopack-repo":
         parsed.turbopackRepo = resolve(invocationCwd, value());
         break;
@@ -101,6 +107,8 @@ Options:
   --bundlers <list>             Comma-separated bundler list
   --output-json <path>          Write raw JSON report
   --summary-md <path>           Write Markdown summary table
+  --unpack-tracing <filter>     Set the Unpack tracing filter (default: unpack_core=trace,unpack_node=trace)
+  --no-unpack-tracing           Do not print Unpack tracing details
   --turbopack-repo <path>       Fixed Next.js checkout containing turbopack/
   --turbopack-commit <sha>      Commit shown for Turbopack results
   --turbopack-profile <name>    Cargo profile for turbopack-cli (default: release)

--- a/packages/benchmarks/src/tracing-summary.mjs
+++ b/packages/benchmarks/src/tracing-summary.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const PHASE_COLUMNS = [
+  ["compilerRun", "compiler run"],
+  ["make", "make"],
+  ["chunkGraph", "chunk graph"],
+  ["createAssets", "asset creation"],
+  ["emitAssets", "emit assets"],
+  ["flushCache", "flush cache"]
+];
+
+export function parseUnpackTracingSummary(log) {
+  const rows = [];
+  let current;
+
+  for (const line of log.split(/\r?\n/)) {
+    const header = parseTracingHeader(line);
+    if (header) {
+      current = {
+        fixture: header.fixture,
+        build: header.phase
+      };
+      rows.push(current);
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+
+    const span = parseSpanClose(line);
+    if (!span) {
+      continue;
+    }
+
+    const key = phaseKey(span.name);
+    if (!key) {
+      continue;
+    }
+
+    current[key] = (current[key] ?? 0) + span.durationMs;
+  }
+
+  return rows;
+}
+
+export function toUnpackTracingSummaryMarkdown(rows) {
+  if (rows.length === 0) {
+    return "No Unpack tracing phase timings were captured.\n";
+  }
+
+  const lines = [
+    "Durations are Rust tracing span close elapsed times.",
+    "",
+    [
+      "fixture",
+      "build",
+      ...PHASE_COLUMNS.map(([, label]) => `${label} ms`)
+    ].join(" | ").replace(/^/, "| ").replace(/$/, " |"),
+    [
+      "---",
+      "---",
+      ...PHASE_COLUMNS.map(() => "---:")
+    ].join(" | ").replace(/^/, "| ").replace(/$/, " |")
+  ];
+
+  for (const row of rows) {
+    lines.push(
+      [
+        row.fixture,
+        row.build,
+        ...PHASE_COLUMNS.map(([key]) => formatMs(row[key]))
+      ].join(" | ").replace(/^/, "| ").replace(/$/, " |")
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function parseTracingHeader(line) {
+  if (!line.startsWith("[unpack tracing]")) {
+    return null;
+  }
+
+  const fields = new Map();
+  for (const match of line.matchAll(/\b([a-z_]+)=([^\s]+)/g)) {
+    fields.set(match[1], match[2]);
+  }
+
+  const fixture = fields.get("fixture");
+  const phase = fields.get("phase");
+  if (!fixture || !phase) {
+    return null;
+  }
+  return { fixture, phase };
+}
+
+function parseSpanClose(line) {
+  const match = line.match(
+    /\bTRACE\s+(.+):\s+\S+:\s+close\s+time\.busy=(\S+)\s+time\.idle=(\S+)/
+  );
+  if (!match) {
+    return null;
+  }
+
+  const busyMs = parseDurationMs(match[2]);
+  const idleMs = parseDurationMs(match[3]);
+  if (busyMs === null || idleMs === null) {
+    return null;
+  }
+
+  return {
+    name: match[1],
+    durationMs: busyMs + idleMs
+  };
+}
+
+function phaseKey(name) {
+  if (name === "Compiler::run") {
+    return "compilerRun";
+  }
+  if (name.includes("Compilation::make")) {
+    return "make";
+  }
+  if (name.includes("Compilation::build_chunk_graph")) {
+    return "chunkGraph";
+  }
+  if (name.includes("Compilation::create_assets")) {
+    return "createAssets";
+  }
+  if (name === "unpack_node::emit_assets") {
+    return "emitAssets";
+  }
+  if (name === "Compiler::flush_cache") {
+    return "flushCache";
+  }
+  return null;
+}
+
+function parseDurationMs(value) {
+  const match = value.match(/^([0-9]+(?:\.[0-9]+)?)(ns|µs|us|ms|s)$/);
+  if (!match) {
+    return null;
+  }
+
+  const amount = Number(match[1]);
+  switch (match[2]) {
+    case "ns":
+      return amount / 1_000_000;
+    case "µs":
+    case "us":
+      return amount / 1_000;
+    case "ms":
+      return amount;
+    case "s":
+      return amount * 1_000;
+    default:
+      return null;
+  }
+}
+
+function formatMs(value) {
+  if (value === undefined) {
+    return "";
+  }
+  return value.toFixed(3);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const [, , inputPath, outputPath] = process.argv;
+  if (!inputPath || !outputPath) {
+    process.stderr.write("Usage: node src/tracing-summary.mjs <input-log> <output-md>\n");
+    process.exit(1);
+  }
+
+  const log = await readFile(inputPath, "utf8").catch(() => "");
+  const markdown = toUnpackTracingSummaryMarkdown(parseUnpackTracingSummary(log));
+  await writeFile(outputPath, markdown, "utf8");
+}

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -108,7 +108,7 @@ test("runner reports unsupported adapters explicitly", async () => {
   }
 });
 
-test("CLI accepts pnpm-style -- separator and writes JSON output", async () => {
+test("CLI accepts pnpm-style -- separator, tracing option, and writes JSON output", async () => {
   const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
   const outputJson = join(workspace, "results.json");
 
@@ -125,7 +125,9 @@ test("CLI accepts pnpm-style -- separator and writes JSON output", async () => {
         "--workspace",
         join(workspace, "run"),
         "--output-json",
-        outputJson
+        outputJson,
+        "--unpack-tracing",
+        "unpack_core=trace"
       ],
       {
         cwd: join(import.meta.dirname, "..")

--- a/packages/benchmarks/test/tracing-summary.test.mjs
+++ b/packages/benchmarks/test/tracing-summary.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseUnpackTracingSummary,
+  toUnpackTracingSummaryMarkdown
+} from "../src/tracing-summary.mjs";
+
+test("tracing summary groups major phase timings by fixture and build phase", () => {
+  const rows = parseUnpackTracingSummary(`[unpack tracing] fixture=small phase=cold persistent_cache=on cache_readonly=off filter=unpack_core=trace,unpack_node=trace
+2026-07-02T10:52:55.739797Z TRACE Compiler::run:Compilation::make: unpack_core::compilation: close time.busy=5.87ms time.idle=9.18ms
+2026-07-02T10:52:55.740174Z TRACE Compiler::run:Compilation::build_chunk_graph: unpack_core::compilation: close time.busy=184µs time.idle=4.46µs
+2026-07-02T10:52:55.741663Z TRACE Compiler::run:Compilation::create_assets: unpack_core::compilation: close time.busy=1.46ms time.idle=3.92µs
+2026-07-02T10:52:55.741697Z TRACE Compiler::run: unpack_core::compiler: close time.busy=8.40ms time.idle=9.02ms
+2026-07-02T10:52:55.742432Z TRACE unpack_node::emit_assets: unpack_node: close time.busy=709µs time.idle=4.75µs
+2026-07-02T10:52:55.747219Z TRACE Compiler::flush_cache: unpack_core::compiler: close time.busy=3.64ms time.idle=16.6µs
+[unpack tracing] fixture=small phase=warm persistent_cache=on cache_readonly=on filter=unpack_core=trace,unpack_node=trace
+2026-07-02T10:52:55.762452Z TRACE Compiler::run:Compilation::make: unpack_core::compilation: close time.busy=3.90ms time.idle=1.96ms
+2026-07-02T10:52:55.763750Z TRACE Compiler::run: unpack_core::compiler: close time.busy=5.32ms time.idle=1.90ms
+`);
+
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0].fixture, "small");
+  assert.equal(rows[0].build, "cold");
+  assert.equal(rows[0].compilerRun.toFixed(3), "17.420");
+  assert.equal(rows[0].make.toFixed(3), "15.050");
+  assert.equal(rows[0].chunkGraph.toFixed(3), "0.188");
+  assert.equal(rows[0].createAssets.toFixed(3), "1.464");
+  assert.equal(rows[0].emitAssets.toFixed(3), "0.714");
+  assert.equal(rows[0].flushCache.toFixed(3), "3.657");
+  assert.equal(rows[1].fixture, "small");
+  assert.equal(rows[1].build, "warm");
+  assert.equal(rows[1].compilerRun.toFixed(3), "7.220");
+  assert.equal(rows[1].make.toFixed(3), "5.860");
+
+  const markdown = toUnpackTracingSummaryMarkdown(rows);
+  assert.match(markdown, /\\| fixture \\| build \\| compiler run ms \\| make ms \\|/);
+  assert.match(markdown, /\\| small \\| cold \\| 17\\.420 \\| 15\\.050 \\| 0\\.188 \\| 1\\.464 \\| 0\\.714 \\| 3\\.657 \\|/);
+  assert.match(markdown, /\\| small \\| warm \\| 7\\.220 \\| 5\\.860 \\|  \\|  \\|  \\|  \\|/);
+});


### PR DESCRIPTION
## Summary

- enable benchmark-owned Unpack internal tracing through the native addon
- capture raw tracing during the cross-bundler benchmark while keeping CI logs focused
- generate a compact Unpack phase timing table for a new PR issue comment
- document the benchmark tracing controls and CI outputs

## Impact

The cross-bundler benchmark now gives maintainers phase-level Unpack timings for cold, warm, and no-cache runs without flooding PR comments with raw tracing lines. The raw tracing log remains available as a workflow artifact for deeper debugging.

## Validation

- `cargo check -p unpack_node`
- `pnpm --filter @unpack-js/benchmarks test`
- `pnpm --filter @unpack-js/core build`
- local small/unpack benchmark smoke with tracing summary generation
- workflow YAML parse
- `git diff --check`
