### PR TITLE
Skip Turbopack benchmarks by default in CI

### DIFF
--- a/.github/workflows/cross-bundler-benchmark.yml
+++ b/.github/workflows/cross-bundler-benchmark.yml
@@ -6,8 +6,16 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+    inputs:
+      include_turbopack:
+        description: Include Turbopack in the benchmark run
+        type: boolean
+        default: false
+        required: false
 
 env:
+  DEFAULT_BENCHMARK_BUNDLERS: unpack,webpack,rspack,rolldown
+  TURBOPACK_BENCHMARK_BUNDLERS: unpack,webpack,rspack,rolldown,turbopack
   TURBOPACK_NEXT_COMMIT: a88f25caf0070b582a8ed83b1ae9e7135d7fd3bc
 
 jobs:
@@ -48,6 +56,7 @@ jobs:
         run: pnpm --filter @unpack-js/core build
 
       - name: Checkout fixed Turbopack source
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.include_turbopack }}
         run: |
           mkdir -p .benchmark-tools/next.js
           git -C .benchmark-tools/next.js init
@@ -58,14 +67,27 @@ jobs:
       - name: Run cross-bundler benchmark
         id: benchmark
         continue-on-error: true
+        env:
+          INCLUDE_TURBOPACK: ${{ github.event_name == 'workflow_dispatch' && inputs.include_turbopack }}
         run: |
           mkdir -p .benchmark-work/ci
+
+          benchmark_bundlers="$DEFAULT_BENCHMARK_BUNDLERS"
+          turbopack_args=()
+          if [ "$INCLUDE_TURBOPACK" = "true" ]; then
+            benchmark_bundlers="$TURBOPACK_BENCHMARK_BUNDLERS"
+            turbopack_args=(
+              --turbopack-repo .benchmark-tools/next.js
+              --turbopack-commit "$TURBOPACK_NEXT_COMMIT"
+            )
+          fi
+
           pnpm --filter @unpack-js/benchmarks bench -- \
             --workspace .benchmark-work/ci \
             --output-json .benchmark-work/ci/results.json \
             --summary-md .benchmark-work/ci/summary.md \
-            --turbopack-repo .benchmark-tools/next.js \
-            --turbopack-commit "$TURBOPACK_NEXT_COMMIT" \
+            --bundlers "$benchmark_bundlers" \
+            "${turbopack_args[@]}" \
             2> >(tee .benchmark-work/ci/bundler-phase-timings.log | sed -E '/^\[(unpack|webpack) tracing\]/d; /(^| )TRACE .*: .*: close time\.busy=/d' >&2)
 
       - name: Format bundler phase timing summary

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -58,7 +58,7 @@ Runtime verification is separate from build timing. A Bundle that builds but doe
 
 ## CI
 
-The `Cross-Bundler Benchmarks` workflow runs on pushes to `main`, pull requests, and manual dispatch. It writes the table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, writes an Unpack and webpack phase timing summary for the `large` fixture to a new pull request issue comment, and uploads the JSON report, Markdown summary, timing summary, and raw timing log as artifacts.
+The `Cross-Bundler Benchmarks` workflow runs on pushes to `main`, pull requests, and manual dispatch. Automatic CI runs compare Unpack with webpack, Rspack, and Rolldown; they skip the fixed Next.js checkout and Turbopack build by default. To include Turbopack, run the workflow manually with the `include_turbopack` input enabled. The workflow writes the table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, writes an Unpack and webpack phase timing summary for the `large` fixture to a new pull request issue comment, and uploads the JSON report, Markdown summary, timing summary, and raw timing log as artifacts.
 
 The workflow builds the Unpack native addon with `UNPACK_NATIVE_PROFILE=release` so benchmark results compare optimized native builds.
 


### PR DESCRIPTION
## Summary

- Make automatic cross-bundler benchmark CI runs compare Unpack with webpack, Rspack, and Rolldown only.
- Add a manual `workflow_dispatch` input to include Turbopack when the extra Next.js checkout and Turbopack build are wanted.
- Update the cross-bundler benchmark implementation notes to document the new CI behavior.

## Why

Turbopack setup is expensive because CI has to checkout a fixed Next.js source tree and build `turbopack-cli`. The benchmark remains available for explicit manual runs while routine push and pull request CI avoids that cost.

## Validation

- `git diff --check`
- YAML parse check
- `pnpm --filter @unpack-js/benchmarks test`
- `pnpm test`
