### PR TITLE
Add webpack phase timings to benchmark comments

### DIFF
--- a/.github/workflows/cross-bundler-benchmark.yml
+++ b/.github/workflows/cross-bundler-benchmark.yml
@@ -66,15 +66,15 @@ jobs:
             --summary-md .benchmark-work/ci/summary.md \
             --turbopack-repo .benchmark-tools/next.js \
             --turbopack-commit "$TURBOPACK_NEXT_COMMIT" \
-            2> >(tee .benchmark-work/ci/unpack-tracing.log | sed -E '/^\[unpack tracing\]/d; / TRACE .*: .*: close time\.busy=/d' >&2)
+            2> >(tee .benchmark-work/ci/bundler-phase-timings.log | sed -E '/^\[(unpack|webpack) tracing\]/d; /(^| )TRACE .*: .*: close time\.busy=/d' >&2)
 
-      - name: Format Unpack tracing summary
+      - name: Format bundler phase timing summary
         if: always()
         run: |
           mkdir -p .benchmark-work/ci
           node packages/benchmarks/src/tracing-summary.mjs \
-            .benchmark-work/ci/unpack-tracing.log \
-            .benchmark-work/ci/unpack-tracing-summary.md \
+            .benchmark-work/ci/bundler-phase-timings.log \
+            .benchmark-work/ci/bundler-phase-timings.md \
             --fixture large
 
       - name: Publish benchmark summary
@@ -131,7 +131,7 @@ jobs:
               -f body="$(cat "$comment_file")"
           fi
 
-      - name: Comment Unpack phase timings on PR
+      - name: Comment bundler phase timings on PR
         if: always() && github.event_name == 'pull_request'
         continue-on-error: true
         env:
@@ -139,19 +139,19 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          trace_summary_file=".benchmark-work/ci/unpack-tracing-summary.md"
+          trace_summary_file=".benchmark-work/ci/bundler-phase-timings.md"
           comment_file=".benchmark-work/ci/tracing-comment.md"
           mkdir -p "$(dirname "$comment_file")"
 
           {
-            echo "## Unpack Phase Timings"
+            echo "## Bundler Phase Timings"
             echo
             echo "[Workflow run]($RUN_URL)"
             echo
             if [ -f "$trace_summary_file" ]; then
               cat "$trace_summary_file"
             else
-              echo "No Unpack tracing phase timings were captured. Check the workflow logs for setup or runner failures."
+              echo "No bundler phase timings were captured. Check the workflow logs for setup or runner failures."
             fi
           } > "$comment_file"
 
@@ -166,6 +166,6 @@ jobs:
           path: |
             .benchmark-work/ci/results.json
             .benchmark-work/ci/summary.md
-            .benchmark-work/ci/unpack-tracing.log
-            .benchmark-work/ci/unpack-tracing-summary.md
+            .benchmark-work/ci/bundler-phase-timings.log
+            .benchmark-work/ci/bundler-phase-timings.md
           if-no-files-found: warn

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -58,7 +58,7 @@ Runtime verification is separate from build timing. A Bundle that builds but doe
 
 ## CI
 
-The `Cross-Bundler Benchmarks` workflow runs on pushes to `main`, pull requests, and manual dispatch. It writes the table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, writes an Unpack phase timing summary for the `large` fixture to a new pull request issue comment, and uploads the JSON report, Markdown summary, tracing summary, and raw tracing log as artifacts.
+The `Cross-Bundler Benchmarks` workflow runs on pushes to `main`, pull requests, and manual dispatch. It writes the table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, writes an Unpack and webpack phase timing summary for the `large` fixture to a new pull request issue comment, and uploads the JSON report, Markdown summary, timing summary, and raw timing log as artifacts.
 
 The workflow builds the Unpack native addon with `UNPACK_NATIVE_PROFILE=release` so benchmark results compare optimized native builds.
 

--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -1,6 +1,7 @@
 import { execFile as execFileCallback } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
+import { performance } from "node:perf_hooks";
 import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 
