### PR TITLE
Add Rspack phase timings to benchmark tracing

### DIFF
--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -79,7 +79,9 @@ export const adapters = {
     }) {
       const webpackModule = await import("webpack");
       const webpack = webpackModule.default ?? webpackModule;
-      const tracing = createWebpackPhaseTracing({
+      const tracing = createWebpackLikePhaseTracing({
+        bundler: "webpack",
+        spanPrefix: "Webpack",
         fixture,
         phase,
         persistentCache,
@@ -112,9 +114,24 @@ export const adapters = {
     name: "rspack",
     supportsWebpackLoaders: true,
     versionSource: () => `@rspack/core@${packageVersion("@rspack/core")}`,
-    async build({ fixture, outputDir, cacheDir, persistentCache = true }) {
+    async build({
+      fixture,
+      outputDir,
+      cacheDir,
+      phase,
+      persistentCache = true,
+      cacheReadonly = false
+    }) {
       const rspackModule = await import("@rspack/core");
       const rspack = rspackModule.rspack ?? rspackModule.default;
+      const tracing = createWebpackLikePhaseTracing({
+        bundler: "rspack",
+        spanPrefix: "Rspack",
+        fixture,
+        phase,
+        persistentCache,
+        cacheReadonly
+      });
       const compiler = rspack({
         ...webpackLikeConfig({ fixture, outputDir }),
         cache: persistentCache
@@ -125,14 +142,15 @@ export const adapters = {
                 directory: cacheDir
               }
             }
-          : false
+          : false,
+        plugins: [tracing.plugin]
       });
 
       try {
         const stats = await runWebpackCompiler(compiler);
         assertWebpackStats(stats, "Rspack");
       } finally {
-        await closeWebpackCompiler(compiler);
+        await tracing.close(compiler);
       }
 
       return { entryFile: join(outputDir, "main.js") };
@@ -654,8 +672,15 @@ function configureUnpackTracing({ fixture, phase, persistentCache, cacheReadonly
   );
 }
 
-function createWebpackPhaseTracing({ fixture, phase, persistentCache, cacheReadonly }) {
-  const pluginName = "UnpackBenchmarkWebpackPhaseTracingPlugin";
+function createWebpackLikePhaseTracing({
+  bundler,
+  spanPrefix,
+  fixture,
+  phase,
+  persistentCache,
+  cacheReadonly
+}) {
+  const pluginName = "UnpackBenchmarkWebpackLikePhaseTracingPlugin";
   const started = new Map();
   const durations = new Map();
 
@@ -677,7 +702,7 @@ function createWebpackPhaseTracing({ fixture, phase, persistentCache, cacheReado
   function print() {
     process.stderr.write(
       [
-        "[webpack tracing]",
+        `[${bundler} tracing]`,
         `fixture=${fixture.name}`,
         `phase=${phase}`,
         `persistent_cache=${persistentCache ? "on" : "off"}`,
@@ -686,37 +711,53 @@ function createWebpackPhaseTracing({ fixture, phase, persistentCache, cacheReado
     );
 
     for (const [span, duration] of [
-      ["Webpack::run", durations.get("compilerRun")],
-      ["Webpack::make", durations.get("make")],
-      ["Webpack::build_chunk_graph", durations.get("chunkGraph")],
-      ["Webpack::create_assets", durations.get("createAssets")],
-      ["Webpack::emit_assets", durations.get("emitAssets")],
-      ["Webpack::flush_cache", durations.get("flushCache")]
+      [`${spanPrefix}::run`, durations.get("compilerRun")],
+      [`${spanPrefix}::make`, durations.get("make")],
+      [`${spanPrefix}::build_chunk_graph`, durations.get("chunkGraph")],
+      [`${spanPrefix}::create_assets`, durations.get("createAssets")],
+      [`${spanPrefix}::emit_assets`, durations.get("emitAssets")],
+      [`${spanPrefix}::flush_cache`, durations.get("flushCache")]
     ]) {
       if (duration === undefined) {
         continue;
       }
       process.stderr.write(
-        `TRACE ${span}: webpack: close time.busy=${formatDurationMs(duration)} time.idle=0ms\n`
+        `TRACE ${span}: ${bundler}: close time.busy=${formatDurationMs(duration)} time.idle=0ms\n`
       );
     }
+  }
+
+  function hasHook(hooks, name) {
+    return Boolean(hooks && Object.prototype.hasOwnProperty.call(hooks, name));
+  }
+
+  function tap(hooks, name, callback) {
+    if (!hasHook(hooks, name)) {
+      return false;
+    }
+    hooks[name].tap(pluginName, callback);
+    return true;
   }
 
   return {
     plugin: {
       apply(compiler) {
-        compiler.hooks.beforeRun.tap(pluginName, () => start("compilerRun"));
-        compiler.hooks.run.tap(pluginName, () => start("compilerRun"));
-        compiler.hooks.done.tap(pluginName, () => end("compilerRun"));
-        compiler.hooks.make.tap(pluginName, () => start("make"));
-        compiler.hooks.finishMake.tap(pluginName, () => end("make"));
-        compiler.hooks.emit.tap(pluginName, () => start("emitAssets"));
-        compiler.hooks.afterEmit.tap(pluginName, () => end("emitAssets"));
-        compiler.hooks.compilation.tap(pluginName, (compilation) => {
-          compilation.hooks.beforeChunks.tap(pluginName, () => start("chunkGraph"));
-          compilation.hooks.afterChunks.tap(pluginName, () => end("chunkGraph"));
-          compilation.hooks.beforeCodeGeneration.tap(pluginName, () => start("createAssets"));
-          compilation.hooks.afterProcessAssets.tap(pluginName, () => end("createAssets"));
+        tap(compiler.hooks, "beforeRun", () => start("compilerRun"));
+        tap(compiler.hooks, "run", () => start("compilerRun"));
+        tap(compiler.hooks, "done", () => end("compilerRun"));
+        tap(compiler.hooks, "make", () => start("make"));
+        tap(compiler.hooks, "finishMake", () => end("make"));
+        tap(compiler.hooks, "emit", () => start("emitAssets"));
+        tap(compiler.hooks, "afterEmit", () => end("emitAssets"));
+        tap(compiler.hooks, "compilation", (compilation) => {
+          tap(compilation.hooks, "beforeChunks", () => start("chunkGraph"));
+          tap(compilation.hooks, "afterChunks", () => end("chunkGraph"));
+          if (hasHook(compilation.hooks, "beforeCodeGeneration")) {
+            tap(compilation.hooks, "beforeCodeGeneration", () => start("createAssets"));
+          } else {
+            tap(compilation.hooks, "processAssets", () => start("createAssets"));
+          }
+          tap(compilation.hooks, "afterProcessAssets", () => end("createAssets"));
         });
       }
     },

--- a/packages/benchmarks/src/tracing-summary.mjs
+++ b/packages/benchmarks/src/tracing-summary.mjs
@@ -93,7 +93,7 @@ export function toUnpackTracingSummaryMarkdown(rows, options = {}) {
 }
 
 function parseTracingHeader(line) {
-  const match = line.match(/^\[(unpack|webpack) tracing\]/);
+  const match = line.match(/^\[(unpack|webpack|rspack) tracing\]/);
   if (!match) {
     return null;
   }
@@ -135,22 +135,42 @@ function phaseKey(name) {
   if (name === "Compiler::run" || name === "Webpack::run") {
     return "compilerRun";
   }
-  if (name.includes("Compilation::make") || name === "Webpack::make") {
+  if (name === "Rspack::run") {
+    return "compilerRun";
+  }
+  if (
+    name.includes("Compilation::make") ||
+    name === "Webpack::make" ||
+    name === "Rspack::make"
+  ) {
     return "make";
   }
   if (
     name.includes("Compilation::build_chunk_graph") ||
-    name === "Webpack::build_chunk_graph"
+    name === "Webpack::build_chunk_graph" ||
+    name === "Rspack::build_chunk_graph"
   ) {
     return "chunkGraph";
   }
-  if (name.includes("Compilation::create_assets") || name === "Webpack::create_assets") {
+  if (
+    name.includes("Compilation::create_assets") ||
+    name === "Webpack::create_assets" ||
+    name === "Rspack::create_assets"
+  ) {
     return "createAssets";
   }
-  if (name === "unpack_node::emit_assets" || name === "Webpack::emit_assets") {
+  if (
+    name === "unpack_node::emit_assets" ||
+    name === "Webpack::emit_assets" ||
+    name === "Rspack::emit_assets"
+  ) {
     return "emitAssets";
   }
-  if (name === "Compiler::flush_cache" || name === "Webpack::flush_cache") {
+  if (
+    name === "Compiler::flush_cache" ||
+    name === "Webpack::flush_cache" ||
+    name === "Rspack::flush_cache"
+  ) {
     return "flushCache";
   }
   return null;

--- a/packages/benchmarks/test/tracing-summary.test.mjs
+++ b/packages/benchmarks/test/tracing-summary.test.mjs
@@ -25,9 +25,15 @@ TRACE Webpack::build_chunk_graph: webpack: close time.busy=1.500ms time.idle=0ms
 TRACE Webpack::create_assets: webpack: close time.busy=2.250ms time.idle=0ms
 TRACE Webpack::emit_assets: webpack: close time.busy=3.500ms time.idle=0ms
 TRACE Webpack::flush_cache: webpack: close time.busy=4.750ms time.idle=0ms
+[rspack tracing] fixture=large phase=cold persistent_cache=on cache_readonly=off
+TRACE Rspack::make: rspack: close time.busy=8.125ms time.idle=0ms
+TRACE Rspack::run: rspack: close time.busy=13.250ms time.idle=0ms
+TRACE Rspack::create_assets: rspack: close time.busy=1.750ms time.idle=0ms
+TRACE Rspack::emit_assets: rspack: close time.busy=2.500ms time.idle=0ms
+TRACE Rspack::flush_cache: rspack: close time.busy=3.750ms time.idle=0ms
 `);
 
-  assert.equal(rows.length, 3);
+  assert.equal(rows.length, 4);
   assert.equal(rows[0].fixture, "large");
   assert.equal(rows[0].bundler, "unpack");
   assert.equal(rows[0].build, "cold");
@@ -47,12 +53,18 @@ TRACE Webpack::flush_cache: webpack: close time.busy=4.750ms time.idle=0ms
   assert.equal(rows[2].build, "cold");
   assert.equal(rows[2].compilerRun.toFixed(3), "15.250");
   assert.equal(rows[2].make.toFixed(3), "10.125");
+  assert.equal(rows[3].fixture, "large");
+  assert.equal(rows[3].bundler, "rspack");
+  assert.equal(rows[3].build, "cold");
+  assert.equal(rows[3].compilerRun.toFixed(3), "13.250");
+  assert.equal(rows[3].make.toFixed(3), "8.125");
 
   const markdown = toUnpackTracingSummaryMarkdown(rows);
   assert.match(markdown, /\\| fixture \\| bundler \\| build \\| compiler run ms \\| make ms \\|/);
   assert.match(markdown, /\\| large \\| unpack \\| cold \\| 17\\.420 \\| 15\\.050 \\| 0\\.188 \\| 1\\.464 \\| 0\\.714 \\| 3\\.657 \\|/);
   assert.match(markdown, /\\| large \\| unpack \\| warm \\| 7\\.220 \\| 5\\.860 \\|  \\|  \\|  \\|  \\|/);
   assert.match(markdown, /\\| large \\| webpack \\| cold \\| 15\\.250 \\| 10\\.125 \\| 1\\.500 \\| 2\\.250 \\| 3\\.500 \\| 4\\.750 \\|/);
+  assert.match(markdown, /\\| large \\| rspack \\| cold \\| 13\\.250 \\| 8\\.125 \\|  \\| 1\\.750 \\| 2\\.500 \\| 3\\.750 \\|/);
 });
 
 test("tracing summary can filter rows to one fixture", () => {


### PR DESCRIPTION
## Summary

Adds Rspack data to the benchmark phase timing output. The Rspack adapter now uses the same webpack-like tracing plugin shape and emits `[rspack tracing]` rows for compiler run, make, asset creation, emit assets, and cache flush.

## Notes

Rspack does not expose webpack's `beforeChunks` / `afterChunks` compilation hooks, so the `chunk graph ms` column remains empty for Rspack. The tracing hook helper checks hook availability before tapping because Rspack throws for unsupported webpack hooks.

## Checks

- `node --test packages/benchmarks/test/tracing-summary.test.mjs`
- `node --test packages/benchmarks/test/runner.test.mjs --test-name-pattern "webpack-compatible adapters"`