### PR TITLE
Show only large fixture phase timings in benchmark comments

### DIFF
--- a/.github/workflows/cross-bundler-benchmark.yml
+++ b/.github/workflows/cross-bundler-benchmark.yml
@@ -74,7 +74,8 @@ jobs:
           mkdir -p .benchmark-work/ci
           node packages/benchmarks/src/tracing-summary.mjs \
             .benchmark-work/ci/unpack-tracing.log \
-            .benchmark-work/ci/unpack-tracing-summary.md
+            .benchmark-work/ci/unpack-tracing-summary.md \
+            --fixture large
 
       - name: Publish benchmark summary
         if: always()

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -58,7 +58,7 @@ Runtime verification is separate from build timing. A Bundle that builds but doe
 
 ## CI
 
-The `Cross-Bundler Benchmarks` workflow runs on pushes to `main`, pull requests, and manual dispatch. It writes the table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, writes an Unpack phase timing summary to a new pull request issue comment, and uploads the JSON report, Markdown summary, tracing summary, and raw tracing log as artifacts.
+The `Cross-Bundler Benchmarks` workflow runs on pushes to `main`, pull requests, and manual dispatch. It writes the table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, writes an Unpack phase timing summary for the `large` fixture to a new pull request issue comment, and uploads the JSON report, Markdown summary, tracing summary, and raw tracing log as artifacts.
 
 The workflow builds the Unpack native addon with `UNPACK_NATIVE_PROFILE=release` so benchmark results compare optimized native builds.
 

--- a/packages/benchmarks/src/tracing-summary.mjs
+++ b/packages/benchmarks/src/tracing-summary.mjs
@@ -47,9 +47,17 @@ export function parseUnpackTracingSummary(log) {
   return rows;
 }
 
-export function toUnpackTracingSummaryMarkdown(rows) {
+export function filterUnpackTracingSummaryRows(rows, options = {}) {
+  if (!options.fixture) {
+    return rows;
+  }
+  return rows.filter((row) => row.fixture === options.fixture);
+}
+
+export function toUnpackTracingSummaryMarkdown(rows, options = {}) {
   if (rows.length === 0) {
-    return "No Unpack tracing phase timings were captured.\n";
+    const fixture = options.fixture ? ` for fixture \`${options.fixture}\`` : "";
+    return `No Unpack tracing phase timings were captured${fixture}.\n`;
   }
 
   const lines = [
@@ -170,13 +178,41 @@ function formatMs(value) {
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  const [, , inputPath, outputPath] = process.argv;
+  const { inputPath, outputPath, fixture } = parseCliArgs(process.argv.slice(2));
   if (!inputPath || !outputPath) {
-    process.stderr.write("Usage: node src/tracing-summary.mjs <input-log> <output-md>\n");
+    process.stderr.write(
+      "Usage: node src/tracing-summary.mjs <input-log> <output-md> [--fixture <name>]\n"
+    );
     process.exit(1);
   }
 
   const log = await readFile(inputPath, "utf8").catch(() => "");
-  const markdown = toUnpackTracingSummaryMarkdown(parseUnpackTracingSummary(log));
+  const rows = filterUnpackTracingSummaryRows(parseUnpackTracingSummary(log), { fixture });
+  const markdown = toUnpackTracingSummaryMarkdown(rows, { fixture });
   await writeFile(outputPath, markdown, "utf8");
+}
+
+function parseCliArgs(args) {
+  const parsed = {
+    inputPath: args[0],
+    outputPath: args[1],
+    fixture: undefined
+  };
+
+  for (let index = 2; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--fixture":
+        index += 1;
+        if (index >= args.length) {
+          throw new Error("--fixture requires a value");
+        }
+        parsed.fixture = args[index];
+        break;
+      default:
+        throw new Error(`unknown argument '${arg}'`);
+    }
+  }
+
+  return parsed;
 }

--- a/packages/benchmarks/test/tracing-summary.test.mjs
+++ b/packages/benchmarks/test/tracing-summary.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  filterUnpackTracingSummaryRows,
   parseUnpackTracingSummary,
   toUnpackTracingSummaryMarkdown
 } from "../src/tracing-summary.mjs";
@@ -37,4 +38,26 @@ test("tracing summary groups major phase timings by fixture and build phase", ()
   assert.match(markdown, /\\| fixture \\| build \\| compiler run ms \\| make ms \\|/);
   assert.match(markdown, /\\| small \\| cold \\| 17\\.420 \\| 15\\.050 \\| 0\\.188 \\| 1\\.464 \\| 0\\.714 \\| 3\\.657 \\|/);
   assert.match(markdown, /\\| small \\| warm \\| 7\\.220 \\| 5\\.860 \\|  \\|  \\|  \\|  \\|/);
+});
+
+test("tracing summary can filter rows to one fixture", () => {
+  const rows = [
+    { fixture: "small", build: "cold", compilerRun: 1 },
+    { fixture: "large", build: "cold", compilerRun: 2 },
+    { fixture: "large", build: "warm", compilerRun: 3 }
+  ];
+
+  const filtered = filterUnpackTracingSummaryRows(rows, { fixture: "large" });
+  assert.deepEqual(filtered, [
+    { fixture: "large", build: "cold", compilerRun: 2 },
+    { fixture: "large", build: "warm", compilerRun: 3 }
+  ]);
+
+  const markdown = toUnpackTracingSummaryMarkdown(filtered, { fixture: "large" });
+  assert.doesNotMatch(markdown, /small/);
+  assert.match(markdown, /\\| large \\| cold \\| 2\\.000 \\|/);
+  assert.equal(
+    toUnpackTracingSummaryMarkdown([], { fixture: "large" }),
+    "No Unpack tracing phase timings were captured for fixture `large`.\n"
+  );
 });


### PR DESCRIPTION
## Summary

- filter the generated Unpack phase timing PR comment to only include the `large` fixture
- keep raw tracing artifacts available for all fixtures
- document that the CI issue comment reports large fixture timings

## Validation

- `pnpm --filter @unpack-js/benchmarks test`
- workflow YAML parse
- `git diff --check origin/main..HEAD`
