### PR TITLE
Use bundler-diff Turbopack release in benchmarks

### DIFF
--- a/.github/workflows/cross-bundler-benchmark.yml
+++ b/.github/workflows/cross-bundler-benchmark.yml
@@ -10,12 +10,12 @@ on:
       include_turbopack:
         description: Include Turbopack in the benchmark run
         type: boolean
-        default: false
+        default: true
         required: false
 
 env:
-  DEFAULT_BENCHMARK_BUNDLERS: unpack,webpack,rspack,rolldown,metro,parcel
-  TURBOPACK_BENCHMARK_BUNDLERS: unpack,webpack,rspack,rolldown,metro,parcel,turbopack
+  DEFAULT_BENCHMARK_BUNDLERS: unpack,webpack,rspack,rolldown,metro,parcel,turbopack
+  NO_TURBOPACK_BENCHMARK_BUNDLERS: unpack,webpack,rspack,rolldown,metro,parcel
   TURBOPACK_CLI_RELEASE_URL: https://github.com/hardfist/bundler-diff/releases/download/turbopack-cli-main/turbopack-cli-linux-x64.tar.gz
 
 jobs:
@@ -56,7 +56,7 @@ jobs:
         run: pnpm --filter @unpack-js/core build
 
       - name: Download Turbopack CLI release
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.include_turbopack }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.include_turbopack }}
         run: |
           set -euo pipefail
           mkdir -p .benchmark-tools/turbopack-cli
@@ -69,14 +69,16 @@ jobs:
         id: benchmark
         continue-on-error: true
         env:
-          INCLUDE_TURBOPACK: ${{ github.event_name == 'workflow_dispatch' && inputs.include_turbopack }}
+          INCLUDE_TURBOPACK: ${{ github.event_name != 'workflow_dispatch' || inputs.include_turbopack }}
         run: |
           mkdir -p .benchmark-work/ci
 
           benchmark_bundlers="$DEFAULT_BENCHMARK_BUNDLERS"
           turbopack_args=()
+          if [ "$INCLUDE_TURBOPACK" != "true" ]; then
+            benchmark_bundlers="$NO_TURBOPACK_BENCHMARK_BUNDLERS"
+          fi
           if [ "$INCLUDE_TURBOPACK" = "true" ]; then
-            benchmark_bundlers="$TURBOPACK_BENCHMARK_BUNDLERS"
             turbopack_commit="turbopack-cli-main"
             if [ -f .benchmark-tools/turbopack-cli/source-commit.txt ]; then
               turbopack_commit="$(cat .benchmark-tools/turbopack-cli/source-commit.txt)"

--- a/.github/workflows/cross-bundler-benchmark.yml
+++ b/.github/workflows/cross-bundler-benchmark.yml
@@ -16,7 +16,7 @@ on:
 env:
   DEFAULT_BENCHMARK_BUNDLERS: unpack,webpack,rspack,rolldown,metro
   TURBOPACK_BENCHMARK_BUNDLERS: unpack,webpack,rspack,rolldown,metro,turbopack
-  TURBOPACK_NEXT_COMMIT: a88f25caf0070b582a8ed83b1ae9e7135d7fd3bc
+  TURBOPACK_CLI_RELEASE_URL: https://github.com/hardfist/bundler-diff/releases/download/turbopack-cli-main/turbopack-cli-linux-x64.tar.gz
 
 jobs:
   cross-bundler-benchmarks:
@@ -55,14 +55,15 @@ jobs:
           UNPACK_NATIVE_PROFILE: release
         run: pnpm --filter @unpack-js/core build
 
-      - name: Checkout fixed Turbopack source
+      - name: Download Turbopack CLI release
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.include_turbopack }}
         run: |
-          mkdir -p .benchmark-tools/next.js
-          git -C .benchmark-tools/next.js init
-          git -C .benchmark-tools/next.js remote add origin https://github.com/vercel/next.js.git
-          git -C .benchmark-tools/next.js fetch --depth=1 --filter=blob:none origin "$TURBOPACK_NEXT_COMMIT"
-          git -C .benchmark-tools/next.js checkout --detach FETCH_HEAD
+          set -euo pipefail
+          mkdir -p .benchmark-tools/turbopack-cli
+          curl -fsSL "$TURBOPACK_CLI_RELEASE_URL" -o .benchmark-tools/turbopack-cli.tar.gz
+          tar -xzf .benchmark-tools/turbopack-cli.tar.gz -C .benchmark-tools/turbopack-cli
+          chmod +x .benchmark-tools/turbopack-cli/turbopack-cli
+          .benchmark-tools/turbopack-cli/turbopack-cli --help >/dev/null
 
       - name: Run cross-bundler benchmark
         id: benchmark
