### PR TITLE
Add Turbopack loader fixture support

### DIFF
--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -1,6 +1,6 @@
 # Cross-Bundler Benchmark
 
-The Cross-Bundler Benchmark compares Unpack with webpack, Rspack, Rolldown, Metro, Parcel, and Turbopack on the `large` and `loader` Benchmark Fixtures. The `large` fixture is derived from webpack's `benchmark/cases/all` workload and generated locally so benchmark runs do not need network access. The `loader` fixture uses the same `large` workload with an added webpack-compatible loader pipeline; adapters without webpack loader support report `unsupported`. The results are diagnostic signals for maintainers; they are not merge gates and they are not compatibility claims.
+The Cross-Bundler Benchmark compares Unpack with webpack, Rspack, Rolldown, Metro, Parcel, and Turbopack on the `large` and `loader` Benchmark Fixtures. The `large` fixture is derived from webpack's `benchmark/cases/all` workload and generated locally so benchmark runs do not need network access. The `loader` fixture uses the same `large` workload with an added webpack-compatible loader pipeline for webpack and Rspack. The Turbopack CLI adapter materializes equivalent JavaScript modules for the loader inputs because the pinned standalone CLI does not expose webpack loader rules. Adapters without a loader-fixture path report `unsupported`. The results are diagnostic signals for maintainers; they are not merge gates and they are not compatibility claims.
 
 ## Local Run
 

