### PR TITLE
Enable readonly Rspack warm benchmark cache

### DIFF
--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -133,16 +133,13 @@ export const adapters = {
         cacheReadonly
       });
       const compiler = rspack({
-        ...webpackLikeConfig({ fixture, outputDir }),
-        cache: persistentCache
-          ? {
-              type: "persistent",
-              storage: {
-                type: "filesystem",
-                directory: cacheDir
-              }
-            }
-          : false,
+        ...createRspackBenchmarkConfig({
+          fixture,
+          outputDir,
+          cacheDir,
+          persistentCache,
+          cacheReadonly
+        }),
         plugins: [tracing.plugin]
       });
 
@@ -434,6 +431,28 @@ export const adapters = {
     }
   }
 };
+
+export function createRspackBenchmarkConfig({
+  fixture,
+  outputDir,
+  cacheDir,
+  persistentCache = true,
+  cacheReadonly = false
+}) {
+  return {
+    ...webpackLikeConfig({ fixture, outputDir }),
+    cache: persistentCache
+      ? {
+          type: "persistent",
+          storage: {
+            type: "filesystem",
+            directory: cacheDir
+          },
+          readonly: cacheReadonly
+        }
+      : false
+  };
+}
 
 export async function applyTurbopackBuildCacheFlushPatch(repo) {
   const buildSourcePath = join(

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -6,7 +6,11 @@ import { join } from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
 
-import { adapters, applyTurbopackBuildCacheFlushPatch } from "../src/adapters.mjs";
+import {
+  adapters,
+  applyTurbopackBuildCacheFlushPatch,
+  createRspackBenchmarkConfig
+} from "../src/adapters.mjs";
 import {
   WARM_BUILD_CHECKSUM_DELTA,
   WARM_BUILD_GRAPH_COPY
@@ -241,6 +245,28 @@ test("webpack-compatible adapters build the loader benchmark fixture", async () 
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }
+});
+
+test("rspack warm benchmark config enables readonly persistent cache", () => {
+  const config = createRspackBenchmarkConfig({
+    fixture: {
+      context: "/benchmark/fixture",
+      entry: "./src/index.js"
+    },
+    outputDir: "/benchmark/output",
+    cacheDir: "/benchmark/cache",
+    persistentCache: true,
+    cacheReadonly: true
+  });
+
+  assert.deepEqual(config.cache, {
+    type: "persistent",
+    storage: {
+      type: "filesystem",
+      directory: "/benchmark/cache"
+    },
+    readonly: true
+  });
 });
 
 test("non-loader adapters mark the loader benchmark fixture unsupported", async () => {


### PR DESCRIPTION
## Summary

Rspack benchmark builds now pass the runner's `cacheReadonly` flag into the persistent cache configuration, so warm benchmark runs use read-only cache mode like the other filesystem-cache adapters.

`createRspackBenchmarkConfig` gives the benchmark test suite a narrow seam for asserting cache option mapping without running a full Rspack build.

## Root Cause

The runner already invoked warm builds with `cacheReadonly: true`, but the Rspack adapter ignored that argument and only configured persistent filesystem storage. As a result, warm Rspack measurements could still write to the cache directory.

Checked with `pnpm --filter @unpack-js/benchmarks test`.