### PR TITLE
Add bundle execution e2e fixture tests

### DIFF
--- a/packages/unpack/test/e2e-cases/README.md
+++ b/packages/unpack/test/e2e-cases/README.md
@@ -1,0 +1,20 @@
+# E2E cases
+
+Each child directory is one bundle execution case. Add source files exactly as
+they should appear in the fixture root, plus a `case.json` manifest:
+
+```json
+{
+  "runtimeExpression": "entry.run()",
+  "expected": "result"
+}
+```
+
+The runner supplies the shared compiler configuration, copies the case directory
+to a temporary fixture, executes the emitted entry asset in Node, and compares
+the JSON-serialized result with `expected`.
+
+Optional manifest fields:
+
+- `entry`: override the default `./src/index.js` entry.
+- `entryAsset`: override the default emitted `main.js` asset to require.

--- a/packages/unpack/test/e2e-cases/async-chunk/case.json
+++ b/packages/unpack/test/e2e-cases/async-chunk/case.json
@@ -1,0 +1,4 @@
+{
+  "runtimeExpression": "entry.run()",
+  "expected": "entry:async:feature-ok"
+}

--- a/packages/unpack/test/e2e-cases/async-chunk/src/feature.js
+++ b/packages/unpack/test/e2e-cases/async-chunk/src/feature.js
@@ -1,0 +1,5 @@
+export const value = "async";
+
+export function describe(suffix) {
+  return "feature-" + suffix;
+}

--- a/packages/unpack/test/e2e-cases/async-chunk/src/index.js
+++ b/packages/unpack/test/e2e-cases/async-chunk/src/index.js
@@ -1,0 +1,6 @@
+import { label } from "./label";
+
+export async function run() {
+  const feature = await import("./feature");
+  return [label, feature.value, feature.describe("ok")].join(":");
+}

--- a/packages/unpack/test/e2e-cases/async-chunk/src/label.js
+++ b/packages/unpack/test/e2e-cases/async-chunk/src/label.js
@@ -1,0 +1,1 @@
+export const label = "entry";

--- a/packages/unpack/test/e2e-cases/static-live-bindings/case.json
+++ b/packages/unpack/test/e2e-cases/static-live-bindings/case.json
@@ -1,0 +1,4 @@
+{
+  "runtimeExpression": "entry.run()",
+  "expected": [1, 7]
+}

--- a/packages/unpack/test/e2e-cases/static-live-bindings/src/index.js
+++ b/packages/unpack/test/e2e-cases/static-live-bindings/src/index.js
@@ -1,0 +1,7 @@
+import { value, setValue } from "./state";
+
+export function run() {
+  const before = value;
+  setValue(7);
+  return [before, value];
+}

--- a/packages/unpack/test/e2e-cases/static-live-bindings/src/state.js
+++ b/packages/unpack/test/e2e-cases/static-live-bindings/src/state.js
@@ -1,0 +1,5 @@
+export let value = 1;
+
+export function setValue(next) {
+  value = next;
+}

--- a/packages/unpack/test/e2e.test.ts
+++ b/packages/unpack/test/e2e.test.ts
@@ -7,65 +7,107 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import unpack from "@unpack-js/core";
-import type { Stats } from "@unpack-js/core";
+import type { Stats, UnpackOptions } from "@unpack-js/core";
 
 const execFileAsync = promisify(execFile);
+const defaultEntry = "./src/index.js";
+const defaultEntryAsset = "main.js";
+const defaultCompilerOptions = {
+  sourcemap: false
+} satisfies Pick<UnpackOptions, "sourcemap">;
 
