### PR TITLE
Add loader fixture to cross-bundler benchmarks

### DIFF
--- a/.github/workflows/cross-bundler-benchmark.yml
+++ b/.github/workflows/cross-bundler-benchmark.yml
@@ -84,7 +84,7 @@ jobs:
 
           pnpm --filter @unpack-js/benchmarks bench -- \
             --workspace .benchmark-work/ci \
-            --fixtures large \
+            --fixtures large,loader \
             --output-json .benchmark-work/ci/results.json \
             --summary-md .benchmark-work/ci/summary.md \
             --bundlers "$benchmark_bundlers" \

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -1,6 +1,6 @@
 # Cross-Bundler Benchmark
 
-The Cross-Bundler Benchmark compares Unpack with webpack, Rspack, Rolldown, Metro, Parcel, and Turbopack on the `large` Benchmark Fixture. The fixture is derived from webpack's `benchmark/cases/all` workload and generated locally so benchmark runs do not need network access. The results are diagnostic signals for maintainers; they are not merge gates and they are not compatibility claims.
+The Cross-Bundler Benchmark compares Unpack with webpack, Rspack, Rolldown, Metro, Parcel, and Turbopack on the `large` and `loader` Benchmark Fixtures. The `large` fixture is derived from webpack's `benchmark/cases/all` workload and generated locally so benchmark runs do not need network access. The `loader` fixture adds a webpack-compatible loader pipeline comparison; adapters without webpack loader support report `unsupported`. The results are diagnostic signals for maintainers; they are not merge gates and they are not compatibility claims.
 
 ## Local Run
 
@@ -13,7 +13,7 @@ pnpm benchmark:bundlers -- --workspace .benchmark-work/local
 To run a local subset of bundlers:
 
 ```sh
-pnpm --filter @unpack-js/benchmarks bench -- --fixtures large --bundlers unpack,webpack,rspack,rolldown,metro,parcel
+pnpm --filter @unpack-js/benchmarks bench -- --fixtures large,loader --bundlers unpack,webpack,rspack,rolldown,metro,parcel
 ```
 
 The cross-bundler benchmark prints Unpack internal tracing details to stderr for
