### PR TITLE
Restore warm build make timings

### DIFF
--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crate::{
-    Asset, CompilerOptions, ModuleIdentity, SnapshotOptions, SnapshotStrategy, WatchDependencies,
+    ModuleIdentity, SnapshotOptions, SnapshotStrategy,
     cache_hash::stable_hash,
     parser::ParsedModule,
     snapshot::{FileSystemInfo, Snapshot, SnapshotCache},
@@ -18,7 +18,6 @@ use serde::{Deserialize, Serialize};
 const CACHE_MAGIC: &str = "UNPACK_PERSISTENT_CACHE";
 const PACK_MAGIC: &[u8] = b"UNPACK-CACHE-PACK\0";
 const DEFAULT_PACK_FILE: &str = "packs/modules.cbor";
-const DEFAULT_COMPILATION_FILE: &str = "packs/compilation.cbor";
 const MANIFEST_FILE: &str = "container.json";
 
 #[derive(Debug, Clone)]
@@ -26,7 +25,6 @@ pub(crate) struct BuildCache {
     options: CacheOptions,
     build_dependency_snapshot_strategy: SnapshotStrategy,
     resolve_build_dependency_snapshot_strategy: SnapshotStrategy,
-    compilation_snapshot_strategy: SnapshotStrategy,
     file_system_info: FileSystemInfo,
     inner: Arc<Mutex<BuildCacheInner>>,
 }
@@ -122,7 +120,6 @@ pub struct BuildDependency {
 struct BuildCacheInner {
     resolve_records: CacheStore<ResolveRequest, ResolveRecord>,
     module_builds: CacheStore<ModuleIdentity, ModuleBuildRecord>,
-    cached_compilation: Option<Arc<CachedCompilationRecord>>,
     filesystem_manifest: Option<CacheManifest>,
     records_restored: bool,
     dirty: bool,
@@ -339,90 +336,15 @@ impl ModuleBuildRecord {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct CachedCompilationRecord {
-    key: CachedCompilationKey,
-    assets: Vec<Asset>,
-    file_dependencies: BTreeSet<PathBuf>,
-    context_dependencies: BTreeSet<PathBuf>,
-    missing_dependencies: BTreeSet<PathBuf>,
-    snapshot: Snapshot,
-}
-
-impl CachedCompilationRecord {
-    fn key_matches(&self, options: &CompilerOptions) -> bool {
-        self.key == CachedCompilationKey::from_options(options)
-    }
-
-    pub(crate) fn assets(&self) -> &[Asset] {
-        &self.assets
-    }
-
-    pub(crate) fn file_dependencies(&self) -> &BTreeSet<PathBuf> {
-        &self.file_dependencies
-    }
-
-    pub(crate) fn context_dependencies(&self) -> &BTreeSet<PathBuf> {
-        &self.context_dependencies
-    }
-
-    pub(crate) fn missing_dependencies(&self) -> &BTreeSet<PathBuf> {
-        &self.missing_dependencies
-    }
-
-    async fn is_valid(
-        &self,
-        file_system_info: &FileSystemInfo,
-        strategy: SnapshotStrategy,
-        snapshot_cache: &SnapshotCache,
-    ) -> bool {
-        file_system_info
-            .is_snapshot_valid_with_cache(&self.snapshot, strategy, snapshot_cache)
-            .await
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-struct CachedCompilationKey {
-    context: PathBuf,
-    entries: Vec<CachedCompilationEntry>,
-    sourcemap: bool,
-}
-
-impl CachedCompilationKey {
-    fn from_options(options: &CompilerOptions) -> Self {
-        Self {
-            context: options.context.clone(),
-            entries: options
-                .entries
-                .iter()
-                .map(|entry| CachedCompilationEntry {
-                    name: entry.name.clone(),
-                    request: entry.request.clone(),
-                })
-                .collect(),
-            sourcemap: options.sourcemap,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-struct CachedCompilationEntry {
-    name: String,
-    request: String,
-}
-
 impl BuildCache {
     pub(crate) fn new(options: CacheOptions, snapshot_options: SnapshotOptions) -> Self {
         let build_dependency_snapshot_strategy = snapshot_options.build_dependencies;
         let resolve_build_dependency_snapshot_strategy =
             snapshot_options.resolve_build_dependencies;
-        let compilation_snapshot_strategy = snapshot_options.module;
         let cache = Self {
             options,
             build_dependency_snapshot_strategy,
             resolve_build_dependency_snapshot_strategy,
-            compilation_snapshot_strategy,
             file_system_info: FileSystemInfo::from_snapshot_options(&snapshot_options),
             inner: Arc::new(Mutex::new(BuildCacheInner::default())),
         };
@@ -444,81 +366,12 @@ impl BuildCache {
         }
     }
 
-    pub(crate) async fn cached_compilation(
-        &self,
-        options: &CompilerOptions,
-    ) -> Option<Arc<CachedCompilationRecord>> {
-        if self.options.kind != CacheKind::Filesystem || !self.options.readonly {
-            return None;
-        }
-
-        let record = self
-            .inner
-            .lock()
-            .expect("build cache mutex should not be poisoned")
-            .cached_compilation
-            .clone()?;
-        if !record.key_matches(options) {
-            return None;
-        }
-
-        let snapshot_cache = SnapshotCache::default();
-        record
-            .is_valid(
-                &self.file_system_info,
-                self.compilation_snapshot_strategy,
-                &snapshot_cache,
-            )
-            .await
-            .then_some(record)
-    }
-
-    pub(crate) async fn store_compilation(
-        &self,
-        options: &CompilerOptions,
-        assets: &[Asset],
-        watch_dependencies: &WatchDependencies,
-    ) -> crate::Result<()> {
-        if self.options.kind != CacheKind::Filesystem || self.options.readonly {
-            return Ok(());
-        }
-
-        let snapshot_cache = SnapshotCache::default();
-        let snapshot = self
-            .file_system_info
-            .create_resolve_snapshot_with_cache(
-                watch_dependencies.files().iter().cloned(),
-                watch_dependencies.contexts().iter().cloned(),
-                watch_dependencies.missing().iter().cloned(),
-                self.compilation_snapshot_strategy,
-                &snapshot_cache,
-            )
-            .await?;
-
-        let record = CachedCompilationRecord {
-            key: CachedCompilationKey::from_options(options),
-            assets: assets.to_vec(),
-            file_dependencies: watch_dependencies.files().clone(),
-            context_dependencies: watch_dependencies.contexts().clone(),
-            missing_dependencies: watch_dependencies.missing().clone(),
-            snapshot,
-        };
-
-        let mut inner = self
-            .inner
-            .lock()
-            .expect("build cache mutex should not be poisoned");
-        inner.cached_compilation = Some(Arc::new(record));
-        inner.dirty = true;
-        Ok(())
-    }
-
     pub(crate) fn flush_to_filesystem(&self) -> io::Result<()> {
         if self.options.kind != CacheKind::Filesystem || self.options.readonly {
             return Ok(());
         }
 
-        let (resolve_records, module_builds, cached_compilation) = {
+        let (resolve_records, module_builds) = {
             let inner = self
                 .inner
                 .lock()
@@ -529,15 +382,10 @@ impl BuildCache {
             (
                 inner.resolve_records.records.clone(),
                 inner.module_builds.records.clone(),
-                inner.cached_compilation.clone(),
             )
         };
 
-        self.write_filesystem_cache(
-            &resolve_records,
-            &module_builds,
-            cached_compilation.as_deref(),
-        )?;
+        self.write_filesystem_cache(&resolve_records, &module_builds)?;
 
         self.inner
             .lock()
@@ -625,14 +473,6 @@ impl BuildCache {
             .lock()
             .expect("build cache mutex should not be poisoned");
         inner.filesystem_manifest = Some(manifest.clone());
-        inner.cached_compilation = manifest
-            .compilation_file
-            .as_deref()
-            .and_then(|compilation_file| read_compilation_pack(cache_location, compilation_file))
-            .and_then(|pack| {
-                (pack.magic == CACHE_MAGIC && pack.cache_version == self.cache_version())
-                    .then(|| Arc::new(pack.compilation))
-            });
         drop(inner);
 
         if !self.options.readonly {
@@ -700,7 +540,6 @@ impl BuildCache {
         &self,
         resolve_records: &HashMap<ResolveRequest, Arc<ResolveRecord>>,
         module_builds: &HashMap<ModuleIdentity, Arc<ModuleBuildRecord>>,
-        cached_compilation: Option<&CachedCompilationRecord>,
     ) -> io::Result<()> {
         let Some(cache_location) = &self.options.cache_location else {
             return Ok(());
@@ -731,33 +570,10 @@ impl BuildCache {
         pack_bytes.extend(pack_payload);
         fs::write(pack_path, pack_bytes)?;
 
-        let compilation_file = if let Some(cached_compilation) = cached_compilation {
-            let compilation_file = PathBuf::from(DEFAULT_COMPILATION_FILE);
-            let compilation_path = cache_location.join(&compilation_file);
-            if let Some(parent) = compilation_path.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            let compilation_pack = CachedCompilationPackDto {
-                magic: CACHE_MAGIC.to_string(),
-                cache_version: cache_version.clone(),
-                compilation: cached_compilation.clone(),
-            };
-            let compilation_payload = cbor4ii::serde::to_vec(Vec::new(), &compilation_pack)
-                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
-            let mut compilation_bytes = PACK_MAGIC.to_vec();
-            compilation_bytes.extend(compilation_payload);
-            fs::write(compilation_path, compilation_bytes)?;
-            Some(compilation_file)
-        } else {
-            None
-        };
-
         let manifest = CacheManifest {
             magic: CACHE_MAGIC.to_string(),
             cache_version,
             pack_file: pack_file.to_string_lossy().replace('\\', "/"),
-            compilation_file: compilation_file
-                .map(|path| path.to_string_lossy().replace('\\', "/")),
             build_dependencies: self
                 .build_dependency_snapshot(self.build_dependency_snapshot_strategy)?,
             resolve_build_dependencies: self
@@ -833,22 +649,11 @@ fn read_pack(cache_location: &Path, pack_file: &str) -> Option<CachePackDto> {
     cbor4ii::serde::from_slice(payload).ok()
 }
 
-fn read_compilation_pack(
-    cache_location: &Path,
-    compilation_file: &str,
-) -> Option<CachedCompilationPackDto> {
-    let bytes = fs::read(cache_location.join(compilation_file)).ok()?;
-    let payload = bytes.strip_prefix(PACK_MAGIC)?;
-    cbor4ii::serde::from_slice(payload).ok()
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CacheManifest {
     magic: String,
     cache_version: String,
     pack_file: String,
-    #[serde(default)]
-    compilation_file: Option<String>,
     build_dependencies: Snapshot,
     resolve_build_dependencies: Snapshot,
 }
@@ -859,13 +664,6 @@ struct CachePackDto {
     cache_version: String,
     resolve_records: Vec<(ResolveRequest, ResolveRecord)>,
     module_builds: Vec<(ModuleIdentity, ModuleBuildRecord)>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct CachedCompilationPackDto {
-    magic: String,
-    cache_version: String,
-    compilation: CachedCompilationRecord,
 }
 
 #[cfg(test)]

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -5,7 +5,7 @@ use tokio::sync::Mutex;
 use crate::{
     Asset, ChunkGraph, CompilerOptions, Error, InfrastructureLogEvent, InfrastructureLogLevel,
     ModuleGraph, ModuleId, Result, UnpackResolver,
-    build_cache::{BuildCache, CachedCompilationRecord},
+    build_cache::BuildCache,
     code_generation,
     make::{self, MakeState},
     snapshot::FileSystemInfo,
@@ -44,32 +44,6 @@ impl Compilation {
             entries: Vec::new(),
             errors: Vec::new(),
             watch_dependencies: WatchDependencies::default(),
-            infrastructure_log_events: Vec::new(),
-            file_system_info,
-        }
-    }
-
-    pub(crate) fn from_cached(
-        options: CompilerOptions,
-        resolver: UnpackResolver,
-        build_cache: BuildCache,
-        cached: &CachedCompilationRecord,
-    ) -> Self {
-        let file_system_info = FileSystemInfo::from_snapshot_options(&options.snapshot);
-        Self {
-            options,
-            resolver,
-            build_cache,
-            module_graph: ModuleGraph::default(),
-            chunk_graph: ChunkGraph::default(),
-            assets: cached.assets().to_vec(),
-            entries: Vec::new(),
-            errors: Vec::new(),
-            watch_dependencies: WatchDependencies::from_sets(
-                cached.file_dependencies().clone(),
-                cached.context_dependencies().clone(),
-                cached.missing_dependencies().clone(),
-            ),
             infrastructure_log_events: Vec::new(),
             file_system_info,
         }
@@ -212,18 +186,6 @@ pub struct WatchDependencies {
 }
 
 impl WatchDependencies {
-    pub(crate) fn from_sets(
-        files: BTreeSet<PathBuf>,
-        contexts: BTreeSet<PathBuf>,
-        missing: BTreeSet<PathBuf>,
-    ) -> Self {
-        Self {
-            files,
-            contexts,
-            missing,
-        }
-    }
-
     pub fn files(&self) -> &BTreeSet<PathBuf> {
         &self.files
     }

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -79,28 +79,10 @@ impl Compiler {
 
     pub async fn run(&self) -> Result<Compilation> {
         async {
-            if let Some(cached) = self.build_cache.cached_compilation(&self.options).await {
-                return Ok(Compilation::from_cached(
-                    self.options.clone(),
-                    UnpackResolver::new(self.options.resolve.clone()),
-                    self.build_cache.clone(),
-                    &cached,
-                ));
-            }
-
             let mut compilation = self.create_compilation();
             compilation.make().await?;
             compilation.build_chunk_graph();
             compilation.create_assets();
-            if compilation.errors().is_empty() {
-                self.build_cache
-                    .store_compilation(
-                        &self.options,
-                        compilation.assets(),
-                        compilation.watch_dependencies(),
-                    )
-                    .await?;
-            }
             Ok(compilation)
         }
         .instrument(tracing::trace_span!("Compiler::run"))
@@ -246,7 +228,7 @@ mod tests {
         assert_eq!(first.errors(), []);
         assert!(cache_location.join("container.json").exists());
         assert!(cache_location.join("packs/modules.cbor").exists());
-        assert!(cache_location.join("packs/compilation.cbor").exists());
+        assert!(!cache_location.join("packs/compilation.cbor").exists());
         let manifest = fs::read_to_string(cache_location.join("container.json"))?;
         assert!(manifest.contains("UNPACK_PERSISTENT_CACHE"));
         assert!(manifest.contains("test-version"));
@@ -267,7 +249,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn filesystem_cache_readonly_uses_cached_compilation_without_module_pack()
+    async fn filesystem_cache_readonly_rebuilds_without_module_pack()
     -> std::result::Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
         write(
@@ -291,7 +273,7 @@ mod tests {
 
         let module_pack = cache_location.join("packs/modules.cbor");
         assert!(module_pack.exists());
-        assert!(cache_location.join("packs/compilation.cbor").exists());
+        assert!(!cache_location.join("packs/compilation.cbor").exists());
         fs::remove_file(module_pack)?;
 
         let mut readonly_options = options;
@@ -302,8 +284,8 @@ mod tests {
 
         let second = readonly_compiler.run().await?;
         assert_eq!(asset_sources(&first), asset_sources(&second));
-        assert_eq!(readonly_compiler.build_cache.stats().resolve_entries, 0);
-        assert_eq!(readonly_compiler.build_cache.stats().module_entries, 0);
+        assert_eq!(readonly_compiler.build_cache.stats().resolve_entries, 2);
+        assert_eq!(readonly_compiler.build_cache.stats().module_entries, 2);
 
         Ok(())
     }

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -48,7 +48,7 @@ The runner emits a Markdown summary and can write the raw JSON report with `--ou
 Important fields:
 
 - `cold_build_ms`: build time after clearing benchmark-owned output and persistent cache state.
-- `warm_build_ms`: build time for the second run in the same job while preserving benchmark-owned persistent cache state.
+- `warm_build_ms`: build time after a cold build in the same job, preserving benchmark-owned persistent cache state, modifying one generated fixture module, and verifying the updated bundle checksum.
 - `no_cache_build_ms`: build time for an additional clean build with persistent cache disabled. Bundlers without a persistent-cache option run this as a separate clean one-shot build.
 - `output_bytes`: bytes emitted under the benchmark output path, excluding runner metadata.
 - `version_source`: the npm package version or fixed source commit used for the bundler.

--- a/packages/benchmarks/src/fixture.mjs
+++ b/packages/benchmarks/src/fixture.mjs
@@ -1,6 +1,8 @@
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
+export const WARM_BUILD_CHECKSUM_DELTA = 2000;
+
 export const FIXTURE_SHAPES = {
   small: {
     name: "small",
@@ -59,8 +61,20 @@ export async function createBenchmarkFixture(rootDir, shape) {
     name: shape.name,
     context,
     entry: "./src/index.js",
-    expectedChecksum: expectedChecksum(shape)
+    expectedChecksum: expectedChecksum(shape),
+    warmBuildMutationApplied: false
   };
+}
+
+export async function applyWarmBuildMutation(fixture) {
+  if (fixture.warmBuildMutationApplied) {
+    return fixture;
+  }
+
+  await writeSource(join(fixture.context, "src/features/leaf0.js"), leafSource(0, 1001));
+  fixture.expectedChecksum += WARM_BUILD_CHECKSUM_DELTA;
+  fixture.warmBuildMutationApplied = true;
+  return fixture;
 }
 
 function entrySource(shape) {
@@ -115,8 +129,8 @@ function sharedSource(shared) {
   return `export const shared${shared} = ${shared + 1};\nexport const sharedValue${shared} = shared${shared} * 2;\n`;
 }
 
-function leafSource(feature) {
-  return `export const leaf${feature} = ${feature + 1};\n`;
+function leafSource(feature, value = feature + 1) {
+  return `export const leaf${feature} = ${value};\n`;
 }
 
 function reexportSource(feature) {

--- a/packages/benchmarks/src/runner.mjs
+++ b/packages/benchmarks/src/runner.mjs
@@ -3,7 +3,11 @@ import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { performance } from "node:perf_hooks";
 import { dirname, join, resolve, sep } from "node:path";
 
-import { createBenchmarkFixture, FIXTURE_SHAPES } from "./fixture.mjs";
+import {
+  applyWarmBuildMutation,
+  createBenchmarkFixture,
+  FIXTURE_SHAPES
+} from "./fixture.mjs";
 
 const require = createRequire(import.meta.url);
 
@@ -36,8 +40,8 @@ export async function runBenchmark(options = {}) {
   const results = [];
 
   for (const shape of shapes) {
-    const fixture = await createBenchmarkFixture(fixtureRoot, shape);
     for (const bundler of bundlerNames) {
+      const fixture = await createBenchmarkFixture(fixtureRoot, shape);
       const adapter = adapters[bundler];
       results.push(
         await runBundlerBenchmark({
@@ -130,6 +134,8 @@ async function runBundlerBenchmark({ adapter, bundler, fixture, workspaceDir, op
   if (cold.status !== "success") {
     return resultFromPhases({ fixture, bundler, versionSource, cold });
   }
+
+  await applyWarmBuildMutation(fixture);
 
   const warm = await timedBuild({
     adapter,

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 import { promisify } from "node:util";
 
 import { adapters, applyTurbopackBuildCacheFlushPatch } from "../src/adapters.mjs";
+import { WARM_BUILD_CHECKSUM_DELTA } from "../src/fixture.mjs";
 import { runBenchmark, toSummaryMarkdown } from "../src/runner.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -50,9 +51,37 @@ test("runner emits persistent-cache and no-cache measurements for a verified bun
         { phase: "no-cache", persistentCache: false, cacheReadonly: false }
       ]
     );
+    assert.equal(
+      calls[1].expectedChecksum,
+      calls[0].expectedChecksum + WARM_BUILD_CHECKSUM_DELTA
+    );
+    assert.equal(calls[2].expectedChecksum, calls[1].expectedChecksum);
     const summary = toSummaryMarkdown(report);
     assert.match(summary, /no_cache_build_ms/);
     assert.match(summary, /\\| small \\| fake \\| fake@1\\.0\\.0 \\|/);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("runner verifies warm builds against the mutated fixture checksum", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
+
+  try {
+    const report = await runBenchmark({
+      workspaceDir: workspace,
+      fixtures: ["small"],
+      bundlers: ["fake"],
+      adapters: {
+        fake: fakeAdapter({ staleWarmChecksum: true })
+      }
+    });
+
+    assert.equal(report.results[0].status, "warm_runtime_failed");
+    assert.equal(report.results[0].cold_status, "success");
+    assert.equal(report.results[0].warm_status, "runtime_failed");
+    assert.equal(report.results[0].no_cache_status, "not_run");
+    assert.match(report.results[0].error, /expected bundle checksum/);
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }
@@ -231,19 +260,32 @@ test("turbopack prepare patches build shutdown to flush persistent cache", async
   }
 });
 
-function fakeAdapter({ checksumOffset = 0, error, calls } = {}) {
+function fakeAdapter({ checksumOffset = 0, error, calls, staleWarmChecksum = false } = {}) {
+  let coldChecksum;
   return {
     name: "fake",
     versionSource: () => "fake@1.0.0",
     async build({ fixture, outputDir, phase, persistentCache, cacheReadonly }) {
-      calls?.push({ phase, persistentCache, cacheReadonly });
+      calls?.push({
+        phase,
+        persistentCache,
+        cacheReadonly,
+        expectedChecksum: fixture.expectedChecksum
+      });
       if (error) {
         throw error;
       }
+      if (phase === "cold") {
+        coldChecksum = fixture.expectedChecksum;
+      }
+      const checksum =
+        staleWarmChecksum && phase === "warm"
+          ? coldChecksum
+          : fixture.expectedChecksum;
       const entryFile = join(outputDir, "main.js");
       await writeFile(
         entryFile,
-        `exports.checksum = ${fixture.expectedChecksum + checksumOffset};\n`,
+        `exports.checksum = ${checksum + checksumOffset};\n`,
         "utf8"
       );
       return { entryFile };


### PR DESCRIPTION
## Summary

- remove the whole-compilation cache shortcut so warm builds still execute make/build phases
- mutate one generated benchmark module before the warm build and verify the updated bundle checksum
- add regression coverage for stale warm output and readonly filesystem cache rebuilds

## Validation

- pnpm --filter @unpack-js/core build
- pnpm --filter @unpack-js/benchmarks bench -- --fixtures large --bundlers unpack --workspace .benchmark-work/warm-make-ci-check --output-json .benchmark-work/warm-make-ci-check/results.json --summary-md .benchmark-work/warm-make-ci-check/summary.md
- node packages/benchmarks/src/tracing-summary.mjs .benchmark-work/warm-make-ci-check/bundler-phase-timings.log .benchmark-work/warm-make-ci-check/bundler-phase-timings.md --fixture large
- asserted the large/unpack/warm row has a numeric make ms value
- cargo test -p unpack_core filesystem_cache
- pnpm --filter @unpack-js/benchmarks test
- git diff --check origin/main..HEAD