-test("emitted bundle executes entry and async chunk", async () => {
-  const fixture = await createFixture({
-    "src/index.js": `
-      import { label } from "./label";
+interface BundleExecutionCase {
+  name: string;
+  files: Record<string, string>;
+  entry?: UnpackOptions["entry"];
+  entryAsset?: string;
+  runtimeExpression: string;
+  expected: unknown;
+}
 
-      export async function run() {
-        const feature = await import("./feature");
-        return [label, feature.value, feature.describe("ok")].join(":");
-      }
-    `,
-    "src/label.js": `
-      export const label = "entry";
-    `,
-    "src/feature.js": `
-      export const value = "async";
+const bundleExecutionCases: BundleExecutionCase[] = [
+  {
+    name: "preserves static ESM live bindings",
+    files: {
+      "src/index.js": `
+        import { value, setValue } from "./state";
 
-      export function describe(suffix) {
-        return "feature-" + suffix;
-      }
-    `
+        export function run() {
+          const before = value;
+          setValue(7);
+          return [before, value];
+        }
+      `,
+      "src/state.js": `
+        export let value = 1;
+
+        export function setValue(next) {
+          value = next;
+        }
+      `
+    },
+    runtimeExpression: "entry.run()",
+    expected: [1, 7]
+  },
+  {
+    name: "loads async chunks",
+    files: {
+      "src/index.js": `
+        import { label } from "./label";
+
+        export async function run() {
+          const feature = await import("./feature");
+          return [label, feature.value, feature.describe("ok")].join(":");
+        }
+      `,
+      "src/label.js": `
+        export const label = "entry";
+      `,
+      "src/feature.js": `
+        export const value = "async";
+
+        export function describe(suffix) {
+          return "feature-" + suffix;
+        }
+      `
+    },
+    runtimeExpression: "entry.run()",
+    expected: "entry:async:feature-ok"
+  }
+];
+
+for (const bundleCase of bundleExecutionCases) {
+  test(`emitted bundle ${bundleCase.name}`, async () => {
+    await runBundleExecutionCase(bundleCase);
   });
+}
+
+async function runBundleExecutionCase(bundleCase: BundleExecutionCase) {
+  const fixture = await createFixture(bundleCase.files);
   const outputPath = join(fixture, "dist");
 
   try {
     const { err, stats } = await runCompiler({
+      ...defaultCompilerOptions,
       context: fixture,
-      entry: "./src/index.js",
-      output: { path: outputPath },
-      sourcemap: false
+      entry: bundleCase.entry ?? defaultEntry,
+      output: { path: outputPath }
     });
 
     assert.equal(err, null);
     assert.equal(stats?.hasErrors(), false);
 
-    const result = await executeBundle(
+    const result = await executeEntryExpression(
       outputPath,
-      `
-        const entry = require("./main.js");
-
-        entry.run()
-          .then((value) => {
-            console.log(JSON.stringify(value));
-          })
-          .catch((error) => {
-            console.error(error && error.stack || error);
-            process.exit(1);
-          });
-      `
+      bundleCase.entryAsset ?? defaultEntryAsset,
+      bundleCase.runtimeExpression
     );
 
-    assert.equal(result, JSON.stringify("entry:async:feature-ok"));
+    assert.equal(result, JSON.stringify(bundleCase.expected));
   } finally {
     await rm(fixture, { recursive: true, force: true });
   }
-});
+}
 
 async function createFixture(files: Record<string, string>) {
   const root = await mkdtemp(join(tmpdir(), "unpack-e2e-"));
@@ -79,7 +121,7 @@ async function createFixture(files: Record<string, string>) {
   return root;
 }
 
-async function runCompiler(options: Parameters<typeof unpack>[0]) {
+async function runCompiler(options: UnpackOptions) {
   return new Promise<{ err: Error | null; stats?: Stats }>((resolve) => {
     unpack(options, (err, stats) => {
       resolve({ err, stats });
@@ -87,15 +129,40 @@ async function runCompiler(options: Parameters<typeof unpack>[0]) {
   });
 }
 
-async function executeBundle(outputPath: string, script: string) {
+async function executeEntryExpression(
+  outputPath: string,
+  entryAsset: string,
+  runtimeExpression: string
+) {
   try {
-    const { stdout } = await execFileAsync(process.execPath, ["-e", script], {
-      cwd: outputPath,
-      encoding: "utf8"
-    });
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      ["-e", createNodeScript(entryAsset, runtimeExpression)],
+      {
+        cwd: outputPath,
+        encoding: "utf8"
+      }
+    );
     return stdout.trim();
   } catch (error) {
     const result = error as { stdout?: string; stderr?: string };
-    assert.fail(`node failed\nstdout:\n${result.stdout ?? ""}\nstderr:\n${result.stderr ?? ""}`);
+    assert.fail(
+      `node failed\nstdout:\n${result.stdout ?? ""}\nstderr:\n${result.stderr ?? ""}`
+    );
   }
+}
+
+function createNodeScript(entryAsset: string, runtimeExpression: string) {
+  return `
+    const entry = require(${JSON.stringify(`./${entryAsset}`)});
+
+    Promise.resolve(${runtimeExpression})
+      .then((value) => {
+        console.log(JSON.stringify(value));
+      })
+      .catch((error) => {
+        console.error(error && error.stack || error);
+        process.exit(1);
+      });
+  `;
 }

--- a/packages/unpack/test/e2e.test.ts
+++ b/packages/unpack/test/e2e.test.ts
@@ -1,7 +1,8 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { cp, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -10,6 +11,13 @@ import unpack from "@unpack-js/core";
 import type { Stats, UnpackOptions } from "@unpack-js/core";
 
 const execFileAsync = promisify(execFile);
+const casesRoot = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "test",
+  "e2e-cases"
+);
 const defaultEntry = "./src/index.js";
 const defaultEntryAsset = "main.js";
 const defaultCompilerOptions = {
@@ -17,73 +25,31 @@ const defaultCompilerOptions = {
 } satisfies Pick<UnpackOptions, "sourcemap">;
 
 interface BundleExecutionCase {
-  name: string;
-  files: Record<string, string>;
+  id: string;
+  path: string;
   entry?: UnpackOptions["entry"];
   entryAsset?: string;
   runtimeExpression: string;
   expected: unknown;
 }
 
-const bundleExecutionCases: BundleExecutionCase[] = [
-  {
-    name: "preserves static ESM live bindings",
-    files: {
-      "src/index.js": `
-        import { value, setValue } from "./state";
+interface BundleExecutionCaseManifest {
+  entry?: UnpackOptions["entry"];
+  entryAsset?: string;
+  runtimeExpression: string;
+  expected: unknown;
+}
 
-        export function run() {
-          const before = value;
-          setValue(7);
-          return [before, value];
-        }
-      `,
-      "src/state.js": `
-        export let value = 1;
-
-        export function setValue(next) {
-          value = next;
-        }
-      `
-    },
-    runtimeExpression: "entry.run()",
-    expected: [1, 7]
-  },
-  {
-    name: "loads async chunks",
-    files: {
-      "src/index.js": `
-        import { label } from "./label";
-
-        export async function run() {
-          const feature = await import("./feature");
-          return [label, feature.value, feature.describe("ok")].join(":");
-        }
-      `,
-      "src/label.js": `
-        export const label = "entry";
-      `,
-      "src/feature.js": `
-        export const value = "async";
-
-        export function describe(suffix) {
-          return "feature-" + suffix;
-        }
-      `
-    },
-    runtimeExpression: "entry.run()",
-    expected: "entry:async:feature-ok"
-  }
-];
+const bundleExecutionCases = await readBundleExecutionCases();
 
 for (const bundleCase of bundleExecutionCases) {
-  test(`emitted bundle ${bundleCase.name}`, async () => {
+  test(`emitted bundle ${bundleCase.id}`, async () => {
     await runBundleExecutionCase(bundleCase);
   });
 }
 
 async function runBundleExecutionCase(bundleCase: BundleExecutionCase) {
-  const fixture = await createFixture(bundleCase.files);
+  const fixture = await createFixture(bundleCase.path);
   const outputPath = join(fixture, "dist");
 
   try {
@@ -109,16 +75,47 @@ async function runBundleExecutionCase(bundleCase: BundleExecutionCase) {
   }
 }
 
-async function createFixture(files: Record<string, string>) {
-  const root = await mkdtemp(join(tmpdir(), "unpack-e2e-"));
-  await Promise.all(
-    Object.entries(files).map(async ([path, source]) => {
-      const absolutePath = join(root, path);
-      await mkdir(dirname(absolutePath), { recursive: true });
-      await writeFile(absolutePath, source, { encoding: "utf8" });
+async function readBundleExecutionCases() {
+  const entries = await readdir(casesRoot, { withFileTypes: true });
+  const caseDirectories = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+
+  assert.notEqual(caseDirectories.length, 0, "expected at least one e2e case");
+
+  return Promise.all(
+    caseDirectories.map(async (id): Promise<BundleExecutionCase> => {
+      const casePath = join(casesRoot, id);
+      const manifest = parseCaseManifest(
+        id,
+        await readFile(join(casePath, "case.json"), "utf8")
+      );
+
+      return {
+        id,
+        path: casePath,
+        ...manifest
+      };
     })
   );
-  return root;
+}
+
+async function createFixture(casePath: string) {
+  const fixturePath = await mkdtemp(join(tmpdir(), "unpack-e2e-"));
+  const entries = await readdir(casePath, { withFileTypes: true });
+
+  await Promise.all(
+    entries
+      .filter((entry) => entry.name !== "case.json")
+      .map((entry) =>
+        cp(join(casePath, entry.name), join(fixturePath, entry.name), {
+          recursive: true
+        })
+      )
+  );
+
+  return fixturePath;
 }
 
 async function runCompiler(options: UnpackOptions) {
@@ -165,4 +162,52 @@ function createNodeScript(entryAsset: string, runtimeExpression: string) {
         process.exit(1);
       });
   `;
+}
+
+function parseCaseManifest(id: string, source: string): BundleExecutionCaseManifest {
+  const parsed = JSON.parse(source) as unknown;
+
+  assert.ok(isRecord(parsed), `${id}/case.json must define an object`);
+
+  const manifest = parsed as Partial<BundleExecutionCaseManifest>;
+
+  assert.equal(
+    typeof manifest.runtimeExpression,
+    "string",
+    `${id}/case.json must define runtimeExpression`
+  );
+  assert.ok(
+    Object.hasOwn(manifest, "expected"),
+    `${id}/case.json must define expected`
+  );
+
+  if (manifest.entry !== undefined) {
+    assert.ok(
+      isEntryOption(manifest.entry),
+      `${id}/case.json entry must match UnpackOptions.entry`
+    );
+  }
+  if (manifest.entryAsset !== undefined) {
+    assert.equal(
+      typeof manifest.entryAsset,
+      "string",
+      `${id}/case.json entryAsset must be a string`
+    );
+  }
+
+  return manifest as BundleExecutionCaseManifest;
+}
+
+function isEntryOption(entry: unknown): entry is UnpackOptions["entry"] {
+  if (typeof entry === "string") {
+    return true;
+  }
+  if (entry == null || typeof entry !== "object" || Array.isArray(entry)) {
+    return false;
+  }
+  return Object.values(entry).every((value) => typeof value === "string");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
 }

--- a/packages/unpack/test/e2e.test.ts
+++ b/packages/unpack/test/e2e.test.ts
@@ -1,0 +1,101 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import unpack from "@unpack-js/core";
+import type { Stats } from "@unpack-js/core";
+
+const execFileAsync = promisify(execFile);
+
+test("emitted bundle executes entry and async chunk", async () => {
+  const fixture = await createFixture({
+    "src/index.js": `
+      import { label } from "./label";
+
+      export async function run() {
+        const feature = await import("./feature");
+        return [label, feature.value, feature.describe("ok")].join(":");
+      }
+    `,
+    "src/label.js": `
+      export const label = "entry";
+    `,
+    "src/feature.js": `
+      export const value = "async";
+
+      export function describe(suffix) {
+        return "feature-" + suffix;
+      }
+    `
+  });
+  const outputPath = join(fixture, "dist");
+
+  try {
+    const { err, stats } = await runCompiler({
+      context: fixture,
+      entry: "./src/index.js",
+      output: { path: outputPath },
+      sourcemap: false
+    });
+
+    assert.equal(err, null);
+    assert.equal(stats?.hasErrors(), false);
+
+    const result = await executeBundle(
+      outputPath,
+      `
+        const entry = require("./main.js");
+
+        entry.run()
+          .then((value) => {
+            console.log(JSON.stringify(value));
+          })
+          .catch((error) => {
+            console.error(error && error.stack || error);
+            process.exit(1);
+          });
+      `
+    );
+
+    assert.equal(result, JSON.stringify("entry:async:feature-ok"));
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+async function createFixture(files: Record<string, string>) {
+  const root = await mkdtemp(join(tmpdir(), "unpack-e2e-"));
+  await Promise.all(
+    Object.entries(files).map(async ([path, source]) => {
+      const absolutePath = join(root, path);
+      await mkdir(dirname(absolutePath), { recursive: true });
+      await writeFile(absolutePath, source, { encoding: "utf8" });
+    })
+  );
+  return root;
+}
+
+async function runCompiler(options: Parameters<typeof unpack>[0]) {
+  return new Promise<{ err: Error | null; stats?: Stats }>((resolve) => {
+    unpack(options, (err, stats) => {
+      resolve({ err, stats });
+    });
+  });
+}
+
+async function executeBundle(outputPath: string, script: string) {
+  try {
+    const { stdout } = await execFileAsync(process.execPath, ["-e", script], {
+      cwd: outputPath,
+      encoding: "utf8"
+    });
+    return stdout.trim();
+  } catch (error) {
+    const result = error as { stdout?: string; stderr?: string };
+    assert.fail(`node failed\nstdout:\n${result.stdout ?? ""}\nstderr:\n${result.stderr ?? ""}`);
+  }
+}


### PR DESCRIPTION
## Summary

- Add a Node-based bundle execution e2e runner for `@unpack-js/core`.
- Move bundle e2e scenarios into per-case fixture directories under `packages/unpack/test/e2e-cases` so the suite can scale to many cases.
- Include initial cases for async chunk loading and static ESM live bindings.

## Tests

- `pnpm --filter @unpack-js/core exec tsc -p tsconfig.test.json`
- `node --test packages/unpack/dist-test/test/e2e.test.js`
- `pnpm --filter @unpack-js/core test`
- `pnpm test`