@@ -76,9 +77,13 @@ jobs:
           turbopack_args=()
           if [ "$INCLUDE_TURBOPACK" = "true" ]; then
             benchmark_bundlers="$TURBOPACK_BENCHMARK_BUNDLERS"
+            turbopack_commit="turbopack-cli-main"
+            if [ -f .benchmark-tools/turbopack-cli/source-commit.txt ]; then
+              turbopack_commit="$(cat .benchmark-tools/turbopack-cli/source-commit.txt)"
+            fi
             turbopack_args=(
-              --turbopack-repo .benchmark-tools/next.js
-              --turbopack-commit "$TURBOPACK_NEXT_COMMIT"
+              --turbopack-binary .benchmark-tools/turbopack-cli/turbopack-cli
+              --turbopack-commit "$turbopack_commit"
             )
           fi
 

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -23,7 +23,9 @@ their close-time busy/idle durations. Pass `--no-unpack-tracing` for quiet
 benchmark logs, or `--unpack-tracing <filter>` to use a custom Rust
 `tracing-subscriber` filter.
 
-Turbopack requires a fixed Next.js checkout:
+Turbopack can run against the prebuilt `turbopack-cli` release produced by
+`hardfist/bundler-diff`, or against a fixed Next.js checkout for local
+source-level comparisons:
 
 ```sh
 git init .benchmark-tools/next.js
@@ -58,7 +60,7 @@ Runtime verification is separate from build timing. A Bundle that builds but doe
 
 ## CI
 
-The `Cross-Bundler Benchmarks` workflow runs on pushes to `main`, pull requests, and manual dispatch. Automatic CI runs compare Unpack with webpack, Rspack, Rolldown, Metro, and Parcel across the `large` and `loader` fixtures; they skip the fixed Next.js checkout and Turbopack build by default. To include Turbopack, run the workflow manually with the `include_turbopack` input enabled. The workflow writes the table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, writes an Unpack and webpack phase timing summary for the `large` fixture to a new pull request issue comment, and uploads the JSON report, Markdown summary, timing summary, and raw timing log as artifacts.
+The `Cross-Bundler Benchmarks` workflow runs on pushes to `main`, pull requests, and manual dispatch. CI runs compare Unpack with webpack, Rspack, Rolldown, Metro, Parcel, and Turbopack across the `large` and `loader` fixtures by default. The workflow downloads the `turbopack-cli-main` release artifact from `hardfist/bundler-diff` and passes it to the benchmark runner with `--turbopack-binary`; manual dispatch can set `include_turbopack` to `false` when a non-Turbopack run is needed. The workflow writes the table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, writes an Unpack and webpack phase timing summary for the `large` fixture to a new pull request issue comment, and uploads the JSON report, Markdown summary, timing summary, and raw timing log as artifacts.
 
 The workflow builds the Unpack native addon with `UNPACK_NATIVE_PROFILE=release` so benchmark results compare optimized native builds.
 

--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -223,12 +223,22 @@ export const adapters = {
   turbopack: {
     name: "turbopack",
     outputDir: ({ fixture }) => join(fixture.context, "dist"),
-    versionSource: ({ options }) =>
-      `vercel/next.js@${options.turbopackCommit ?? DEFAULT_TURBOPACK_COMMIT}+benchmark-cache-flush`,
+    versionSource: ({ options }) => {
+      if (options.turbopackBinary) {
+        return `hardfist/bundler-diff@${options.turbopackCommit ?? "turbopack-cli-main"}+release-turbopack-cli`;
+      }
+      return `vercel/next.js@${options.turbopackCommit ?? DEFAULT_TURBOPACK_COMMIT}+benchmark-cache-flush`;
+    },
     async prepare({ options }) {
+      if (options.turbopackBinary) {
+        return;
+      }
+
       const repo = options.turbopackRepo;
       if (!repo) {
-        throw unsupported("Turbopack requires --turbopack-repo pointing at a fixed Next.js checkout");
+        throw unsupported(
+          "Turbopack requires --turbopack-binary or --turbopack-repo pointing at a fixed Next.js checkout"
+        );
       }
 
       const profile = options.turbopackProfile ?? "release";
@@ -255,17 +265,18 @@ export const adapters = {
     },
     async build({ fixture, cacheDir, persistentCache = true, options }) {
       const repo = options.turbopackRepo;
-      if (!repo) {
-        throw unsupported("Turbopack requires --turbopack-repo pointing at a fixed Next.js checkout");
+      const profile = options.turbopackProfile ?? "release";
+      const binary = options.turbopackBinary
+        ? options.turbopackBinary
+        : repo
+          ? join(repo, "target", profile === "dev" ? "debug" : profile, "turbopack-cli")
+          : null;
+      if (!binary) {
+        throw unsupported(
+          "Turbopack requires --turbopack-binary or --turbopack-repo pointing at a fixed Next.js checkout"
+        );
       }
 
-      const profile = options.turbopackProfile ?? "release";
-      const binary = join(
-        repo,
-        "target",
-        profile === "dev" ? "debug" : profile,
-        "turbopack-cli"
-      );
       const args = [
         "build",
         "--dir",
@@ -287,7 +298,7 @@ export const adapters = {
         binary,
         args,
         {
-          cwd: repo,
+          cwd: repo ?? dirname(binary),
           env: { ...process.env, CI: process.env.CI ?? "1" },
           timeout: 10 * 60 * 1000,
           maxBuffer: 1024 * 1024 * 20

--- a/packages/benchmarks/src/run.mjs
+++ b/packages/benchmarks/src/run.mjs
@@ -71,6 +71,9 @@ function parseArgs(args) {
       case "--turbopack-repo":
         parsed.turbopackRepo = resolve(invocationCwd, value());
         break;
+      case "--turbopack-binary":
+        parsed.turbopackBinary = resolve(invocationCwd, value());
+        break;
       case "--turbopack-commit":
         parsed.turbopackCommit = value();
         break;
@@ -110,6 +113,7 @@ Options:
   --unpack-tracing <filter>     Set the Unpack tracing filter (default: unpack_core=trace,unpack_node=trace)
   --no-unpack-tracing           Do not print Unpack tracing details
   --turbopack-repo <path>       Fixed Next.js checkout containing turbopack/
+  --turbopack-binary <path>     Prebuilt turbopack-cli binary
   --turbopack-commit <sha>      Commit shown for Turbopack results
   --turbopack-profile <name>    Cargo profile for turbopack-cli (default: release)
 `);

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -236,6 +236,59 @@ test("turbopack build enables persistent cache for warm measurements", async () 
   }
 });
 