@@ -48,7 +48,7 @@ The runner emits a Markdown summary and can write the raw JSON report with `--ou
 Important fields:
 
 - `cold_build_ms`: build time after clearing benchmark-owned output and persistent cache state.
-- `warm_build_ms`: build time after a cold build in the same job, preserving benchmark-owned persistent cache state, modifying the fixture checksum marker, and verifying the updated bundle checksum.
+- `warm_build_ms`: build time after a cold build in the same job, preserving benchmark-owned persistent cache state, modifying the fixture checksum marker or one loader input file, and verifying the updated bundle checksum.
 - `no_cache_build_ms`: build time for an additional clean build with persistent cache disabled. Bundlers without a persistent-cache option run this as a separate clean one-shot build.
 - `output_bytes`: bytes emitted under the benchmark output path, excluding runner metadata.
 - `version_source`: the npm package version or fixed source commit used for the bundler.
@@ -58,7 +58,7 @@ Runtime verification is separate from build timing. A Bundle that builds but doe
 
 ## CI
 
-The `Cross-Bundler Benchmarks` workflow runs on pushes to `main`, pull requests, and manual dispatch. Automatic CI runs compare Unpack with webpack, Rspack, Rolldown, Metro, and Parcel; they skip the fixed Next.js checkout and Turbopack build by default. To include Turbopack, run the workflow manually with the `include_turbopack` input enabled. The workflow writes the table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, writes an Unpack and webpack phase timing summary for the `large` fixture to a new pull request issue comment, and uploads the JSON report, Markdown summary, timing summary, and raw timing log as artifacts.
+The `Cross-Bundler Benchmarks` workflow runs on pushes to `main`, pull requests, and manual dispatch. Automatic CI runs compare Unpack with webpack, Rspack, Rolldown, Metro, and Parcel across the `large` and `loader` fixtures; they skip the fixed Next.js checkout and Turbopack build by default. To include Turbopack, run the workflow manually with the `include_turbopack` input enabled. The workflow writes the table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, writes an Unpack and webpack phase timing summary for the `large` fixture to a new pull request issue comment, and uploads the JSON report, Markdown summary, timing summary, and raw timing log as artifacts.
 
 The workflow builds the Unpack native addon with `UNPACK_NATIVE_PROFILE=release` so benchmark results compare optimized native builds.
 

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -1,6 +1,6 @@
 # Cross-Bundler Benchmark
 
-The Cross-Bundler Benchmark compares Unpack with webpack, Rspack, Rolldown, Metro, Parcel, and Turbopack on the `large` and `loader` Benchmark Fixtures. The `large` fixture is derived from webpack's `benchmark/cases/all` workload and generated locally so benchmark runs do not need network access. The `loader` fixture adds a webpack-compatible loader pipeline comparison; adapters without webpack loader support report `unsupported`. The results are diagnostic signals for maintainers; they are not merge gates and they are not compatibility claims.
+The Cross-Bundler Benchmark compares Unpack with webpack, Rspack, Rolldown, Metro, Parcel, and Turbopack on the `large` and `loader` Benchmark Fixtures. The `large` fixture is derived from webpack's `benchmark/cases/all` workload and generated locally so benchmark runs do not need network access. The `loader` fixture uses the same `large` workload with an added webpack-compatible loader pipeline; adapters without webpack loader support report `unsupported`. The results are diagnostic signals for maintainers; they are not merge gates and they are not compatibility claims.
 
 ## Local Run
 

--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -27,6 +27,7 @@ export const adapters = {
       cacheReadonly = false,
       options
     }) {
+      assertNoWebpackLoaderFixture(fixture, "Unpack");
       configureUnpackTracing({ fixture, phase, persistentCache, cacheReadonly, options });
       const { default: unpack } = await import("@unpack-js/core");
       const compiler = unpack({
@@ -64,6 +65,7 @@ export const adapters = {
 
   webpack: {
     name: "webpack",
+    supportsWebpackLoaders: true,
     versionSource: () => `webpack@${packageVersion("webpack")}`,
     async build({
       fixture,
@@ -106,6 +108,7 @@ export const adapters = {
 
   rspack: {
     name: "rspack",
+    supportsWebpackLoaders: true,
     versionSource: () => `@rspack/core@${packageVersion("@rspack/core")}`,
     async build({ fixture, outputDir, cacheDir, persistentCache = true }) {
       const rspackModule = await import("@rspack/core");
@@ -138,6 +141,7 @@ export const adapters = {
     name: "rolldown",
     versionSource: () => `rolldown@${packageVersion("rolldown")}`,
     async build({ fixture, outputDir }) {
+      assertNoWebpackLoaderFixture(fixture, "Rolldown");
       const { rolldown } = await import("rolldown");
       const bundle = await rolldown({
         input: resolve(fixture.context, fixture.entry),
@@ -166,6 +170,7 @@ export const adapters = {
     name: "metro",
     versionSource: () => `metro@${packageVersion("metro")}`,
     async build({ fixture, outputDir, cacheDir, persistentCache = true }) {
+      assertNoWebpackLoaderFixture(fixture, "Metro");
       const metroModule = await import("metro");
       const metroRuntimeRoot = resolveMetroRuntimeRoot();
       const transformCacheDir = join(cacheDir, "transform");
@@ -231,6 +236,7 @@ export const adapters = {
       persistentCache = true,
       cacheReadonly = false
     }) {
+      assertNoWebpackLoaderFixture(fixture, "Parcel");
       const parcelRequire = createParcelRequire();
       const { default: Parcel } = parcelRequire("@parcel/core");
       const currentCwd = process.cwd();
@@ -322,6 +328,7 @@ export const adapters = {
       preparedTurbopackBuilds.add(prepareKey);
     },
     async build({ fixture, cacheDir, persistentCache = true, options }) {
+      assertNoWebpackLoaderFixture(fixture, "Turbopack");
       const repo = options.turbopackRepo;
       if (!repo) {
         throw unsupported("Turbopack requires --turbopack-repo pointing at a fixed Next.js checkout");
@@ -405,7 +412,7 @@ export async function applyTurbopackBuildCacheFlushPatch(repo) {
 }
 
 function webpackLikeConfig({ fixture, outputDir }) {
-  return {
+  const config = {
     mode: "none",
     target: "node",
     context: fixture.context,
@@ -427,6 +434,34 @@ function webpackLikeConfig({ fixture, outputDir }) {
     },
     stats: "errors-warnings"
   };
+
+  const rules = webpackLoaderRules(fixture);
+  if (rules.length > 0) {
+    config.module = { rules };
+  }
+
+  return config;
+}
+
+function webpackLoaderRules(fixture) {
+  if (!fixture.requiresWebpackLoaders) {
+    return [];
+  }
+
+  return [
+    {
+      test: /\.benchdata$/,
+      loader: join(fixture.context, "loaders/benchmark-loader.cjs")
+    }
+  ];
+}
+
+function assertNoWebpackLoaderFixture(fixture, bundler) {
+  if (!fixture.requiresWebpackLoaders) {
+    return;
+  }
+
+  throw unsupported(`${bundler} does not support the webpack loader benchmark fixture`);
 }
 
 function runUnpackCompiler(compiler) {

--- a/packages/benchmarks/src/fixture.mjs
+++ b/packages/benchmarks/src/fixture.mjs
@@ -20,7 +20,7 @@ export const FIXTURE_SHAPES = {
     name: "loader",
     kind: "loader",
     moduleCount: LOADER_MODULE_COUNT,
-    expectedChecksum: loaderExpectedChecksum(LOADER_MODULE_COUNT)
+    expectedChecksum: LARGE_BASE_CHECKSUM + loaderExpectedChecksum(LOADER_MODULE_COUNT)
   }
 };
 
@@ -208,19 +208,20 @@ async function writeWebpackAllFixture(context, shape) {
     private: true,
     benchmarkCase: {
       source: "webpack/benchmark/cases/all",
-      commit: WEBPACK_ALL_COMMIT
+      commit: WEBPACK_ALL_COMMIT,
+      loaderOverlay: shape.kind === "loader"
     },
     dependencies: WEBPACK_ALL_DEPENDENCIES
   });
   await writeSource(join(context, "tsconfig.json"), tsconfigSource());
   await writeSource(join(context, "webpack.config.js"), webpackConfigSource());
   await writeSource(join(context, "src/.gitignore"), "copy*\nrome\n");
-  await writeSource(join(context, "src/index.js"), webpackAllEntrySource());
+  await writeSource(join(context, "src/index.js"), webpackAllEntrySource(shape));
   await writeSource(join(context, "src/babel-runtime.js"), babelRuntimeSource());
   await writeSource(join(context, "src/rome.ts"), romeEntrySource());
   await writeSource(
     join(context, "src/__benchmark_checksum.js"),
-    checksumSource(shape.expectedChecksum)
+    checksumSource(LARGE_BASE_CHECKSUM)
   );
 
   await writeWebpackAllPackages(context);
@@ -229,13 +230,7 @@ async function writeWebpackAllFixture(context, shape) {
 }
 
 async function writeLoaderFixture(context, shape) {
-  await writeJson(join(context, "package.json"), {
-    private: true,
-    benchmarkCase: {
-      source: "webpack-compatible local loader fixture"
-    }
-  });
-  await writeSource(join(context, "src/index.js"), loaderEntrySource(shape));
+  await writeWebpackAllFixture(context, shape);
   await writeSource(
     join(context, "loaders/benchmark-loader.cjs"),
     benchmarkLoaderSource()
@@ -375,7 +370,7 @@ async function writeRomeTree(context) {
   );
 }
 
-function webpackAllEntrySource() {
+function webpackAllEntrySource(shape) {
   const copyImports = [];
   for (let copy = 1; copy <= THREE_COPY_COUNT; copy += 1) {
     copyImports.push(`import * as copy${copy} from "./copy${copy}/Three.js";`);
@@ -460,8 +455,10 @@ ${copyImports.join("\n")}
 import "./rome.ts";
 
 import { benchmarkChecksum } from "./__benchmark_checksum.js";
+${loaderEntryImports(shape)}
 
-export const checksum = benchmarkChecksum;
+${loaderChecksumSource(shape)}
+export const checksum = benchmarkChecksum + loaderChecksum;
 export default { checksum };
 
 console.log("Hello World", checksum);
@@ -496,24 +493,37 @@ console.log("Hello World");
 `;
 }
 
