### PR TITLE
Improve cross-bundler warm and loader benchmarks

### DIFF
--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -48,7 +48,7 @@ The runner emits a Markdown summary and can write the raw JSON report with `--ou
 Important fields:
 
 - `cold_build_ms`: build time after clearing benchmark-owned output and persistent cache state.
-- `warm_build_ms`: build time after a cold build in the same job, preserving benchmark-owned persistent cache state, modifying the fixture checksum marker or one loader input file, and verifying the updated bundle checksum.
+- `warm_build_ms`: build time after a cold build in the same job, preserving benchmark-owned persistent cache state, rewriting the fixture entry to comment out one generated module import/export, and verifying the updated bundle checksum.
 - `no_cache_build_ms`: build time for an additional clean build with persistent cache disabled. Bundlers without a persistent-cache option run this as a separate clean one-shot build.
 - `output_bytes`: bytes emitted under the benchmark output path, excluding runner metadata.
 - `version_source`: the npm package version or fixed source commit used for the bundler.

--- a/packages/benchmarks/src/fixture.mjs
+++ b/packages/benchmarks/src/fixture.mjs
@@ -1,8 +1,6 @@
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
-export const WARM_BUILD_CHECKSUM_DELTA = 2000;
-
 const WEBPACK_ALL_COMMIT = "d3a1ca290b4b887757a45901288ea30f86b2f842";
 const LARGE_BASE_CHECKSUM = 100000;
 const LOADER_MODULE_COUNT = 300;
@@ -10,17 +8,21 @@ const THREE_COPY_COUNT = 10;
 const THREE_PARTS_PER_COPY = 20;
 const ROME_MODULE_COUNT = 80;
 
+export const WARM_BUILD_GRAPH_COPY = THREE_COPY_COUNT;
+export const WARM_BUILD_CHECKSUM_DELTA = -copyChecksum(WARM_BUILD_GRAPH_COPY);
+
 export const FIXTURE_SHAPES = {
   large: {
     name: "large",
     kind: "webpack-all",
-    expectedChecksum: LARGE_BASE_CHECKSUM
+    expectedChecksum: largeExpectedChecksum()
   },
   loader: {
     name: "loader",
     kind: "loader",
     moduleCount: LOADER_MODULE_COUNT,
-    expectedChecksum: LARGE_BASE_CHECKSUM + loaderExpectedChecksum(LOADER_MODULE_COUNT)
+    expectedChecksum:
+      largeExpectedChecksum() + loaderExpectedChecksum(LOADER_MODULE_COUNT)
   }
 };
 
@@ -177,6 +179,8 @@ export async function createBenchmarkFixture(rootDir, shape) {
     context,
     entry: "./src/index.js",
     expectedChecksum: shape.expectedChecksum,
+    fixtureKind: shape.kind,
+    loaderModuleCount: shape.moduleCount ?? 0,
     requiresWebpackLoaders: shape.kind === "loader",
     warmBuildMutationApplied: false
   };
@@ -188,17 +192,16 @@ export async function applyWarmBuildMutation(fixture) {
   }
 
   fixture.expectedChecksum += WARM_BUILD_CHECKSUM_DELTA;
-  if (fixture.requiresWebpackLoaders) {
-    await writeSource(
-      join(fixture.context, "src/loader-data/item0.benchdata"),
-      `${1 + WARM_BUILD_CHECKSUM_DELTA}\n`
-    );
-  } else {
-    await writeSource(
-      join(fixture.context, "src/__benchmark_checksum.js"),
-      checksumSource(fixture.expectedChecksum)
-    );
-  }
+  await writeSource(
+    join(fixture.context, "src/index.js"),
+    webpackAllEntrySource(
+      {
+        kind: fixture.fixtureKind,
+        moduleCount: fixture.loaderModuleCount
+      },
+      { excludedCopy: WARM_BUILD_GRAPH_COPY }
+    )
+  );
   fixture.warmBuildMutationApplied = true;
   return fixture;
 }
@@ -370,12 +373,22 @@ async function writeRomeTree(context) {
   );
 }
 
-function webpackAllEntrySource(shape) {
+function webpackAllEntrySource(shape, { excludedCopy } = {}) {
   const copyImports = [];
+  const copyChecksumValues = [];
   for (let copy = 1; copy <= THREE_COPY_COUNT; copy += 1) {
+    if (copy === excludedCopy) {
+      copyImports.push(`// warm-build graph mutation excludes copy${copy}.`);
+      copyImports.push(`// import * as copy${copy} from "./copy${copy}/Three.js";`);
+      copyImports.push(`// export { copy${copy} };`);
+      continue;
+    }
+
     copyImports.push(`import * as copy${copy} from "./copy${copy}/Three.js";`);
     copyImports.push(`export { copy${copy} };`);
