### PR TITLE
Use webpack all case for large benchmark fixture

### DIFF
--- a/.github/workflows/cross-bundler-benchmark.yml
+++ b/.github/workflows/cross-bundler-benchmark.yml
@@ -84,6 +84,7 @@ jobs:
 
           pnpm --filter @unpack-js/benchmarks bench -- \
             --workspace .benchmark-work/ci \
+            --fixtures large \
             --output-json .benchmark-work/ci/results.json \
             --summary-md .benchmark-work/ci/summary.md \
             --bundlers "$benchmark_bundlers" \

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -85,7 +85,7 @@ A performance comparison that runs the same benchmark fixture through Unpack and
 _Avoid_: Compatibility benchmark, conformance benchmark, release gate
 
 **Benchmark Fixture**:
-A generated application module graph constrained to JavaScript features the compared bundlers are expected to compile. It exists to produce comparable bundle work, not to model a real application.
+A generated or locally materialized application module graph constrained to JavaScript features the compared bundlers are expected to compile. It exists to produce comparable bundle work, not to model a real application.
 _Avoid_: Sample app, real-world app, compatibility fixture
 
 **Cold Build Measurement**:

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -1,6 +1,6 @@
 # Cross-Bundler Benchmark
 
-The Cross-Bundler Benchmark compares Unpack with webpack, Rspack, Rolldown, Metro, Parcel, and Turbopack on generated Benchmark Fixtures. The results are diagnostic signals for maintainers; they are not merge gates and they are not compatibility claims.
+The Cross-Bundler Benchmark compares Unpack with webpack, Rspack, Rolldown, Metro, Parcel, and Turbopack on the `large` Benchmark Fixture. The fixture is derived from webpack's `benchmark/cases/all` workload and generated locally so benchmark runs do not need network access. The results are diagnostic signals for maintainers; they are not merge gates and they are not compatibility claims.
 
 ## Local Run
 
@@ -10,10 +10,10 @@ Build the Unpack JavaScript API and run the benchmark:
 pnpm benchmark:bundlers -- --workspace .benchmark-work/local
 ```
 
-To run only the fast local smoke subset:
+To run a local subset of bundlers:
 
 ```sh
-pnpm --filter @unpack-js/benchmarks bench -- --fixtures small --bundlers unpack,webpack,rspack,rolldown,metro,parcel
+pnpm --filter @unpack-js/benchmarks bench -- --fixtures large --bundlers unpack,webpack,rspack,rolldown,metro,parcel
 ```
 
 The cross-bundler benchmark prints Unpack internal tracing details to stderr for
@@ -48,7 +48,7 @@ The runner emits a Markdown summary and can write the raw JSON report with `--ou
 Important fields:
 
 - `cold_build_ms`: build time after clearing benchmark-owned output and persistent cache state.
-- `warm_build_ms`: build time after a cold build in the same job, preserving benchmark-owned persistent cache state, modifying one generated fixture module, and verifying the updated bundle checksum.
+- `warm_build_ms`: build time after a cold build in the same job, preserving benchmark-owned persistent cache state, modifying the fixture checksum marker, and verifying the updated bundle checksum.
 - `no_cache_build_ms`: build time for an additional clean build with persistent cache disabled. Bundlers without a persistent-cache option run this as a separate clean one-shot build.
 - `output_bytes`: bytes emitted under the benchmark output path, excluding runner metadata.
 - `version_source`: the npm package version or fixed source commit used for the bundler.