-function loaderEntrySource(shape) {
+function loaderEntryImports(shape) {
+  if (shape.kind !== "loader") {
+    return "";
+  }
+
   const imports = [];
-  const values = [];
   for (let index = 0; index < shape.moduleCount; index += 1) {
     imports.push(`import value${index} from "./loader-data/item${index}.benchdata";`);
+  }
+
+  return `
+// webpack-compatible loader overlay
+${imports.join("\n")}
+`;
+}
+
+function loaderChecksumSource(shape) {
+  if (shape.kind !== "loader") {
+    return "const loaderChecksum = 0;";
+  }
+
+  const values = [];
+  for (let index = 0; index < shape.moduleCount; index += 1) {
     values.push(`value${index}`);
   }
 
-  return `// Benchmark fixture that exercises a webpack-compatible loader pipeline.
-${imports.join("\n")}
-
-const values = [
+  return `const loaderValues = [
   ${values.join(",\n  ")}
 ];
 
-export const checksum = values.reduce((total, value) => total + value, 0);
-export default { checksum };
-`;
+const loaderChecksum = loaderValues.reduce((total, value) => total + value, 0);`;
 }
 
 function benchmarkLoaderSource() {

--- a/packages/benchmarks/src/fixture.mjs
+++ b/packages/benchmarks/src/fixture.mjs
@@ -5,6 +5,7 @@ export const WARM_BUILD_CHECKSUM_DELTA = 2000;
 
 const WEBPACK_ALL_COMMIT = "d3a1ca290b4b887757a45901288ea30f86b2f842";
 const LARGE_BASE_CHECKSUM = 100000;
+const LOADER_MODULE_COUNT = 300;
 const THREE_COPY_COUNT = 10;
 const THREE_PARTS_PER_COPY = 20;
 const ROME_MODULE_COUNT = 80;
@@ -12,7 +13,14 @@ const ROME_MODULE_COUNT = 80;
 export const FIXTURE_SHAPES = {
   large: {
     name: "large",
+    kind: "webpack-all",
     expectedChecksum: LARGE_BASE_CHECKSUM
+  },
+  loader: {
+    name: "loader",
+    kind: "loader",
+    moduleCount: LOADER_MODULE_COUNT,
+    expectedChecksum: loaderExpectedChecksum(LOADER_MODULE_COUNT)
   }
 };
 
@@ -158,6 +166,44 @@ export async function createBenchmarkFixture(rootDir, shape) {
   await rm(context, { recursive: true, force: true });
   await mkdir(context, { recursive: true });
 
+  if (shape.kind === "loader") {
+    await writeLoaderFixture(context, shape);
+  } else {
+    await writeWebpackAllFixture(context, shape);
+  }
+
+  return {
+    name: shape.name,
+    context,
+    entry: "./src/index.js",
+    expectedChecksum: shape.expectedChecksum,
+    requiresWebpackLoaders: shape.kind === "loader",
+    warmBuildMutationApplied: false
+  };
+}
+
+export async function applyWarmBuildMutation(fixture) {
+  if (fixture.warmBuildMutationApplied) {
+    return fixture;
+  }
+
+  fixture.expectedChecksum += WARM_BUILD_CHECKSUM_DELTA;
+  if (fixture.requiresWebpackLoaders) {
+    await writeSource(
+      join(fixture.context, "src/loader-data/item0.benchdata"),
+      `${1 + WARM_BUILD_CHECKSUM_DELTA}\n`
+    );
+  } else {
+    await writeSource(
+      join(fixture.context, "src/__benchmark_checksum.js"),
+      checksumSource(fixture.expectedChecksum)
+    );
+  }
+  fixture.warmBuildMutationApplied = true;
+  return fixture;
+}
+
+async function writeWebpackAllFixture(context, shape) {
   await writeJson(join(context, "package.json"), {
     private: true,
     benchmarkCase: {
@@ -180,28 +226,27 @@ export async function createBenchmarkFixture(rootDir, shape) {
   await writeWebpackAllPackages(context);
   await writeThreeCopies(context);
   await writeRomeTree(context);
-
-  return {
-    name: shape.name,
-    context,
-    entry: "./src/index.js",
-    expectedChecksum: shape.expectedChecksum,
-    warmBuildMutationApplied: false
-  };
 }
 
-export async function applyWarmBuildMutation(fixture) {
-  if (fixture.warmBuildMutationApplied) {
-    return fixture;
-  }
-
-  fixture.expectedChecksum += WARM_BUILD_CHECKSUM_DELTA;
+async function writeLoaderFixture(context, shape) {
+  await writeJson(join(context, "package.json"), {
+    private: true,
+    benchmarkCase: {
+      source: "webpack-compatible local loader fixture"
+    }
+  });
+  await writeSource(join(context, "src/index.js"), loaderEntrySource(shape));
   await writeSource(
-    join(fixture.context, "src/__benchmark_checksum.js"),
-    checksumSource(fixture.expectedChecksum)
+    join(context, "loaders/benchmark-loader.cjs"),
+    benchmarkLoaderSource()
   );
-  fixture.warmBuildMutationApplied = true;
-  return fixture;
+
+  for (let index = 0; index < shape.moduleCount; index += 1) {
+    await writeSource(
+      join(context, `src/loader-data/item${index}.benchdata`),
+      `${index + 1}\n`
+    );
+  }
 }
 
 async function writeWebpackAllPackages(context) {
@@ -451,6 +496,41 @@ console.log("Hello World");
 `;
 }
 
+function loaderEntrySource(shape) {
+  const imports = [];
+  const values = [];
+  for (let index = 0; index < shape.moduleCount; index += 1) {
+    imports.push(`import value${index} from "./loader-data/item${index}.benchdata";`);
+    values.push(`value${index}`);
+  }
+
+  return `// Benchmark fixture that exercises a webpack-compatible loader pipeline.
+${imports.join("\n")}
+
+const values = [
+  ${values.join(",\n  ")}
+];
+
+export const checksum = values.reduce((total, value) => total + value, 0);
+export default { checksum };
+`;
+}
+
+function benchmarkLoaderSource() {
+  return `module.exports = function benchmarkLoader(source) {
+  const value = Number.parseInt(String(source).trim(), 10);
+  if (!Number.isFinite(value)) {
+    throw new Error("benchmark loader expected a numeric payload");
+  }
+  return [
+    \`const value = \${value};\`,
+    "export default value;",
+    "export { value as loadedValue };"
+  ].join("\\n");
+};
+`;
+}
+
 function packageModuleSource(packageName) {
   return `const packageName = ${JSON.stringify(packageName)};
 
@@ -531,6 +611,10 @@ export const helperName = ${JSON.stringify(helper)};
 
 function checksumSource(checksum) {
   return `export const benchmarkChecksum = ${checksum};\n`;
+}
+
+function loaderExpectedChecksum(moduleCount) {
+  return (moduleCount * (moduleCount + 1)) / 2;
 }
 
 function tsconfigSource() {

--- a/packages/benchmarks/src/run.mjs
+++ b/packages/benchmarks/src/run.mjs
@@ -104,7 +104,7 @@ function printHelp() {
 
 Options:
   --workspace <path>            Benchmark-owned workspace directory
-  --fixtures <list>             Comma-separated fixture list (default: large)
+  --fixtures <list>             Comma-separated fixture list (default: large,loader)
   --bundlers <list>             Comma-separated bundler list
   --output-json <path>          Write raw JSON report
   --summary-md <path>           Write Markdown summary table

--- a/packages/benchmarks/src/runner.mjs
+++ b/packages/benchmarks/src/runner.mjs
@@ -21,7 +21,7 @@ export const DEFAULT_BUNDLERS = [
   "turbopack"
 ];
 
-export const DEFAULT_FIXTURES = ["large"];
+export const DEFAULT_FIXTURES = ["large", "loader"];
 
 export const DEFAULT_TURBOPACK_COMMIT =
   "a88f25caf0070b582a8ed83b1ae9e7135d7fd3bc";
@@ -110,6 +110,16 @@ async function runBundlerBenchmark({ adapter, bundler, fixture, workspaceDir, op
       versionSource: "not_configured",
       status: "unsupported",
       message: "no adapter configured"
+    });
+  }
+
+  if (fixture.requiresWebpackLoaders && !adapter.supportsWebpackLoaders) {
+    return emptyResult({
+      fixture,
+      bundler,
+      versionSource,
+      status: "unsupported",
+      message: `${adapter.name ?? bundler} does not support the webpack loader benchmark fixture`
     });
   }
 

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -210,6 +210,14 @@ test("webpack-compatible adapters build the loader benchmark fixture", async () 
       assert.equal(result.no_cache_status, "success");
       assert.equal(result.verify_status, "success");
     }
+
+    const loaderEntry = await readFile(
+      join(workspace, "fixtures", "loader", "src", "index.js"),
+      "utf8"
+    );
+    assert.match(loaderEntry, /@material-ui\/core/);
+    assert.match(loaderEntry, /\.\/rome\.ts/);
+    assert.match(loaderEntry, /\.\/loader-data\/item0\.benchdata/);
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -187,6 +187,57 @@ test("parcel adapter builds a verified benchmark fixture", async () => {
   }
 });
 
+test("webpack-compatible adapters build the loader benchmark fixture", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
+
+  try {
+    const report = await runBenchmark({
+      workspaceDir: workspace,
+      fixtures: ["loader"],
+      bundlers: ["webpack", "rspack"],
+      adapters: {
+        webpack: adapters.webpack,
+        rspack: adapters.rspack
+      }
+    });
+
+    assert.equal(report.results.length, 2);
+    for (const result of report.results) {
+      assert.equal(result.fixture, "loader");
+      assert.equal(result.status, "success");
+      assert.equal(result.cold_status, "success");
+      assert.equal(result.warm_status, "success");
+      assert.equal(result.no_cache_status, "success");
+      assert.equal(result.verify_status, "success");
+    }
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("non-loader adapters mark the loader benchmark fixture unsupported", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
+
+  try {
+    const report = await runBenchmark({
+      workspaceDir: workspace,
+      fixtures: ["loader"],
+      bundlers: ["metro"],
+      adapters: {
+        metro: adapters.metro
+      }
+    });
+
+    assert.equal(report.results[0].fixture, "loader");
+    assert.equal(report.results[0].bundler, "metro");
+    assert.equal(report.results[0].status, "unsupported");
+    assert.equal(report.results[0].cold_build_ms, null);
+    assert.match(report.results[0].error, /webpack loader benchmark fixture/);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
 test("CLI accepts pnpm-style -- separator, tracing option, and writes JSON output", async () => {
   const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
   const outputJson = join(workspace, "results.json");


### PR DESCRIPTION
## Summary
- add a `loader` benchmark fixture by layering a webpack-compatible loader pipeline onto the existing `large` / webpack `cases/all` workload
- run `large,loader` by default and in the benchmark workflow
- report loader fixture support explicitly: webpack/rspack build it, non-loader adapters return `unsupported`

## Validation
- `pnpm --filter @unpack-js/benchmarks test`
- `pnpm --filter @unpack-js/benchmarks bench -- --fixtures large,loader --bundlers unpack,webpack,rspack,rolldown,metro,parcel --workspace .benchmark-work/loader-large-smoke --no-unpack-tracing`
- `pnpm test`