--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -296,6 +296,7 @@ export const adapters = {
 
   turbopack: {
     name: "turbopack",
+    supportsLoaderFixture: true,
     outputDir: ({ fixture }) => join(fixture.context, "dist"),
     versionSource: ({ options }) => {
       if (options.turbopackBinary) {
@@ -338,7 +339,6 @@ export const adapters = {
       preparedTurbopackBuilds.add(prepareKey);
     },
     async build({ fixture, cacheDir, persistentCache = true, options }) {
-      assertNoWebpackLoaderFixture(fixture, "Turbopack");
       const repo = options.turbopackRepo;
       const profile = options.turbopackProfile ?? "release";
       const binary = options.turbopackBinary
@@ -351,6 +351,7 @@ export const adapters = {
           "Turbopack requires --turbopack-binary or --turbopack-repo pointing at a fixed Next.js checkout"
         );
       }
+      await materializeTurbopackLoaderFixture(fixture);
 
       const args = [
         "build",
@@ -472,7 +473,40 @@ function assertNoWebpackLoaderFixture(fixture, bundler) {
     return;
   }
 
-  throw unsupported(`${bundler} does not support the webpack loader benchmark fixture`);
+  throw unsupported(`${bundler} does not support the loader benchmark fixture`);
+}
+
+async function materializeTurbopackLoaderFixture(fixture) {
+  if (!fixture.requiresWebpackLoaders) {
+    return;
+  }
+
+  const entryPath = resolve(fixture.context, fixture.entry);
+  const entrySource = await readFile(entryPath, "utf8");
+  const rewrittenEntrySource = entrySource.replace(
+    /(\.\/loader-data\/item\d+\.benchdata)(?=")/g,
+    "$1.js"
+  );
+  if (rewrittenEntrySource !== entrySource) {
+    await writeFile(entryPath, rewrittenEntrySource, "utf8");
+  }
+
+  for (let index = 0; index < fixture.loaderModuleCount; index += 1) {
+    const dataPath = join(fixture.context, `src/loader-data/item${index}.benchdata`);
+    const value = Number.parseInt((await readFile(dataPath, "utf8")).trim(), 10);
+    if (!Number.isFinite(value)) {
+      throw new Error(`benchmark loader expected a numeric payload in ${dataPath}`);
+    }
+    await writeFile(
+      `${dataPath}.js`,
+      [
+        `const value = ${value};`,
+        "export default value;",
+        "export { value as loadedValue };"
+      ].join("\n") + "\n",
+      "utf8"
+    );
+  }
 }
 
 function runUnpackCompiler(compiler) {

--- a/packages/benchmarks/src/runner.mjs
+++ b/packages/benchmarks/src/runner.mjs
@@ -113,13 +113,17 @@ async function runBundlerBenchmark({ adapter, bundler, fixture, workspaceDir, op
     });
   }
 
-  if (fixture.requiresWebpackLoaders && !adapter.supportsWebpackLoaders) {
+  if (
+    fixture.requiresWebpackLoaders &&
+    !adapter.supportsWebpackLoaders &&
+    !adapter.supportsLoaderFixture
+  ) {
     return emptyResult({
       fixture,
       bundler,
       versionSource,
       status: "unsupported",
-      message: `${adapter.name ?? bundler} does not support the webpack loader benchmark fixture`
+      message: `${adapter.name ?? bundler} does not support the loader benchmark fixture`
     });
   }
 

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -260,7 +260,7 @@ test("non-loader adapters mark the loader benchmark fixture unsupported", async 
     assert.equal(report.results[0].bundler, "metro");
     assert.equal(report.results[0].status, "unsupported");
     assert.equal(report.results[0].cold_build_ms, null);
-    assert.match(report.results[0].error, /webpack loader benchmark fixture/);
+    assert.match(report.results[0].error, /loader benchmark fixture/);
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }
@@ -388,6 +388,63 @@ test("turbopack build can use a prebuilt binary without a source checkout", asyn
       }),
       /^hardfist\/bundler-diff@release-source\+release-turbopack-cli$/
     );
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("turbopack adapter materializes loader fixture inputs as JavaScript modules", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
+
+  try {
+    const binary = join(workspace, "tools", "turbopack-cli");
+    const argsLog = join(workspace, "turbopack-args.txt");
+    const fixtureContext = join(workspace, "fixture");
+    const cacheDir = join(workspace, "cache");
+
+    await mkdir(join(workspace, "tools"), { recursive: true });
+    await mkdir(join(fixtureContext, "src", "loader-data"), { recursive: true });
+    await writeFile(
+      binary,
+      `#!/bin/sh\nprintf '%s\\n' "$@" > "${argsLog}"\n`,
+      "utf8"
+    );
+    await chmod(binary, 0o755);
+    await writeFile(
+      join(fixtureContext, "src", "index.js"),
+      [
+        'import value0 from "./loader-data/item0.benchdata";',
+        'import value1 from "./loader-data/item1.benchdata";',
+        "export const checksum = value0 + value1;"
+      ].join("\n") + "\n",
+      "utf8"
+    );
+    await writeFile(join(fixtureContext, "src", "loader-data", "item0.benchdata"), "1\n");
+    await writeFile(join(fixtureContext, "src", "loader-data", "item1.benchdata"), "2\n");
+
+    await adapters.turbopack.build({
+      fixture: {
+        context: fixtureContext,
+        entry: "./src/index.js",
+        loaderModuleCount: 2,
+        requiresWebpackLoaders: true
+      },
+      cacheDir,
+      options: {
+        turbopackBinary: binary
+      }
+    });
+
+    const entry = await readFile(join(fixtureContext, "src", "index.js"), "utf8");
+    assert.match(entry, /\.\/loader-data\/item0\.benchdata\.js/);
+    assert.doesNotMatch(entry, /\.\/loader-data\/item0\.benchdata"/);
+
+    const materialized = await readFile(
+      join(fixtureContext, "src", "loader-data", "item0.benchdata.js"),
+      "utf8"
+    );
+    assert.match(materialized, /const value = 1;/);
+    assert.match(materialized, /export default value;/);
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Let the Turbopack adapter participate in the loader benchmark fixture instead of reporting it unsupported.
- Materialize `.benchdata` loader inputs into equivalent `.benchdata.js` modules before invoking the pinned standalone Turbopack CLI.
- Split runner support for true webpack loader rules from support for the benchmark loader fixture, and document the Turbopack-specific path.

## Why

The pinned standalone `turbopack-cli` does not expose webpack loader rule configuration. The benchmark can still include Turbopack in the loader fixture by converting the loader payloads into equivalent JavaScript modules at adapter time, while webpack and Rspack continue to exercise the actual webpack-compatible loader rule.

## Validation

- `pnpm --filter @unpack-js/benchmarks test`