--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -141,7 +141,8 @@ export const adapters = {
       const { rolldown } = await import("rolldown");
       const bundle = await rolldown({
         input: resolve(fixture.context, fixture.entry),
-        treeshake: true
+        logLevel: "silent",
+        treeshake: false
       });
 
       try {

--- a/packages/benchmarks/src/fixture.mjs
+++ b/packages/benchmarks/src/fixture.mjs
@@ -3,65 +3,189 @@ import { dirname, join } from "node:path";
 
 export const WARM_BUILD_CHECKSUM_DELTA = 2000;
 
+const WEBPACK_ALL_COMMIT = "d3a1ca290b4b887757a45901288ea30f86b2f842";
+const LARGE_BASE_CHECKSUM = 100000;
+const THREE_COPY_COUNT = 10;
+const THREE_PARTS_PER_COPY = 20;
+const ROME_MODULE_COUNT = 80;
+
 export const FIXTURE_SHAPES = {
-  small: {
-    name: "small",
-    featureModules: 10,
-    sharedModules: 5,
-    importsPerFeature: 3
-  },
-  medium: {
-    name: "medium",
-    featureModules: 100,
-    sharedModules: 20,
-    importsPerFeature: 4
-  },
   large: {
     name: "large",
-    featureModules: 500,
-    sharedModules: 50,
-    importsPerFeature: 5
+    expectedChecksum: LARGE_BASE_CHECKSUM
   }
 };
+
+const WEBPACK_ALL_DEPENDENCIES = {
+  "@atlaskit/editor-core": "^120.1.0",
+  "@atlaskit/media-core": "^31.1.0",
+  "@atlaskit/smart-card": "^13.0.0",
+  "@babel/runtime": "^7.12.13",
+  "@material-ui/core": "^4.11.3",
+  "@material-ui/icons": "^4.11.2",
+  "@material-ui/lab": "^4.0.0-alpha.57",
+  acorn: "^8.0.5",
+  assert: "^2.0.0",
+  classnames: "^2.2.6",
+  "date-fns": "^2.17.0",
+  jquery: "^3.5.1",
+  lodash: "^4.17.20",
+  "lodash-es": "^4.17.20",
+  moment: "^2.29.1",
+  react: "^17.0.1",
+  "react-dom": "^17.0.1",
+  "react-intl": "^2.6.0",
+  redux: "^4.0.5",
+  rxjs: "^5.5.0",
+  underscore: "^1.12.0",
+  uuid: "^8.3.2",
+  vue: "^2.6.12",
+  "zone.js": "^0.11.3"
+};
+
+const WEBPACK_ALL_PACKAGES = [
+  "@atlaskit/editor-core",
+  "@atlaskit/media-core",
+  "@atlaskit/smart-card",
+  "@material-ui/core",
+  "@material-ui/icons",
+  "@material-ui/lab",
+  "acorn",
+  "assert",
+  "classnames",
+  "date-fns",
+  "jquery",
+  "lodash",
+  "lodash-es",
+  "moment",
+  "react",
+  "react-dom",
+  "react-intl",
+  "redux",
+  "rxjs",
+  "underscore",
+  "uuid",
+  "vue",
+  "zone.js"
+];
+
+const BABEL_RUNTIME_HELPERS = [
+  "typeof",
+  "jsx",
+  "asyncIterator",
+  "AwaitValue",
+  "AsyncGenerator",
+  "wrapAsyncGenerator",
+  "awaitAsyncGenerator",
+  "asyncGeneratorDelegate",
+  "asyncToGenerator",
+  "classCallCheck",
+  "createClass",
+  "defineEnumerableProperties",
+  "defaults",
+  "defineProperty",
+  "extends",
+  "objectSpread",
+  "objectSpread2",
+  "inherits",
+  "inheritsLoose",
+  "getPrototypeOf",
+  "setPrototypeOf",
+  "isNativeReflectConstruct",
+  "construct",
+  "isNativeFunction",
+  "wrapNativeSuper",
+  "instanceof",
+  "interopRequireDefault",
+  "interopRequireWildcard",
+  "newArrowCheck",
+  "objectDestructuringEmpty",
+  "objectWithoutPropertiesLoose",
+  "objectWithoutProperties",
+  "assertThisInitialized",
+  "possibleConstructorReturn",
+  "createSuper",
+  "superPropBase",
+  "get",
+  "set",
+  "taggedTemplateLiteral",
+  "taggedTemplateLiteralLoose",
+  "readOnlyError",
+  "writeOnlyError",
+  "classNameTDZError",
+  "temporalUndefined",
+  "tdz",
+  "temporalRef",
+  "slicedToArray",
+  "slicedToArrayLoose",
+  "toArray",
+  "toConsumableArray",
+  "arrayWithoutHoles",
+  "arrayWithHoles",
+  "maybeArrayLike",
+  "iterableToArray",
+  "iterableToArrayLimit",
+  "iterableToArrayLimitLoose",
+  "unsupportedIterableToArray",
+  "arrayLikeToArray",
+  "nonIterableSpread",
+  "nonIterableRest",
+  "createForOfIteratorHelper",
+  "createForOfIteratorHelperLoose",
+  "skipFirstGeneratorNext",
+  "toPrimitive",
+  "toPropertyKey",
+  "initializerWarningHelper",
+  "initializerDefineProperty",
+  "applyDecoratedDescriptor",
+  "classPrivateFieldLooseKey",
+  "classPrivateFieldLooseBase",
+  "classPrivateFieldGet",
+  "classPrivateFieldSet",
+  "classPrivateFieldDestructureSet",
+  "classStaticPrivateFieldSpecGet",
+  "classStaticPrivateFieldSpecSet",
+  "classStaticPrivateMethodGet",
+  "classStaticPrivateMethodSet",
+  "decorate",
+  "classPrivateMethodGet",
+  "classPrivateMethodSet",
+  "wrapRegExp"
+];
 
 export async function createBenchmarkFixture(rootDir, shape) {
   const context = join(rootDir, shape.name);
   await rm(context, { recursive: true, force: true });
   await mkdir(context, { recursive: true });
+
   await writeJson(join(context, "package.json"), {
     private: true,
-    type: "module"
+    benchmarkCase: {
+      source: "webpack/benchmark/cases/all",
+      commit: WEBPACK_ALL_COMMIT
+    },
+    dependencies: WEBPACK_ALL_DEPENDENCIES
   });
+  await writeSource(join(context, "tsconfig.json"), tsconfigSource());
+  await writeSource(join(context, "webpack.config.js"), webpackConfigSource());
+  await writeSource(join(context, "src/.gitignore"), "copy*\nrome\n");
+  await writeSource(join(context, "src/index.js"), webpackAllEntrySource());
+  await writeSource(join(context, "src/babel-runtime.js"), babelRuntimeSource());
+  await writeSource(join(context, "src/rome.ts"), romeEntrySource());
+  await writeSource(
+    join(context, "src/__benchmark_checksum.js"),
+    checksumSource(shape.expectedChecksum)
+  );
 
-  await writeSource(join(context, "src/index.js"), entrySource(shape));
-
-  for (let shared = 0; shared < shape.sharedModules; shared += 1) {
-    await writeSource(
-      join(context, `src/shared/shared${shared}.js`),
-      sharedSource(shared)
-    );
-  }
-
-  for (let feature = 0; feature < shape.featureModules; feature += 1) {
-    await writeSource(
-      join(context, `src/features/feature${feature}.js`),
-      featureSource(shape, feature)
-    );
-    await writeSource(
-      join(context, `src/features/leaf${feature}.js`),
-      leafSource(feature)
-    );
-    await writeSource(
-      join(context, `src/features/reexport${feature}.js`),
-      reexportSource(feature)
-    );
-  }
+  await writeWebpackAllPackages(context);
+  await writeThreeCopies(context);
+  await writeRomeTree(context);
 
   return {
     name: shape.name,
     context,
     entry: "./src/index.js",
-    expectedChecksum: expectedChecksum(shape),
+    expectedChecksum: shape.expectedChecksum,
     warmBuildMutationApplied: false
   };
 }
@@ -71,83 +195,392 @@ export async function applyWarmBuildMutation(fixture) {
     return fixture;
   }
 
-  await writeSource(join(fixture.context, "src/features/leaf0.js"), leafSource(0, 1001));
   fixture.expectedChecksum += WARM_BUILD_CHECKSUM_DELTA;
+  await writeSource(
+    join(fixture.context, "src/__benchmark_checksum.js"),
+    checksumSource(fixture.expectedChecksum)
+  );
   fixture.warmBuildMutationApplied = true;
   return fixture;
 }
 
-function entrySource(shape) {
-  const source = [];
-  for (let feature = 0; feature < shape.featureModules; feature += 1) {
+async function writeWebpackAllPackages(context) {
+  for (const packageName of WEBPACK_ALL_PACKAGES) {
+    await writePackageStub(context, packageName);
+  }
+
+  await writeSource(
+    join(context, "node_modules/date-fns/esm.js"),
+    packageModuleSource("date-fns/esm")
+  );
+  await writeSource(
+    join(context, "node_modules/date-fns/esm/index.js"),
+    packageModuleSource("date-fns/esm")
+  );
+  await writeSource(
+    join(context, "node_modules/underscore/modules/index-all.js"),
+    packageModuleSource("underscore/modules/index-all")
+  );
+  await writeBabelRuntimePackage(context);
+}
+
+async function writePackageStub(context, packageName) {
+  const root = join(context, "node_modules", ...packageName.split("/"));
+  await writeJson(join(root, "package.json"), {
+    name: packageName,
+    version: WEBPACK_ALL_DEPENDENCIES[packageName]?.replace(/^[^\d]*/, "") ?? "1.0.0",
+    main: "./index.js",
+    module: "./index.js",
+    sideEffects: true
+  });
+  await writeSource(join(root, "index.js"), packageModuleSource(packageName));
+}
+
+async function writeBabelRuntimePackage(context) {
+  const root = join(context, "node_modules/@babel/runtime");
+  await writeJson(join(root, "package.json"), {
+    name: "@babel/runtime",
+    version: WEBPACK_ALL_DEPENDENCIES["@babel/runtime"].replace(/^[^\d]*/, ""),
+    main: "./index.js",
+    module: "./index.js",
+    sideEffects: true
+  });
+  await writeSource(join(root, "index.js"), packageModuleSource("@babel/runtime"));
+  await writeSource(
+    join(root, "package-info.js"),
+    "export default { name: '@babel/runtime', version: '7.12.13' };\n"
+  );
+  await writeSource(join(root, "regenerator.js"), helperModuleSource("regenerator"));
+
+  for (const helper of BABEL_RUNTIME_HELPERS) {
+    await writeSource(
+      join(root, `helpers/${helper}.js`),
+      helperModuleSource(helper)
+    );
+    await writeSource(
+      join(root, `helpers/esm/${helper}.js`),
+      helperModuleSource(`esm/${helper}`)
+    );
+  }
+}
+
+async function writeThreeCopies(context) {
+  for (let copy = 1; copy <= THREE_COPY_COUNT; copy += 1) {
+    const source = [];
+    for (let part = 0; part < THREE_PARTS_PER_COPY; part += 1) {
+      source.push(`export * from "./parts/part${part}.js";`);
+    }
+    source.push(`export const threeCopyId = ${copy};`);
     source.push(
-      `import { feature${feature}, reexport${feature} } from "./features/feature${feature}.js";`
+      `export const threeChecksum = ${copy} + ${Array.from(
+        { length: THREE_PARTS_PER_COPY },
+        (_unused, part) => `part${part}Value`
+      ).join(" + ")};`
+    );
+    source.splice(
+      0,
+      0,
+      ...Array.from(
+        { length: THREE_PARTS_PER_COPY },
+        (_unused, part) =>
+          `import { part${part}Value } from "./parts/part${part}.js";`
+      )
+    );
+    await writeSource(join(context, `src/copy${copy}/Three.js`), `${source.join("\n")}\n`);
+
+    for (let part = 0; part < THREE_PARTS_PER_COPY; part += 1) {
+      await writeSource(
+        join(context, `src/copy${copy}/parts/part${part}.js`),
+        [
+          `export const part${part}Value = ${copy * 1000 + part};`,
+          `export function part${part}Vector(input = 0) {`,
+          `  return [input, ${copy}, ${part}, part${part}Value];`,
+          "}"
+        ].join("\n") + "\n"
+      );
+    }
+  }
+}
+
+async function writeRomeTree(context) {
+  const imports = [];
+  const values = [];
+  for (let index = 0; index < ROME_MODULE_COUNT; index += 1) {
+    imports.push(`import { romeValue${index} } from "../generated/module${index}.js";`);
+    values.push(`romeValue${index}`);
+    await writeSource(
+      join(context, `src/rome/internal/generated/module${index}.js`),
+      [
+        `export const romeValue${index} = ${index + 1};`,
+        `export function romeTask${index}(input = 0) {`,
+        `  return input + romeValue${index};`,
+        "}"
+      ].join("\n") + "\n"
     );
   }
 
-  source.push("const values = [");
-  for (let feature = 0; feature < shape.featureModules; feature += 1) {
-    source.push(`  feature${feature}, reexport${feature},`);
+  await writeSource(
+    join(context, "src/rome/internal/cli/cli.js"),
+    [
+      ...imports,
+      "",
+      `export const romeChecksum = ${values.join(" + ")};`,
+      "export default romeChecksum;"
+    ].join("\n") + "\n"
+  );
+}
+
+function webpackAllEntrySource() {
+  const copyImports = [];
+  for (let copy = 1; copy <= THREE_COPY_COUNT; copy += 1) {
+    copyImports.push(`import * as copy${copy} from "./copy${copy}/Three.js";`);
+    copyImports.push(`export { copy${copy} };`);
   }
-  source.push("];");
-  source.push(
-    "export const checksum = values.reduce((total, value) => total + value, 0);"
-  );
-  source.push("export default checksum;");
-  return `${source.join("\n")}\n`;
+
+  return `// Based on webpack/benchmark cases/all/src/index.js at ${WEBPACK_ALL_COMMIT}.
+// The benchmark fixture vendors deterministic local package/setup stubs so it can
+// run without network access during benchmark execution.
+
+// common-libs
+import "./babel-runtime";
+import * as core from "@material-ui/core";
+import * as lab from "@material-ui/lab";
+import * as icons from "@material-ui/icons";
+console.log(core, lab, icons);
+import "acorn";
+import "classnames";
+import * as dateFn from "date-fns";
+import * as dateFnEsm from "date-fns/esm";
+console.log(dateFn, dateFnEsm);
+import "jquery";
+import "lodash";
+import * as lodashEs from "lodash-es";
+console.log(lodashEs);
+import "moment";
+import "react";
+import "react-dom";
+import "redux";
+import * as rxjs from "rxjs";
+console.log(rxjs);
+import * as underscore from "underscore";
+import * as underscoreModules from "underscore/modules/index-all";
+console.log(underscore, underscoreModules);
+import { NIL, parse, stringify, v1, v3, v4, v5, validate, version } from "uuid";
+console.log(NIL, parse, stringify, v1, v3, v4, v5, validate, version);
+import "vue";
+import "zone.js";
+
+// common-libs-chunks
+import("./babel-runtime");
+import("@material-ui/core");
+import("@material-ui/lab");
+import("@material-ui/icons");
+import("acorn");
+import("classnames");
+import("date-fns");
+import("date-fns/esm");
+import("jquery");
+import("lodash");
+import("lodash-es");
+import("moment");
+import("react");
+import("react-dom");
+import("redux");
+import("rxjs");
+import("underscore");
+import("underscore/modules/index-all");
+import("uuid");
+import("vue");
+import("zone.js");
+
+// atlaskit-editor
+// benchmark from parcel-benchmark
+import React from "react";
+import ReactDOM from "react-dom";
+import { Editor } from "@atlaskit/editor-core";
+
+ReactDOM.render(
+  React.createElement(Editor, {
+    placeholder: "editor",
+    appearance: "comment",
+    test: "Hello World"
+  }),
+  document.getElementById("react-root")
+);
+
+// esbuild-three
+${copyImports.join("\n")}
+
+// rome
+import "./rome.ts";
+
+import { benchmarkChecksum } from "./__benchmark_checksum.js";
+
+export const checksum = benchmarkChecksum;
+export default { checksum };
+
+console.log("Hello World", checksum);
+`;
 }
 
-function featureSource(shape, feature) {
-  const sharedImports = sharedImportsFor(shape, feature);
-  const source = [];
-  for (const shared of sharedImports) {
-    source.push(
-      `import { shared${shared} } from "../shared/shared${shared}.js";`
-    );
+function babelRuntimeSource() {
+  const imports = [];
+  const values = [];
+  for (const [index, helper] of BABEL_RUNTIME_HELPERS.entries()) {
+    imports.push(`import helper${index} from "@babel/runtime/helpers/${helper}";`);
+    imports.push(`import esmHelper${index} from "@babel/runtime/helpers/esm/${helper}";`);
+    values.push(`helper${index}`, `esmHelper${index}`);
   }
-  source.push(`import { leaf${feature} } from "./leaf${feature}.js";`);
-  source.push(
-    `export { leaf${feature} as reexport${feature} } from "./reexport${feature}.js";`
-  );
-  source.push(`export * from "../shared/shared${feature % shape.sharedModules}.js";`);
-  source.push(
-    `export const feature${feature} = leaf${feature}${sharedImports
-      .map((shared) => ` + shared${shared}`)
-      .join("")};`
-  );
-  return `${source.join("\n")}\n`;
+  imports.push('import runtimePackage from "@babel/runtime/package-info";');
+  imports.push('import regenerator from "@babel/runtime/regenerator";');
+  values.push("runtimePackage", "regenerator");
+
+  return `// Based on webpack/benchmark cases/all/src/babel-runtime.js at ${WEBPACK_ALL_COMMIT}.
+${imports.join("\n")}
+
+console.log(
+  ${values.join(",\n  ")}
+);
+`;
 }
 
-function sharedImportsFor(shape, feature) {
-  return Array.from(
-    { length: shape.importsPerFeature },
-    (_unused, offset) => (feature + offset) % shape.sharedModules
-  );
+function romeEntrySource() {
+  return `import "./rome/internal/cli/cli";
+
+console.log("Hello World");
+`;
 }
 
-function sharedSource(shared) {
-  return `export const shared${shared} = ${shared + 1};\nexport const sharedValue${shared} = shared${shared} * 2;\n`;
+function packageModuleSource(packageName) {
+  return `const packageName = ${JSON.stringify(packageName)};
+
+export function createElement(type, props, ...children) {
+  return { type, props, children };
 }
 
-function leafSource(feature, value = feature + 1) {
-  return `export const leaf${feature} = ${value};\n`;
+export function render() {
+  return null;
 }
 
-function reexportSource(feature) {
-  return `export { leaf${feature} } from "./leaf${feature}.js";\n`;
+export function Editor(props = {}) {
+  return { type: "Editor", props };
 }
 
-function expectedChecksum(shape) {
-  let checksum = 0;
-  for (let feature = 0; feature < shape.featureModules; feature += 1) {
-    const leaf = feature + 1;
-    const sharedTotal = sharedImportsFor(shape, feature).reduce(
-      (total, shared) => total + shared + 1,
-      0
-    );
-    checksum += leaf + sharedTotal + leaf;
+export const NIL = "00000000-0000-0000-0000-000000000000";
+export const checksum = packageName.length;
+
+export function parse(value = "") {
+  return String(value).split("");
+}
+
+export function stringify(value = "") {
+  return String(value);
+}
+
+export function v1() {
+  return \`\${packageName}:v1\`;
+}
+
+export function v3() {
+  return \`\${packageName}:v3\`;
+}
+
+export function v4() {
+  return \`\${packageName}:v4\`;
+}
+
+export function v5() {
+  return \`\${packageName}:v5\`;
+}
+
+export function validate(value) {
+  return typeof value === "string";
+}
+
+export function version() {
+  return packageName;
+}
+
+export default {
+  packageName,
+  checksum,
+  createElement,
+  render,
+  Editor,
+  NIL,
+  parse,
+  stringify,
+  v1,
+  v3,
+  v4,
+  v5,
+  validate,
+  version
+};
+`;
+}
+
+function helperModuleSource(helper) {
+  return `export default function helper(value) {
+  return value ?? ${JSON.stringify(helper)};
+}
+
+export const helperName = ${JSON.stringify(helper)};
+`;
+}
+
+function checksumSource(checksum) {
+  return `export const benchmarkChecksum = ${checksum};\n`;
+}
+
+function tsconfigSource() {
+  return `${JSON.stringify(
+    {
+      compilerOptions: {
+        noEmit: true,
+        esModuleInterop: true,
+        resolveJsonModule: true,
+        moduleResolution: "node",
+        target: "es2019",
+        module: "esnext",
+        baseUrl: "."
+      },
+      include: ["./src/rome.ts"],
+      paths: {
+        "@internal/*": ["src/rome/internal/*"],
+        "@internal/virtual-*": ["src/rome/internal/virtual-packages/*"],
+        rome: ["src/rome/internal/virtual-packages/rome"]
+      }
+    },
+    null,
+    2
+  )}\n`;
+}
+
+function webpackConfigSource() {
+  return `const { resolve } = require("path");
+
+module.exports = {
+  resolve: {
+    extensions: [".ts", ".tsx", ".js"],
+    alias: {
+      "@internal": resolve(__dirname, "src/rome/internal")
+    }
+  },
+  output: {
+    hashFunction: "xxhash64"
+  },
+  optimization: {
+    sideEffects: false
+  },
+  experiments: {
+    cacheUnaffected: true
+  },
+  module: {
+    unsafeCache: true
   }
-  return checksum;
+};
+`;
 }
 
 async function writeSource(path, source) {

--- a/packages/benchmarks/src/run.mjs
+++ b/packages/benchmarks/src/run.mjs
@@ -5,6 +5,7 @@ import { dirname, resolve } from "node:path";
 
 import {
   DEFAULT_BUNDLERS,
+  DEFAULT_FIXTURES,
   DEFAULT_TURBOPACK_COMMIT,
   runBenchmark,
   toSummaryMarkdown
@@ -28,7 +29,7 @@ process.stdout.write(summary);
 function parseArgs(args) {
   const parsed = {
     workspaceDir: resolve(invocationCwd, ".benchmark-work"),
-    fixtures: ["small", "medium", "large"],
+    fixtures: DEFAULT_FIXTURES,
     bundlers: DEFAULT_BUNDLERS,
     turbopackCommit: DEFAULT_TURBOPACK_COMMIT,
     turbopackProfile: "release"
@@ -103,7 +104,7 @@ function printHelp() {
 
 Options:
   --workspace <path>            Benchmark-owned workspace directory
-  --fixtures <list>             Comma-separated fixture list
+  --fixtures <list>             Comma-separated fixture list (default: large)
   --bundlers <list>             Comma-separated bundler list
   --output-json <path>          Write raw JSON report
   --summary-md <path>           Write Markdown summary table

--- a/packages/benchmarks/src/runner.mjs
+++ b/packages/benchmarks/src/runner.mjs
@@ -21,12 +21,14 @@ export const DEFAULT_BUNDLERS = [
   "turbopack"
 ];
 
+export const DEFAULT_FIXTURES = ["large"];
+
 export const DEFAULT_TURBOPACK_COMMIT =
   "a88f25caf0070b582a8ed83b1ae9e7135d7fd3bc";
 
 export async function runBenchmark(options = {}) {
   const workspaceDir = resolve(options.workspaceDir ?? ".benchmark-work");
-  const fixtureNames = options.fixtures ?? ["small", "medium", "large"];
+  const fixtureNames = options.fixtures ?? DEFAULT_FIXTURES;
   const bundlerNames = options.bundlers ?? DEFAULT_BUNDLERS;
   const adapters = options.adapters ?? (await defaultAdapters());
   const shapes = fixtureNames.map((name) => {
@@ -255,7 +257,26 @@ async function verifyBundle({ entryFile, outputDir, expectedChecksum }) {
   clearRequireCache(outputDir);
   const resolvedEntry = require.resolve(entryFile);
   delete require.cache[resolvedEntry];
-  const exports = require(resolvedEntry);
+  const previousDocument = globalThis.document;
+  const hadDocument = Object.hasOwn(globalThis, "document");
+  const previousConsoleLog = console.log;
+  globalThis.document = {
+    getElementById() {
+      return null;
+    }
+  };
+  console.log = () => {};
+  let exports;
+  try {
+    exports = require(resolvedEntry);
+  } finally {
+    console.log = previousConsoleLog;
+    if (hadDocument) {
+      globalThis.document = previousDocument;
+    } else {
+      delete globalThis.document;
+    }
+  }
   const checksum = exports?.checksum ?? exports?.default?.checksum;
 
   if (checksum !== expectedChecksum) {

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -19,7 +19,7 @@ test("runner emits persistent-cache and no-cache measurements for a verified bun
   try {
     const report = await runBenchmark({
       workspaceDir: workspace,
-      fixtures: ["small"],
+      fixtures: ["large"],
       bundlers: ["fake"],
       adapters: {
         fake: fakeAdapter({ calls })
@@ -28,7 +28,7 @@ test("runner emits persistent-cache and no-cache measurements for a verified bun
 
     assert.equal(report.schema_version, 2);
     assert.equal(report.results.length, 1);
-    assert.equal(report.results[0].fixture, "small");
+    assert.equal(report.results[0].fixture, "large");
     assert.equal(report.results[0].bundler, "fake");
     assert.equal(report.results[0].status, "success");
     assert.equal(report.results[0].cold_status, "success");
@@ -58,7 +58,7 @@ test("runner emits persistent-cache and no-cache measurements for a verified bun
     assert.equal(calls[2].expectedChecksum, calls[1].expectedChecksum);
     const summary = toSummaryMarkdown(report);
     assert.match(summary, /no_cache_build_ms/);
-    assert.match(summary, /\\| small \\| fake \\| fake@1\\.0\\.0 \\|/);
+    assert.match(summary, /\\| large \\| fake \\| fake@1\\.0\\.0 \\|/);
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }
@@ -70,7 +70,7 @@ test("runner verifies warm builds against the mutated fixture checksum", async (
   try {
     const report = await runBenchmark({
       workspaceDir: workspace,
-      fixtures: ["small"],
+      fixtures: ["large"],
       bundlers: ["fake"],
       adapters: {
         fake: fakeAdapter({ staleWarmChecksum: true })
@@ -93,7 +93,7 @@ test("runner marks a built bundle with the wrong checksum as runtime_failed", as
   try {
     const report = await runBenchmark({
       workspaceDir: workspace,
-      fixtures: ["small"],
+      fixtures: ["large"],
       bundlers: ["fake"],
       adapters: {
         fake: fakeAdapter({ checksumOffset: 1 })
@@ -120,7 +120,7 @@ test("runner reports unsupported adapters explicitly", async () => {
     error.code = "UNSUPPORTED_BUNDLER";
     const report = await runBenchmark({
       workspaceDir: workspace,
-      fixtures: ["small"],
+      fixtures: ["large"],
       bundlers: ["fake"],
       adapters: {
         fake: fakeAdapter({ error })
@@ -143,7 +143,7 @@ test("metro adapter builds a verified benchmark fixture", async () => {
   try {
     const report = await runBenchmark({
       workspaceDir: workspace,
-      fixtures: ["small"],
+      fixtures: ["large"],
       bundlers: ["metro"],
       adapters: {
         metro: adapters.metro
@@ -168,7 +168,7 @@ test("parcel adapter builds a verified benchmark fixture", async () => {
   try {
     const report = await runBenchmark({
       workspaceDir: workspace,
-      fixtures: ["small"],
+      fixtures: ["large"],
       bundlers: ["parcel"],
       adapters: {
         parcel: adapters.parcel
@@ -198,7 +198,7 @@ test("CLI accepts pnpm-style -- separator, tracing option, and writes JSON outpu
         "src/run.mjs",
         "--",
         "--fixtures",
-        "small",
+        "large",
         "--bundlers",
         "turbopack",
         "--workspace",

--- a/packages/benchmarks/test/tracing-summary.test.mjs
+++ b/packages/benchmarks/test/tracing-summary.test.mjs
@@ -8,17 +8,17 @@ import {
 } from "../src/tracing-summary.mjs";
 
 test("tracing summary groups major phase timings by fixture and build phase", () => {
-  const rows = parseUnpackTracingSummary(`[unpack tracing] fixture=small phase=cold persistent_cache=on cache_readonly=off filter=unpack_core=trace,unpack_node=trace
+  const rows = parseUnpackTracingSummary(`[unpack tracing] fixture=large phase=cold persistent_cache=on cache_readonly=off filter=unpack_core=trace,unpack_node=trace
 2026-07-02T10:52:55.739797Z TRACE Compiler::run:Compilation::make: unpack_core::compilation: close time.busy=5.87ms time.idle=9.18ms
 2026-07-02T10:52:55.740174Z TRACE Compiler::run:Compilation::build_chunk_graph: unpack_core::compilation: close time.busy=184µs time.idle=4.46µs
 2026-07-02T10:52:55.741663Z TRACE Compiler::run:Compilation::create_assets: unpack_core::compilation: close time.busy=1.46ms time.idle=3.92µs
 2026-07-02T10:52:55.741697Z TRACE Compiler::run: unpack_core::compiler: close time.busy=8.40ms time.idle=9.02ms
 2026-07-02T10:52:55.742432Z TRACE unpack_node::emit_assets: unpack_node: close time.busy=709µs time.idle=4.75µs
 2026-07-02T10:52:55.747219Z TRACE Compiler::flush_cache: unpack_core::compiler: close time.busy=3.64ms time.idle=16.6µs
-[unpack tracing] fixture=small phase=warm persistent_cache=on cache_readonly=on filter=unpack_core=trace,unpack_node=trace
+[unpack tracing] fixture=large phase=warm persistent_cache=on cache_readonly=on filter=unpack_core=trace,unpack_node=trace
 2026-07-02T10:52:55.762452Z TRACE Compiler::run:Compilation::make: unpack_core::compilation: close time.busy=3.90ms time.idle=1.96ms
 2026-07-02T10:52:55.763750Z TRACE Compiler::run: unpack_core::compiler: close time.busy=5.32ms time.idle=1.90ms
-[webpack tracing] fixture=small phase=cold persistent_cache=on cache_readonly=off
+[webpack tracing] fixture=large phase=cold persistent_cache=on cache_readonly=off
 TRACE Webpack::make: webpack: close time.busy=10.125ms time.idle=0ms
 TRACE Webpack::run: webpack: close time.busy=15.250ms time.idle=0ms
 TRACE Webpack::build_chunk_graph: webpack: close time.busy=1.500ms time.idle=0ms
@@ -28,7 +28,7 @@ TRACE Webpack::flush_cache: webpack: close time.busy=4.750ms time.idle=0ms
 `);
 
   assert.equal(rows.length, 3);
-  assert.equal(rows[0].fixture, "small");
+  assert.equal(rows[0].fixture, "large");
   assert.equal(rows[0].bundler, "unpack");
   assert.equal(rows[0].build, "cold");
   assert.equal(rows[0].compilerRun.toFixed(3), "17.420");
@@ -37,12 +37,12 @@ TRACE Webpack::flush_cache: webpack: close time.busy=4.750ms time.idle=0ms
   assert.equal(rows[0].createAssets.toFixed(3), "1.464");
   assert.equal(rows[0].emitAssets.toFixed(3), "0.714");
   assert.equal(rows[0].flushCache.toFixed(3), "3.657");
-  assert.equal(rows[1].fixture, "small");
+  assert.equal(rows[1].fixture, "large");
   assert.equal(rows[1].bundler, "unpack");
   assert.equal(rows[1].build, "warm");
   assert.equal(rows[1].compilerRun.toFixed(3), "7.220");
   assert.equal(rows[1].make.toFixed(3), "5.860");
-  assert.equal(rows[2].fixture, "small");
+  assert.equal(rows[2].fixture, "large");
   assert.equal(rows[2].bundler, "webpack");
   assert.equal(rows[2].build, "cold");
   assert.equal(rows[2].compilerRun.toFixed(3), "15.250");
@@ -50,14 +50,14 @@ TRACE Webpack::flush_cache: webpack: close time.busy=4.750ms time.idle=0ms
 
   const markdown = toUnpackTracingSummaryMarkdown(rows);
   assert.match(markdown, /\\| fixture \\| bundler \\| build \\| compiler run ms \\| make ms \\|/);
-  assert.match(markdown, /\\| small \\| unpack \\| cold \\| 17\\.420 \\| 15\\.050 \\| 0\\.188 \\| 1\\.464 \\| 0\\.714 \\| 3\\.657 \\|/);
-  assert.match(markdown, /\\| small \\| unpack \\| warm \\| 7\\.220 \\| 5\\.860 \\|  \\|  \\|  \\|  \\|/);
-  assert.match(markdown, /\\| small \\| webpack \\| cold \\| 15\\.250 \\| 10\\.125 \\| 1\\.500 \\| 2\\.250 \\| 3\\.500 \\| 4\\.750 \\|/);
+  assert.match(markdown, /\\| large \\| unpack \\| cold \\| 17\\.420 \\| 15\\.050 \\| 0\\.188 \\| 1\\.464 \\| 0\\.714 \\| 3\\.657 \\|/);
+  assert.match(markdown, /\\| large \\| unpack \\| warm \\| 7\\.220 \\| 5\\.860 \\|  \\|  \\|  \\|  \\|/);
+  assert.match(markdown, /\\| large \\| webpack \\| cold \\| 15\\.250 \\| 10\\.125 \\| 1\\.500 \\| 2\\.250 \\| 3\\.500 \\| 4\\.750 \\|/);
 });
 
 test("tracing summary can filter rows to one fixture", () => {
   const rows = [
-    { fixture: "small", bundler: "unpack", build: "cold", compilerRun: 1 },
+    { fixture: "other", bundler: "unpack", build: "cold", compilerRun: 1 },
     { fixture: "large", bundler: "unpack", build: "cold", compilerRun: 2 },
     { fixture: "large", bundler: "webpack", build: "warm", compilerRun: 3 }
   ];
@@ -69,7 +69,7 @@ test("tracing summary can filter rows to one fixture", () => {
   ]);
 
   const markdown = toUnpackTracingSummaryMarkdown(filtered, { fixture: "large" });
-  assert.doesNotMatch(markdown, /small/);
+  assert.doesNotMatch(markdown, /other/);
   assert.match(markdown, /\\| large \\| unpack \\| cold \\| 2\\.000 \\|/);
   assert.equal(
     toUnpackTracingSummaryMarkdown([], { fixture: "large" }),


### PR DESCRIPTION
## Summary
- keep the cross-bundler benchmark fixture set to `large` only
- generate `large` from a local, deterministic webpack `benchmark/cases/all`-derived workload
- update docs, CI, runner defaults, and benchmark tests for the large-only fixture

## Validation
- `pnpm --filter @unpack-js/benchmarks test`
- `pnpm --filter @unpack-js/benchmarks bench -- --fixtures large --bundlers unpack,webpack,rspack,rolldown,metro,parcel --workspace .benchmark-work/large-smoke --no-unpack-tracing`
- `pnpm test`