@@ -63,9 +64,22 @@ export const adapters = {
   webpack: {
     name: "webpack",
     versionSource: () => `webpack@${packageVersion("webpack")}`,
-    async build({ fixture, outputDir, cacheDir, persistentCache = true, cacheReadonly = false }) {
+    async build({
+      fixture,
+      outputDir,
+      cacheDir,
+      phase,
+      persistentCache = true,
+      cacheReadonly = false
+    }) {
       const webpackModule = await import("webpack");
       const webpack = webpackModule.default ?? webpackModule;
+      const tracing = createWebpackPhaseTracing({
+        fixture,
+        phase,
+        persistentCache,
+        cacheReadonly
+      });
       const compiler = webpack({
         ...webpackLikeConfig({ fixture, outputDir }),
         cache: persistentCache
@@ -74,14 +88,15 @@ export const adapters = {
               cacheDirectory: cacheDir,
               readonly: cacheReadonly
             }
-          : false
+          : false,
+        plugins: [tracing.plugin]
       });
 
       try {
         const stats = await runWebpackCompiler(compiler);
         assertWebpackStats(stats, "webpack");
       } finally {
-        await closeWebpackCompiler(compiler);
+        await tracing.close(compiler);
       }
 
       return { entryFile: join(outputDir, "main.js") };
@@ -386,6 +401,88 @@ function configureUnpackTracing({ fixture, phase, persistentCache, cacheReadonly
       `filter=${filter}`
     ].join(" ") + "\n"
   );
+}
+
+function createWebpackPhaseTracing({ fixture, phase, persistentCache, cacheReadonly }) {
+  const pluginName = "UnpackBenchmarkWebpackPhaseTracingPlugin";
+  const started = new Map();
+  const durations = new Map();
+
+  function start(name) {
+    if (!started.has(name)) {
+      started.set(name, performance.now());
+    }
+  }
+
+  function end(name) {
+    const startTime = started.get(name);
+    if (startTime === undefined) {
+      return;
+    }
+    started.delete(name);
+    durations.set(name, (durations.get(name) ?? 0) + performance.now() - startTime);
+  }
+
+  function print() {
+    process.stderr.write(
+      [
+        "[webpack tracing]",
+        `fixture=${fixture.name}`,
+        `phase=${phase}`,
+        `persistent_cache=${persistentCache ? "on" : "off"}`,
+        `cache_readonly=${cacheReadonly ? "on" : "off"}`
+      ].join(" ") + "\n"
+    );
+
+    for (const [span, duration] of [
+      ["Webpack::run", durations.get("compilerRun")],
+      ["Webpack::make", durations.get("make")],
+      ["Webpack::build_chunk_graph", durations.get("chunkGraph")],
+      ["Webpack::create_assets", durations.get("createAssets")],
+      ["Webpack::emit_assets", durations.get("emitAssets")],
+      ["Webpack::flush_cache", durations.get("flushCache")]
+    ]) {
+      if (duration === undefined) {
+        continue;
+      }
+      process.stderr.write(
+        `TRACE ${span}: webpack: close time.busy=${formatDurationMs(duration)} time.idle=0ms\n`
+      );
+    }
+  }
+
+  return {
+    plugin: {
+      apply(compiler) {
+        compiler.hooks.beforeRun.tap(pluginName, () => start("compilerRun"));
+        compiler.hooks.run.tap(pluginName, () => start("compilerRun"));
+        compiler.hooks.done.tap(pluginName, () => end("compilerRun"));
+        compiler.hooks.make.tap(pluginName, () => start("make"));
+        compiler.hooks.finishMake.tap(pluginName, () => end("make"));
+        compiler.hooks.emit.tap(pluginName, () => start("emitAssets"));
+        compiler.hooks.afterEmit.tap(pluginName, () => end("emitAssets"));
+        compiler.hooks.compilation.tap(pluginName, (compilation) => {
+          compilation.hooks.beforeChunks.tap(pluginName, () => start("chunkGraph"));
+          compilation.hooks.afterChunks.tap(pluginName, () => end("chunkGraph"));
+          compilation.hooks.beforeCodeGeneration.tap(pluginName, () => start("createAssets"));
+          compilation.hooks.afterProcessAssets.tap(pluginName, () => end("createAssets"));
+        });
+      }
+    },
+    async close(compiler) {
+      const startedClose = performance.now();
+      try {
+        await closeWebpackCompiler(compiler);
+      } finally {
+        durations.set("flushCache", performance.now() - startedClose);
+        print();
+      }
+    }
+  };
+}
+
+function formatDurationMs(duration) {
+  return `${duration.toFixed(3)}ms`;
 }
 
 function unpackTracingFilter(options) {

--- a/packages/benchmarks/src/tracing-summary.mjs
+++ b/packages/benchmarks/src/tracing-summary.mjs
@@ -20,6 +20,7 @@ export function parseUnpackTracingSummary(log) {
     const header = parseTracingHeader(line);
     if (header) {
       current = {
+        bundler: header.bundler,
         fixture: header.fixture,
         build: header.phase
       };
@@ -57,18 +58,20 @@ export function filterUnpackTracingSummaryRows(rows, options = {}) {
 export function toUnpackTracingSummaryMarkdown(rows, options = {}) {
   if (rows.length === 0) {
     const fixture = options.fixture ? ` for fixture \`${options.fixture}\`` : "";
-    return `No Unpack tracing phase timings were captured${fixture}.\n`;
+    return `No bundler phase timings were captured${fixture}.\n`;
   }
 
   const lines = [
-    "Durations are Rust tracing span close elapsed times.",
+    "Durations are phase elapsed times captured by benchmark tracing.",
     "",
     [
       "fixture",
+      "bundler",
       "build",
       ...PHASE_COLUMNS.map(([, label]) => `${label} ms`)
     ].join(" | ").replace(/^/, "| ").replace(/$/, " |"),
     [
+      "---",
       "---",
       "---",
       ...PHASE_COLUMNS.map(() => "---:")
@@ -79,6 +82,7 @@ export function toUnpackTracingSummaryMarkdown(rows, options = {}) {
     lines.push(
       [
         row.fixture,
+        row.bundler,
         row.build,
         ...PHASE_COLUMNS.map(([key]) => formatMs(row[key]))
       ].join(" | ").replace(/^/, "| ").replace(/$/, " |")
@@ -89,7 +93,8 @@ export function toUnpackTracingSummaryMarkdown(rows, options = {}) {
 }
 
 function parseTracingHeader(line) {
-  if (!line.startsWith("[unpack tracing]")) {
+  const match = line.match(/^\[(unpack|webpack) tracing\]/);
+  if (!match) {
     return null;
   }
 
@@ -103,7 +108,7 @@ function parseTracingHeader(line) {
   if (!fixture || !phase) {
     return null;
   }
-  return { fixture, phase };
+  return { bundler: match[1], fixture, phase };
 }
 
 function parseSpanClose(line) {
@@ -127,22 +132,25 @@ function parseSpanClose(line) {
 }
 
 function phaseKey(name) {
-  if (name === "Compiler::run") {
+  if (name === "Compiler::run" || name === "Webpack::run") {
     return "compilerRun";
   }
-  if (name.includes("Compilation::make")) {
+  if (name.includes("Compilation::make") || name === "Webpack::make") {
     return "make";
   }
-  if (name.includes("Compilation::build_chunk_graph")) {
+  if (
+    name.includes("Compilation::build_chunk_graph") ||
+    name === "Webpack::build_chunk_graph"
+  ) {
     return "chunkGraph";
   }
-  if (name.includes("Compilation::create_assets")) {
+  if (name.includes("Compilation::create_assets") || name === "Webpack::create_assets") {
     return "createAssets";
   }
-  if (name === "unpack_node::emit_assets") {
+  if (name === "unpack_node::emit_assets" || name === "Webpack::emit_assets") {
     return "emitAssets";
   }
-  if (name === "Compiler::flush_cache") {
+  if (name === "Compiler::flush_cache" || name === "Webpack::flush_cache") {
     return "flushCache";
   }
   return null;

--- a/packages/benchmarks/test/tracing-summary.test.mjs
+++ b/packages/benchmarks/test/tracing-summary.test.mjs
@@ -18,10 +18,18 @@ test("tracing summary groups major phase timings by fixture and build phase", ()
 [unpack tracing] fixture=small phase=warm persistent_cache=on cache_readonly=on filter=unpack_core=trace,unpack_node=trace
 2026-07-02T10:52:55.762452Z TRACE Compiler::run:Compilation::make: unpack_core::compilation: close time.busy=3.90ms time.idle=1.96ms
 2026-07-02T10:52:55.763750Z TRACE Compiler::run: unpack_core::compiler: close time.busy=5.32ms time.idle=1.90ms
+[webpack tracing] fixture=small phase=cold persistent_cache=on cache_readonly=off
+TRACE Webpack::make: webpack: close time.busy=10.125ms time.idle=0ms
+TRACE Webpack::run: webpack: close time.busy=15.250ms time.idle=0ms
+TRACE Webpack::build_chunk_graph: webpack: close time.busy=1.500ms time.idle=0ms
+TRACE Webpack::create_assets: webpack: close time.busy=2.250ms time.idle=0ms
+TRACE Webpack::emit_assets: webpack: close time.busy=3.500ms time.idle=0ms
+TRACE Webpack::flush_cache: webpack: close time.busy=4.750ms time.idle=0ms
 `);
 
-  assert.equal(rows.length, 2);
+  assert.equal(rows.length, 3);
   assert.equal(rows[0].fixture, "small");
+  assert.equal(rows[0].bundler, "unpack");
   assert.equal(rows[0].build, "cold");
   assert.equal(rows[0].compilerRun.toFixed(3), "17.420");
   assert.equal(rows[0].make.toFixed(3), "15.050");
@@ -30,34 +38,41 @@ test("tracing summary groups major phase timings by fixture and build phase", ()
   assert.equal(rows[0].emitAssets.toFixed(3), "0.714");
   assert.equal(rows[0].flushCache.toFixed(3), "3.657");
   assert.equal(rows[1].fixture, "small");
+  assert.equal(rows[1].bundler, "unpack");
   assert.equal(rows[1].build, "warm");
   assert.equal(rows[1].compilerRun.toFixed(3), "7.220");
   assert.equal(rows[1].make.toFixed(3), "5.860");
+  assert.equal(rows[2].fixture, "small");
+  assert.equal(rows[2].bundler, "webpack");
+  assert.equal(rows[2].build, "cold");
+  assert.equal(rows[2].compilerRun.toFixed(3), "15.250");
+  assert.equal(rows[2].make.toFixed(3), "10.125");
 
   const markdown = toUnpackTracingSummaryMarkdown(rows);
-  assert.match(markdown, /\\| fixture \\| build \\| compiler run ms \\| make ms \\|/);
-  assert.match(markdown, /\\| small \\| cold \\| 17\\.420 \\| 15\\.050 \\| 0\\.188 \\| 1\\.464 \\| 0\\.714 \\| 3\\.657 \\|/);
-  assert.match(markdown, /\\| small \\| warm \\| 7\\.220 \\| 5\\.860 \\|  \\|  \\|  \\|  \\|/);
+  assert.match(markdown, /\\| fixture \\| bundler \\| build \\| compiler run ms \\| make ms \\|/);
+  assert.match(markdown, /\\| small \\| unpack \\| cold \\| 17\\.420 \\| 15\\.050 \\| 0\\.188 \\| 1\\.464 \\| 0\\.714 \\| 3\\.657 \\|/);
+  assert.match(markdown, /\\| small \\| unpack \\| warm \\| 7\\.220 \\| 5\\.860 \\|  \\|  \\|  \\|  \\|/);
+  assert.match(markdown, /\\| small \\| webpack \\| cold \\| 15\\.250 \\| 10\\.125 \\| 1\\.500 \\| 2\\.250 \\| 3\\.500 \\| 4\\.750 \\|/);
 });
 
 test("tracing summary can filter rows to one fixture", () => {
   const rows = [
-    { fixture: "small", build: "cold", compilerRun: 1 },
-    { fixture: "large", build: "cold", compilerRun: 2 },
-    { fixture: "large", build: "warm", compilerRun: 3 }
+    { fixture: "small", bundler: "unpack", build: "cold", compilerRun: 1 },
+    { fixture: "large", bundler: "unpack", build: "cold", compilerRun: 2 },
+    { fixture: "large", bundler: "webpack", build: "warm", compilerRun: 3 }
   ];
 
   const filtered = filterUnpackTracingSummaryRows(rows, { fixture: "large" });
   assert.deepEqual(filtered, [
-    { fixture: "large", build: "cold", compilerRun: 2 },
-    { fixture: "large", build: "warm", compilerRun: 3 }
+    { fixture: "large", bundler: "unpack", build: "cold", compilerRun: 2 },
+    { fixture: "large", bundler: "webpack", build: "warm", compilerRun: 3 }
   ]);
 
   const markdown = toUnpackTracingSummaryMarkdown(filtered, { fixture: "large" });
   assert.doesNotMatch(markdown, /small/);
-  assert.match(markdown, /\\| large \\| cold \\| 2\\.000 \\|/);
+  assert.match(markdown, /\\| large \\| unpack \\| cold \\| 2\\.000 \\|/);
   assert.equal(
     toUnpackTracingSummaryMarkdown([], { fixture: "large" }),
-    "No Unpack tracing phase timings were captured for fixture `large`.\n"
+    "No bundler phase timings were captured for fixture `large`.\n"
   );
 });


### PR DESCRIPTION
## Summary

- add benchmark-only webpack hook timing for run, make, chunk graph, asset creation, emit assets, and cache close/flush
- include a bundler column in the phase timing summary so `large` fixture comments show both Unpack and webpack rows
- keep raw timing details in artifacts while filtering detailed trace lines from CI logs

## Validation

- `pnpm --filter @unpack-js/benchmarks test`
- `pnpm --filter @unpack-js/core build`
- local small/unpack+webpack benchmark smoke with phase summary generation
- workflow YAML parse
- `git diff --check`