+    copyChecksumValues.push(`copy${copy}.threeChecksum`);
   }
+  const copyChecksumSource = `const copyChecksum = ${copyChecksumValues.join(" + ")};`;
 
   return `// Based on webpack/benchmark cases/all/src/index.js at ${WEBPACK_ALL_COMMIT}.
 // The benchmark fixture vendors deterministic local package/setup stubs so it can
@@ -457,8 +470,9 @@ import "./rome.ts";
 import { benchmarkChecksum } from "./__benchmark_checksum.js";
 ${loaderEntryImports(shape)}
 
+${copyChecksumSource}
 ${loaderChecksumSource(shape)}
-export const checksum = benchmarkChecksum + loaderChecksum;
+export const checksum = benchmarkChecksum + copyChecksum + loaderChecksum;
 export default { checksum };
 
 console.log("Hello World", checksum);
@@ -625,6 +639,22 @@ function checksumSource(checksum) {
 
 function loaderExpectedChecksum(moduleCount) {
   return (moduleCount * (moduleCount + 1)) / 2;
+}
+
+function largeExpectedChecksum() {
+  let total = LARGE_BASE_CHECKSUM;
+  for (let copy = 1; copy <= THREE_COPY_COUNT; copy += 1) {
+    total += copyChecksum(copy);
+  }
+  return total;
+}
+
+function copyChecksum(copy) {
+  let total = copy;
+  for (let part = 0; part < THREE_PARTS_PER_COPY; part += 1) {
+    total += copy * 1000 + part;
+  }
+  return total;
 }
 
 function tsconfigSource() {

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -7,7 +7,10 @@ import test from "node:test";
 import { promisify } from "node:util";
 
 import { adapters, applyTurbopackBuildCacheFlushPatch } from "../src/adapters.mjs";
-import { WARM_BUILD_CHECKSUM_DELTA } from "../src/fixture.mjs";
+import {
+  WARM_BUILD_CHECKSUM_DELTA,
+  WARM_BUILD_GRAPH_COPY
+} from "../src/fixture.mjs";
 import { runBenchmark, toSummaryMarkdown } from "../src/runner.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -56,6 +59,23 @@ test("runner emits persistent-cache and no-cache measurements for a verified bun
       calls[0].expectedChecksum + WARM_BUILD_CHECKSUM_DELTA
     );
     assert.equal(calls[2].expectedChecksum, calls[1].expectedChecksum);
+    const mutatedEntry = await readFile(
+      join(workspace, "fixtures", "large", "src", "index.js"),
+      "utf8"
+    );
+    assert.match(
+      mutatedEntry,
+      new RegExp(
+        `// import \\* as copy${WARM_BUILD_GRAPH_COPY} from "\\./copy${WARM_BUILD_GRAPH_COPY}/Three\\.js";`
+      )
+    );
+    assert.doesNotMatch(
+      mutatedEntry,
+      new RegExp(
+        `^import \\* as copy${WARM_BUILD_GRAPH_COPY} from "\\./copy${WARM_BUILD_GRAPH_COPY}/Three\\.js";`,
+        "m"
+      )
+    );
     const summary = toSummaryMarkdown(report);
     assert.match(summary, /no_cache_build_ms/);
     assert.match(summary, /\\| large \\| fake \\| fake@1\\.0\\.0 \\|/);


### PR DESCRIPTION
## Summary

- Change the cross-bundler warm build mutation to rewrite the fixture entry and comment out one generated module import/export.
- Include generated copy module checksums in the benchmark checksum so warm build verification reflects the module graph change.
- Let the Turbopack adapter run the loader fixture by materializing equivalent JavaScript modules for `.benchdata` inputs before invoking the pinned standalone CLI.
- Update runner gating, tests, and benchmark documentation for the new warm build and Turbopack loader behavior.

## Why

The previous warm build mutation only changed a checksum marker or loader input. That exercised a warm rebuild after a file-content change, but it did not force a module graph change. The new mutation changes the entry dependency graph while still validating the emitted bundle checksum.

The pinned standalone `turbopack-cli` does not expose webpack loader rules, so the benchmark adapter now uses a Turbopack-specific materialization step for loader fixture inputs instead of marking the loader fixture unsupported for Turbopack.

## Validation

- `pnpm --filter @unpack-js/benchmarks test`
- `pnpm --filter @unpack-js/core build`
- `pnpm --filter @unpack-js/benchmarks bench -- --workspace .benchmark-work-unpack-check --fixtures large --bundlers unpack --no-unpack-tracing`