+test("turbopack build can use a prebuilt binary without a source checkout", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
+
+  try {
+    const binary = join(workspace, "tools", "turbopack-cli");
+    const argsLog = join(workspace, "turbopack-args.txt");
+    const fixtureContext = join(workspace, "fixture");
+    const cacheDir = join(workspace, "cache");
+
+    await mkdir(join(workspace, "tools"), { recursive: true });
+    await mkdir(fixtureContext, { recursive: true });
+    await writeFile(
+      binary,
+      `#!/bin/sh\nprintf '%s\\n' "$@" > "${argsLog}"\n`,
+      "utf8"
+    );
+    await chmod(binary, 0o755);
+
+    await adapters.turbopack.prepare({
+      options: {
+        turbopackBinary: binary
+      }
+    });
+
+    await adapters.turbopack.build({
+      fixture: {
+        context: fixtureContext,
+        entry: "./src/index.js"
+      },
+      cacheDir,
+      options: {
+        turbopackBinary: binary
+      }
+    });
+
+    const args = (await readFile(argsLog, "utf8")).trim().split("\n");
+    assert.ok(args.includes("--persistent-caching"));
+    assert.equal(args[args.indexOf("--cache-dir") + 1], cacheDir);
+    assert.equal(args.at(-1), "./src/index.js");
+    assert.match(
+      adapters.turbopack.versionSource({
+        options: {
+          turbopackBinary: binary,
+          turbopackCommit: "release-source"
+        }
+      }),
+      /^hardfist\/bundler-diff@release-source\+release-turbopack-cli$/
+    );
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
 test("turbopack prepare patches build shutdown to flush persistent cache", async () => {
   const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
 


### PR DESCRIPTION
## Summary

- Add `--turbopack-binary` to the benchmark CLI so Turbopack can run from a prebuilt `turbopack-cli` instead of a fixed Next.js source checkout.
- Keep the existing `--turbopack-repo` source-build path as a local fallback.
- Update the cross-bundler benchmark workflow to download `hardfist/bundler-diff`'s `turbopack-cli-main` release asset when manual Turbopack runs are requested.

Depends on hardfist/bundler-diff#3 publishing `turbopack-cli-linux-x64.tar.gz` from main before running `Cross-Bundler Benchmarks` with `include_turbopack=true`.

## Validation

- `pnpm --filter @unpack-js/benchmarks test`
- parsed `.github/workflows/cross-bundler-benchmark.yml` with Ruby YAML
- parsed `packages/benchmarks/package.json` with Node
- `git diff --check`
- manually dispatched `CI` on this branch: passed
- manually dispatched `Cross-Bundler Benchmarks` with `include_turbopack=false`: passed

`include_turbopack=true` should be run after hardfist/bundler-diff#3 merges and publishes the main release asset.
