### PR TITLE
Separate code generation from asset rendering

### DIFF
--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -121,7 +121,23 @@ impl CodeGenerationKey {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CodeGenerationResult {
+    etag: CodeGenerationETag,
     source: ConcatSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CodeGenerationETag {
+    module_hash: u64,
+    module_render_id: String,
+    dependency_template_inputs: Vec<DependencyTemplateInput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct DependencyTemplateInput {
+    block: Option<usize>,
+    dependency: usize,
+    target_render_id: Option<String>,
+    chunk_render_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -140,32 +156,36 @@ impl CodeGenerationResults {
     }
 }
 
-struct CodeGenerationInput<'a> {
-    module: &'a Module,
-    module_graph: &'a ModuleGraph,
-    chunk_graph: &'a ChunkGraph,
-    module_render_ids: &'a HashMap<ModuleId, String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct RenderManifest {
-    entries: Vec<AssetRenderManifest>,
+struct CodeGenerationInput {
+    key: CodeGenerationKey,
+    module: Module,
+    module_render_id: String,
+    etag: CodeGenerationETag,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AssetRenderPlan {
-    filenames: Vec<String>,
-    manifest: RenderManifest,
-}
-
-impl AssetRenderPlan {
-    pub(crate) fn manifest(&self) -> &RenderManifest {
-        &self.manifest
-    }
+    entries: Vec<AssetRenderPlanEntry>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum AssetRenderManifest {
+struct AssetRenderPlanEntry {
+    key: AssetRenderKey,
+    filename: String,
+    manifest: AssetRenderManifest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct AssetRenderKey(String);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RenderedAssetSource {
+    key: AssetRenderKey,
+    source: RenderedSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AssetRenderManifest {
     InitialChunk {
         modules: Vec<ModuleRenderManifest>,
         chunk_filename_map: String,
@@ -180,7 +200,7 @@ enum AssetRenderManifest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct ModuleRenderManifest {
+pub(crate) struct ModuleRenderManifest {
     render_id: String,
     code_generation_key: CodeGenerationKey,
 }
@@ -234,15 +254,16 @@ pub(crate) fn generate_code(
             let Some(module) = module_graph.module(*module_id) else {
                 continue;
             };
-            let key = CodeGenerationKey::new(module.identity().clone(), runtime.clone());
-            results.entry(key).or_insert_with(|| {
-                generate_module_code(CodeGenerationInput {
-                    module,
-                    module_graph,
-                    chunk_graph,
-                    module_render_ids: &module_render_ids,
-                })
-            });
+            let input = create_code_generation_input(
+                module,
+                runtime.clone(),
+                module_graph,
+                chunk_graph,
+                &module_render_ids,
+            );
+            results
+                .entry(input.key.clone())
+                .or_insert_with(|| generate_module_code(input));
         }
     }
 
@@ -253,13 +274,89 @@ pub(crate) fn generate_code(
     }
 }
 
+fn create_code_generation_input(
+    module: &Module,
+    runtime: RuntimeSpec,
+    module_graph: &ModuleGraph,
+    chunk_graph: &ChunkGraph,
+    module_render_ids: &HashMap<ModuleId, String>,
+) -> CodeGenerationInput {
+    let mut dependency_template_inputs = Vec::new();
+    for dependency in 0..module.dependencies().len() {
+        dependency_template_inputs.push(dependency_template_input(
+            module.id(),
+            None,
+            dependency,
+            module_graph,
+            chunk_graph,
+            module_render_ids,
+        ));
+    }
+    for (block, dependencies) in module.blocks().iter().enumerate() {
+        for dependency in 0..dependencies.dependencies().len() {
+            dependency_template_inputs.push(dependency_template_input(
+                module.id(),
+                Some(block),
+                dependency,
+                module_graph,
+                chunk_graph,
+                module_render_ids,
+            ));
+        }
+    }
+
+    let module_render_id = module_render_ids[&module.id()].clone();
+    CodeGenerationInput {
+        key: CodeGenerationKey::new(module.identity().clone(), runtime),
+        module: module.clone(),
+        module_render_id: module_render_id.clone(),
+        etag: CodeGenerationETag {
+            module_hash: module.source_hash(),
+            module_render_id,
+            dependency_template_inputs,
+        },
+    }
+}
+
+fn dependency_template_input(
+    module: ModuleId,
+    block: Option<usize>,
+    dependency: usize,
+    module_graph: &ModuleGraph,
+    chunk_graph: &ChunkGraph,
+    module_render_ids: &HashMap<ModuleId, String>,
+) -> DependencyTemplateInput {
+    let target_render_id = module_graph
+        .module_for_dependency(module, block, dependency)
+        .and_then(|target| module_render_ids.get(&target).cloned());
+    let chunk_render_id = block.and_then(|block_index| {
+        chunk_graph
+            .block_chunk_group(AsyncBlockOrigin {
+                module,
+                block_index,
+            })
+            .and_then(|group_id| {
+                chunk_graph.chunk_groups()[group_id.index()]
+                    .chunks()
+                    .first()
+            })
+            .and_then(|chunk_id| chunk_graph.chunk(*chunk_id))
+            .map(|chunk| chunk.render_id().to_string())
+    });
+    DependencyTemplateInput {
+        block,
+        dependency,
+        target_render_id,
+        chunk_render_id,
+    }
+}
+
 pub(crate) fn create_render_manifest(
     chunk_graph: &ChunkGraph,
     entries: &[ModuleId],
     code_generation_results: &CodeGenerationResults,
 ) -> AssetRenderPlan {
-    let mut manifest_entries = Vec::new();
-    let mut filenames = Vec::new();
+    let mut plan_entries = Vec::new();
 
     for (entry_index, group_id) in chunk_graph.entrypoints().iter().copied().enumerate() {
         let group = &chunk_graph.chunk_groups()[group_id.index()];
@@ -273,13 +370,16 @@ pub(crate) fn create_render_manifest(
             continue;
         };
         let modules = module_render_manifest(chunk_graph, chunk, code_generation_results);
-        filenames.push(chunk.filename().to_string());
-        manifest_entries.push(AssetRenderManifest::InitialChunk {
-            modules,
-            chunk_filename_map: render_chunk_filename_map(chunk_graph),
-            entry_id: code_generation_results.module_render_ids[&entry_module].clone(),
-            chunk_id: chunk.render_id().to_string(),
-            runtime_requirements: RuntimeRequirements::for_initial_chunk(chunk_graph, chunk),
+        plan_entries.push(AssetRenderPlanEntry {
+            key: AssetRenderKey(format!("initial:{}", chunk.render_id())),
+            filename: chunk.filename().to_string(),
+            manifest: AssetRenderManifest::InitialChunk {
+                modules,
+                chunk_filename_map: render_chunk_filename_map(chunk_graph),
+                entry_id: code_generation_results.module_render_ids[&entry_module].clone(),
+                chunk_id: chunk.render_id().to_string(),
+                runtime_requirements: RuntimeRequirements::for_initial_chunk(chunk_graph, chunk),
+            },
         });
     }
 
@@ -293,28 +393,31 @@ pub(crate) fn create_render_manifest(
         if is_initial {
             continue;
         }
-        filenames.push(chunk.filename().to_string());
-        manifest_entries.push(AssetRenderManifest::AsyncChunk {
-            modules: module_render_manifest(chunk_graph, chunk, code_generation_results),
-            chunk_id: chunk.render_id().to_string(),
+        plan_entries.push(AssetRenderPlanEntry {
+            key: AssetRenderKey(format!("async:{}", chunk.render_id())),
+            filename: chunk.filename().to_string(),
+            manifest: AssetRenderManifest::AsyncChunk {
+                modules: module_render_manifest(chunk_graph, chunk, code_generation_results),
+                chunk_id: chunk.render_id().to_string(),
+            },
         });
     }
 
     AssetRenderPlan {
-        filenames,
-        manifest: RenderManifest {
-            entries: manifest_entries,
-        },
+        entries: plan_entries,
     }
 }
 
 pub(crate) fn render_asset_sources(
-    manifest: &RenderManifest,
+    plan: &AssetRenderPlan,
     code_generation_results: &CodeGenerationResults,
-) -> Vec<RenderedSource> {
+) -> Vec<RenderedAssetSource> {
     let mut rendered_sources = Vec::new();
-    for entry in &manifest.entries {
-        rendered_sources.push(render_asset(entry, code_generation_results));
+    for entry in &plan.entries {
+        rendered_sources.push(RenderedAssetSource {
+            key: entry.key.clone(),
+            source: render_asset_source(&entry.manifest, code_generation_results),
+        });
     }
     rendered_sources
 }
@@ -322,13 +425,17 @@ pub(crate) fn render_asset_sources(
 pub(crate) fn create_assets(
     options: &CompilerOptions,
     plan: &AssetRenderPlan,
-    rendered_sources: &[RenderedSource],
+    rendered_sources: &[RenderedAssetSource],
 ) -> Vec<Asset> {
-    plan.filenames
+    plan.entries
         .iter()
-        .cloned()
-        .zip(rendered_sources)
-        .flat_map(|(filename, rendered)| emit_asset(filename, rendered, options.sourcemap))
+        .flat_map(|entry| {
+            let rendered = rendered_sources
+                .iter()
+                .find(|rendered| rendered.key == entry.key)
+                .unwrap_or_else(|| panic!("rendered source missing for {:?}", entry.key));
+            emit_asset(entry.filename.clone(), &rendered.source, options.sourcemap)
+        })
         .collect()
 }
 
@@ -361,7 +468,7 @@ fn module_render_manifest(
         .collect()
 }
 
-fn render_asset(
+pub(crate) fn render_asset_source(
     manifest: &AssetRenderManifest,
     code_generation_results: &CodeGenerationResults,
 ) -> RenderedSource {
@@ -559,37 +666,30 @@ fn render_module_table(
     source
 }
 
-fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult {
+fn generate_module_code(input: CodeGenerationInput) -> CodeGenerationResult {
     let CodeGenerationInput {
         module,
-        module_graph,
-        chunk_graph,
-        module_render_ids,
+        module_render_id,
+        etag,
+        ..
     } = input;
     if let Some(error) = module.build_error() {
         return CodeGenerationResult {
+            etag,
             source: render_failed_module_factory(error),
         };
     }
 
-    let module_id = module.id();
-    let module_render_id = &module_render_ids[&module_id];
-    let mut source = ReplaceSource::new(OriginalSource::new(
-        module.source(),
-        module_render_id.as_str(),
-    ));
+    let mut source = ReplaceSource::new(OriginalSource::new(module.source(), module_render_id));
     let mut init_fragments = Vec::new();
 
     for dependency in module.presentational_dependencies() {
         apply_dependency_template(
             dependency,
-            module_id,
             None,
             None,
-            module_graph,
-            chunk_graph,
+            &etag,
             module.exports_info(),
-            module_render_ids,
             &mut source,
             &mut init_fragments,
         );
@@ -597,13 +697,10 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
     for (dependency_id, dependency) in module.dependencies().iter().enumerate() {
         apply_dependency_template(
             dependency,
-            module_id,
             None,
             Some(dependency_id),
-            module_graph,
-            chunk_graph,
+            &etag,
             module.exports_info(),
-            module_render_ids,
             &mut source,
             &mut init_fragments,
         );
@@ -612,13 +709,10 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
         for (dependency_id, dependency) in block.dependencies().iter().enumerate() {
             apply_dependency_template(
                 dependency,
-                module_id,
                 Some(block_index),
                 Some(dependency_id),
-                module_graph,
-                chunk_graph,
+                &etag,
                 module.exports_info(),
-                module_render_ids,
                 &mut source,
                 &mut init_fragments,
             );
@@ -632,7 +726,10 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
     )));
     factory.add(source);
     factory.add(RawStringSource::from("\n})".to_string()));
-    CodeGenerationResult { source: factory }
+    CodeGenerationResult {
+        etag,
+        source: factory,
+    }
 }
 
 fn render_failed_module_factory(error: &Error) -> ConcatSource {
@@ -667,13 +764,10 @@ fn push_init_fragment(
 #[allow(clippy::too_many_arguments)]
 fn apply_dependency_template(
     dependency: &Dependency,
-    module_id: ModuleId,
     origin_block: Option<usize>,
     dependency_id: Option<usize>,
-    module_graph: &ModuleGraph,
-    chunk_graph: &ChunkGraph,
+    etag: &CodeGenerationETag,
     exports_info: &ExportsInfo,
-    module_render_ids: &HashMap<ModuleId, String>,
     source: &mut ReplaceSource,
     init_fragments: &mut Vec<InitFragment>,
 ) {
@@ -683,18 +777,12 @@ fn apply_dependency_template(
         Dependency::HarmonyExportHeader(dep) => apply_export_header_dependency(dep, source),
         Dependency::HarmonyImportSideEffect(dep) => apply_harmony_import_side_effect_dependency(
             dep,
-            module_id,
-            dependency_id,
-            module_graph,
-            module_render_ids,
+            template_input(etag, origin_block, dependency_id),
             init_fragments,
         ),
         Dependency::HarmonyImportSpecifier(dep) => apply_harmony_import_specifier_dependency(
             dep,
-            module_id,
-            dependency_id,
-            module_graph,
-            module_render_ids,
+            template_input(etag, origin_block, dependency_id),
             source,
         ),
         Dependency::HarmonyExportSpecifier(dep) => {
@@ -706,26 +794,29 @@ fn apply_dependency_template(
         Dependency::HarmonyExportImportedSpecifier(dep) => {
             apply_harmony_export_imported_specifier_dependency(
                 dep,
-                module_id,
-                dependency_id,
-                module_graph,
+                template_input(etag, origin_block, dependency_id),
                 exports_info,
-                module_render_ids,
                 init_fragments,
             )
         }
         Dependency::Import(dep) => apply_import_dependency(
             dep,
-            module_id,
-            origin_block,
-            dependency_id,
-            module_graph,
-            chunk_graph,
-            module_render_ids,
+            template_input(etag, origin_block, dependency_id),
             source,
         ),
         Dependency::Entry(_) => {}
     }
+}
+
+fn template_input(
+    etag: &CodeGenerationETag,
+    block: Option<usize>,
+    dependency: Option<usize>,
+) -> Option<&DependencyTemplateInput> {
+    let dependency = dependency?;
+    etag.dependency_template_inputs
+        .iter()
+        .find(|input| input.block == block && input.dependency == dependency)
 }
 
 fn apply_const_dependency(dep: &ConstDependency, source: &mut ReplaceSource) {
@@ -746,20 +837,14 @@ fn apply_export_header_dependency(dep: &HarmonyExportHeaderDependency, source: &
 
 fn apply_harmony_import_side_effect_dependency(
     dep: &HarmonyImportSideEffectDependency,
-    module_id: ModuleId,
-    dependency_id: Option<usize>,
-    module_graph: &ModuleGraph,
-    module_render_ids: &HashMap<ModuleId, String>,
+    input: Option<&DependencyTemplateInput>,
     init_fragments: &mut Vec<InitFragment>,
 ) {
-    let Some(dependency_id) = dependency_id else {
-        return;
-    };
-    let Some(target) = module_graph.module_for_dependency(module_id, None, dependency_id) else {
+    let Some(target_render_id) = input.and_then(|input| input.target_render_id.as_deref()) else {
         return;
     };
     let import_var = import_var(&dep.module.request, dep.module.source_order.unwrap_or(0));
-    let target_id = json_string(&module_render_ids[&target]);
+    let target_id = json_string(target_render_id);
     push_init_fragment(
         init_fragments,
         InitFragmentStage::HarmonyImport,
@@ -769,18 +854,15 @@ fn apply_harmony_import_side_effect_dependency(
 
 fn apply_harmony_import_specifier_dependency(
     dep: &HarmonyImportSpecifierDependency,
-    module_id: ModuleId,
-    dependency_id: Option<usize>,
-    module_graph: &ModuleGraph,
-    module_render_ids: &HashMap<ModuleId, String>,
+    input: Option<&DependencyTemplateInput>,
     source: &mut ReplaceSource,
 ) {
-    let Some(dependency_id) = dependency_id else {
+    if input
+        .and_then(|input| input.target_render_id.as_ref())
+        .is_none()
+    {
         return;
-    };
-    let Some(_target) = module_graph.module_for_dependency(module_id, None, dependency_id) else {
-        return;
-    };
+    }
     let expression = import_expression(
         &dep.module.request,
         dep.module.source_order.unwrap_or(0),
@@ -792,7 +874,6 @@ fn apply_harmony_import_specifier_dependency(
         expression
     };
     replace(source, dep.usage_range, expression);
-    let _ = module_render_ids;
 }
 
 fn apply_harmony_export_specifier_dependency(
@@ -848,19 +929,16 @@ fn apply_harmony_export_expression_dependency(
 
 fn apply_harmony_export_imported_specifier_dependency(
     dep: &HarmonyExportImportedSpecifierDependency,
-    module_id: ModuleId,
-    dependency_id: Option<usize>,
-    module_graph: &ModuleGraph,
+    input: Option<&DependencyTemplateInput>,
     exports_info: &ExportsInfo,
-    module_render_ids: &HashMap<ModuleId, String>,
     init_fragments: &mut Vec<InitFragment>,
 ) {
-    let Some(dependency_id) = dependency_id else {
+    if input
+        .and_then(|input| input.target_render_id.as_ref())
+        .is_none()
+    {
         return;
-    };
-    let Some(_target) = module_graph.module_for_dependency(module_id, None, dependency_id) else {
-        return;
-    };
+    }
     let import_var = import_var(&dep.module.request, dep.module.source_order.unwrap_or(0));
     if dep.is_star {
         push_init_fragment(
@@ -882,43 +960,22 @@ fn apply_harmony_export_imported_specifier_dependency(
             ),
         );
     }
-    let _ = module_render_ids;
 }
 
 fn apply_import_dependency(
     dep: &ImportDependency,
-    module_id: ModuleId,
-    origin_block: Option<usize>,
-    dependency_id: Option<usize>,
-    module_graph: &ModuleGraph,
-    chunk_graph: &ChunkGraph,
-    module_render_ids: &HashMap<ModuleId, String>,
+    input: Option<&DependencyTemplateInput>,
     source: &mut ReplaceSource,
 ) {
-    let Some(block_index) = origin_block else {
+    let Some(input) = input else {
         return;
     };
-    let Some(dependency_id) = dependency_id else {
+    let Some(target_render_id) = input.target_render_id.as_deref() else {
         return;
     };
-    let Some(target) =
-        module_graph.module_for_dependency(module_id, Some(block_index), dependency_id)
-    else {
-        return;
-    };
-    let target_id = json_string(&module_render_ids[&target]);
-    let origin = AsyncBlockOrigin {
-        module: module_id,
-        block_index,
-    };
-    let expression = if let Some(group_id) = chunk_graph.block_chunk_group(origin) {
-        let group = &chunk_graph.chunk_groups()[group_id.index()];
-        let chunk_id = group
-            .chunks()
-            .first()
-            .and_then(|chunk_id| chunk_graph.chunk(*chunk_id))
-            .map(|chunk| json_string(chunk.render_id()))
-            .unwrap_or_else(|| "\"\"".to_string());
+    let target_id = json_string(target_render_id);
+    let expression = if let Some(chunk_render_id) = input.chunk_render_id.as_deref() {
+        let chunk_id = json_string(chunk_render_id);
         format!(
             "__webpack_require__.e({chunk_id}).then(__webpack_require__.bind(__webpack_require__, {target_id}))"
         )

--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -51,6 +51,29 @@ impl RuntimeRequirements {
     pub fn iter(&self) -> impl Iterator<Item = RuntimeRequirement> + '_ {
         self.requirements.iter().copied()
     }
+
+    fn for_initial_chunk(chunk_graph: &ChunkGraph, chunk: &Chunk) -> Self {
+        let mut requirements = Self::default();
+        requirements.insert(RuntimeRequirement::ModuleFactories);
+        requirements.insert(RuntimeRequirement::ModuleCache);
+        requirements.insert(RuntimeRequirement::Require);
+        requirements.insert(RuntimeRequirement::DefinePropertyGetters);
+        requirements.insert(RuntimeRequirement::HasOwnProperty);
+        requirements.insert(RuntimeRequirement::MakeNamespaceObject);
+
+        let has_async_child = chunk.groups().iter().any(|group_id| {
+            !chunk_graph.chunk_groups()[group_id.index()]
+                .children()
+                .is_empty()
+        });
+        if has_async_child {
+            requirements.insert(RuntimeRequirement::EnsureChunk);
+            requirements.insert(RuntimeRequirement::GetChunkFilename);
+            requirements.insert(RuntimeRequirement::RequireChunkLoading);
+        }
+
+        requirements
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -126,13 +149,19 @@ struct CodeGenerationInput<'a> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RenderManifest {
-    entries: Vec<RenderManifestEntry>,
+    entries: Vec<AssetRenderManifest>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct RenderManifestEntry {
-    filename: String,
-    render: AssetRenderManifest,
+pub(crate) struct AssetRenderPlan {
+    filenames: Vec<String>,
+    manifest: RenderManifest,
+}
+
+impl AssetRenderPlan {
+    pub(crate) fn manifest(&self) -> &RenderManifest {
+        &self.manifest
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -142,6 +171,7 @@ enum AssetRenderManifest {
         chunk_filename_map: String,
         entry_id: String,
         chunk_id: String,
+        runtime_requirements: RuntimeRequirements,
     },
     AsyncChunk {
         modules: Vec<ModuleRenderManifest>,
@@ -156,7 +186,7 @@ struct ModuleRenderManifest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct RenderedSource {
+pub(crate) struct RenderedSource {
     source: ConcatSource,
 }
 
@@ -227,8 +257,9 @@ pub(crate) fn create_render_manifest(
     chunk_graph: &ChunkGraph,
     entries: &[ModuleId],
     code_generation_results: &CodeGenerationResults,
-) -> RenderManifest {
+) -> AssetRenderPlan {
     let mut manifest_entries = Vec::new();
+    let mut filenames = Vec::new();
 
     for (entry_index, group_id) in chunk_graph.entrypoints().iter().copied().enumerate() {
         let group = &chunk_graph.chunk_groups()[group_id.index()];
@@ -242,14 +273,13 @@ pub(crate) fn create_render_manifest(
             continue;
         };
         let modules = module_render_manifest(chunk_graph, chunk, code_generation_results);
-        manifest_entries.push(RenderManifestEntry {
-            filename: chunk.filename().to_string(),
-            render: AssetRenderManifest::InitialChunk {
-                modules,
-                chunk_filename_map: render_chunk_filename_map(chunk_graph),
-                entry_id: code_generation_results.module_render_ids[&entry_module].clone(),
-                chunk_id: chunk.render_id().to_string(),
-            },
+        filenames.push(chunk.filename().to_string());
+        manifest_entries.push(AssetRenderManifest::InitialChunk {
+            modules,
+            chunk_filename_map: render_chunk_filename_map(chunk_graph),
+            entry_id: code_generation_results.module_render_ids[&entry_module].clone(),
+            chunk_id: chunk.render_id().to_string(),
+            runtime_requirements: RuntimeRequirements::for_initial_chunk(chunk_graph, chunk),
         });
     }
 
@@ -263,35 +293,43 @@ pub(crate) fn create_render_manifest(
         if is_initial {
             continue;
         }
-        manifest_entries.push(RenderManifestEntry {
-            filename: chunk.filename().to_string(),
-            render: AssetRenderManifest::AsyncChunk {
-                modules: module_render_manifest(chunk_graph, chunk, code_generation_results),
-                chunk_id: chunk.render_id().to_string(),
-            },
+        filenames.push(chunk.filename().to_string());
+        manifest_entries.push(AssetRenderManifest::AsyncChunk {
+            modules: module_render_manifest(chunk_graph, chunk, code_generation_results),
+            chunk_id: chunk.render_id().to_string(),
         });
     }
 
-    RenderManifest {
-        entries: manifest_entries,
+    AssetRenderPlan {
+        filenames,
+        manifest: RenderManifest {
+            entries: manifest_entries,
+        },
     }
 }
 
-pub(crate) fn render_assets(
-    options: &CompilerOptions,
+pub(crate) fn render_asset_sources(
     manifest: &RenderManifest,
     code_generation_results: &CodeGenerationResults,
-) -> Vec<Asset> {
-    let mut assets = Vec::new();
+) -> Vec<RenderedSource> {
+    let mut rendered_sources = Vec::new();
     for entry in &manifest.entries {
-        let rendered_source = render_asset(&entry.render, code_generation_results);
-        assets.extend(emit_asset(
-            entry.filename.clone(),
-            &rendered_source,
-            options.sourcemap,
-        ));
+        rendered_sources.push(render_asset(entry, code_generation_results));
     }
-    assets
+    rendered_sources
+}
+
+pub(crate) fn create_assets(
+    options: &CompilerOptions,
+    plan: &AssetRenderPlan,
+    rendered_sources: &[RenderedSource],
+) -> Vec<Asset> {
+    plan.filenames
+        .iter()
+        .cloned()
+        .zip(rendered_sources)
+        .flat_map(|(filename, rendered)| emit_asset(filename, rendered, options.sourcemap))
+        .collect()
 }
 
 fn module_render_manifest(
@@ -303,16 +341,22 @@ fn module_render_manifest(
     chunk_graph
         .chunk_modules(chunk.id())
         .iter()
-        .filter_map(|module_id| {
-            let code_generation_key =
-                code_generation_results.key_for(*module_id, runtime.clone())?;
-            code_generation_results
-                .results
-                .contains_key(&code_generation_key)
-                .then(|| ModuleRenderManifest {
-                    render_id: code_generation_results.module_render_ids[module_id].clone(),
-                    code_generation_key,
-                })
+        .map(|module_id| {
+            let code_generation_key = code_generation_results
+                .key_for(*module_id, runtime.clone())
+                .unwrap_or_else(|| {
+                    panic!("module {module_id:?} must have a Code Generation identity")
+                });
+            assert!(
+                code_generation_results
+                    .results
+                    .contains_key(&code_generation_key),
+                "module {module_id:?} must have a Code Generation result"
+            );
+            ModuleRenderManifest {
+                render_id: code_generation_results.module_render_ids[module_id].clone(),
+                code_generation_key,
+            }
         })
         .collect()
 }
@@ -327,11 +371,13 @@ fn render_asset(
             chunk_filename_map,
             entry_id,
             chunk_id,
+            runtime_requirements,
         } => render_initial_asset(
             modules,
             chunk_filename_map,
             entry_id,
             chunk_id,
+            runtime_requirements,
             code_generation_results,
         ),
         AssetRenderManifest::AsyncChunk { modules, chunk_id } => {
@@ -380,8 +426,10 @@ fn render_initial_asset(
     chunk_filename_map: &str,
     entry_id: &str,
     chunk_id: &str,
+    runtime_requirements: &RuntimeRequirements,
     code_generation_results: &CodeGenerationResults,
 ) -> ConcatSource {
+    debug_assert!(runtime_requirements.contains(RuntimeRequirement::Require));
     let modules = render_module_table(modules, code_generation_results);
     let entry_id = json_string(entry_id);
     let chunk_id = json_string(chunk_id);

--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -11,7 +11,8 @@ use crate::{
     Dependency, Error, ExportsInfo, HarmonyExportExpressionDependency,
     HarmonyExportHeaderDependency, HarmonyExportImportedSpecifierDependency,
     HarmonyExportSpecifierDependency, HarmonyImportSideEffectDependency,
-    HarmonyImportSpecifierDependency, ImportDependency, Module, ModuleGraph, ModuleId, SourceRange,
+    HarmonyImportSpecifierDependency, ImportDependency, Module, ModuleGraph, ModuleId,
+    ModuleIdentity, SourceRange,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -50,28 +51,122 @@ impl RuntimeRequirements {
     pub fn iter(&self) -> impl Iterator<Item = RuntimeRequirement> + '_ {
         self.requirements.iter().copied()
     }
+}
 
-    fn for_initial_chunk(chunk_graph: &ChunkGraph, chunk: &Chunk) -> Self {
-        let mut requirements = Self::default();
-        requirements.insert(RuntimeRequirement::ModuleFactories);
-        requirements.insert(RuntimeRequirement::ModuleCache);
-        requirements.insert(RuntimeRequirement::Require);
-        requirements.insert(RuntimeRequirement::DefinePropertyGetters);
-        requirements.insert(RuntimeRequirement::HasOwnProperty);
-        requirements.insert(RuntimeRequirement::MakeNamespaceObject);
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct RuntimeSpec(BTreeSet<String>);
 
-        let has_async_child = chunk.groups().iter().any(|group_id| {
-            !chunk_graph.chunk_groups()[group_id.index()]
-                .children()
-                .is_empty()
-        });
-        if has_async_child {
-            requirements.insert(RuntimeRequirement::EnsureChunk);
-            requirements.insert(RuntimeRequirement::GetChunkFilename);
-            requirements.insert(RuntimeRequirement::RequireChunkLoading);
+impl RuntimeSpec {
+    fn for_chunk(chunk_graph: &ChunkGraph, chunk: &Chunk) -> Self {
+        let mut names = BTreeSet::new();
+        let mut visited = BTreeSet::new();
+        let mut pending = chunk.groups().to_vec();
+
+        while let Some(group_id) = pending.pop() {
+            if !visited.insert(group_id) {
+                continue;
+            }
+            let group = &chunk_graph.chunk_groups()[group_id.index()];
+            match group.kind() {
+                ChunkGroupKind::Entrypoint { name } => {
+                    names.insert(name.clone());
+                }
+                ChunkGroupKind::Async => pending.extend(group.parents().iter().copied()),
+            }
         }
 
-        requirements
+        Self(names)
+    }
+
+    #[cfg(test)]
+    fn names(&self) -> impl Iterator<Item = &str> {
+        self.0.iter().map(String::as_str)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct CodeGenerationKey {
+    module: ModuleIdentity,
+    runtime: RuntimeSpec,
+}
+
+impl CodeGenerationKey {
+    fn new(module: ModuleIdentity, runtime: RuntimeSpec) -> Self {
+        Self { module, runtime }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CodeGenerationResult {
+    source: ConcatSource,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct CodeGenerationResults {
+    module_render_ids: HashMap<ModuleId, String>,
+    module_identities: HashMap<ModuleId, ModuleIdentity>,
+    results: HashMap<CodeGenerationKey, CodeGenerationResult>,
+}
+
+impl CodeGenerationResults {
+    fn key_for(&self, module: ModuleId, runtime: RuntimeSpec) -> Option<CodeGenerationKey> {
+        self.module_identities
+            .get(&module)
+            .cloned()
+            .map(|identity| CodeGenerationKey::new(identity, runtime))
+    }
+}
+
+struct CodeGenerationInput<'a> {
+    module: &'a Module,
+    module_graph: &'a ModuleGraph,
+    chunk_graph: &'a ChunkGraph,
+    module_render_ids: &'a HashMap<ModuleId, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RenderManifest {
+    entries: Vec<RenderManifestEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RenderManifestEntry {
+    filename: String,
+    render: AssetRenderManifest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AssetRenderManifest {
+    InitialChunk {
+        modules: Vec<ModuleRenderManifest>,
+        chunk_filename_map: String,
+        entry_id: String,
+        chunk_id: String,
+    },
+    AsyncChunk {
+        modules: Vec<ModuleRenderManifest>,
+        chunk_id: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ModuleRenderManifest {
+    render_id: String,
+    code_generation_key: CodeGenerationKey,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RenderedSource {
+    source: ConcatSource,
+}
+
+impl RenderedSource {
+    fn new(source: ConcatSource) -> Self {
+        Self { source }
+    }
+
+    fn source(&self) -> &ConcatSource {
+        &self.source
     }
 }
 
@@ -89,15 +184,51 @@ enum InitFragmentStage {
     HarmonyStarReexport,
 }
 
-pub(crate) fn create_assets(
+pub(crate) fn generate_code(
     options: &CompilerOptions,
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
-    entries: &[ModuleId],
-) -> Vec<Asset> {
+) -> CodeGenerationResults {
     let render_context = RenderPathContext::new(options.context.as_path());
     let module_render_ids = module_render_ids(&render_context, module_graph);
-    let mut assets = Vec::new();
+    let module_identities = module_graph
+        .modules()
+        .iter()
+        .map(|module| (module.id(), module.identity().clone()))
+        .collect::<HashMap<_, _>>();
+    let mut results = HashMap::new();
+
+    for chunk in chunk_graph.chunks() {
+        let runtime = RuntimeSpec::for_chunk(chunk_graph, chunk);
+        for module_id in chunk_graph.chunk_modules(chunk.id()) {
+            let Some(module) = module_graph.module(*module_id) else {
+                continue;
+            };
+            let key = CodeGenerationKey::new(module.identity().clone(), runtime.clone());
+            results.entry(key).or_insert_with(|| {
+                generate_module_code(CodeGenerationInput {
+                    module,
+                    module_graph,
+                    chunk_graph,
+                    module_render_ids: &module_render_ids,
+                })
+            });
+        }
+    }
+
+    CodeGenerationResults {
+        module_render_ids,
+        module_identities,
+        results,
+    }
+}
+
+pub(crate) fn create_render_manifest(
+    chunk_graph: &ChunkGraph,
+    entries: &[ModuleId],
+    code_generation_results: &CodeGenerationResults,
+) -> RenderManifest {
+    let mut manifest_entries = Vec::new();
 
     for (entry_index, group_id) in chunk_graph.entrypoints().iter().copied().enumerate() {
         let group = &chunk_graph.chunk_groups()[group_id.index()];
@@ -110,18 +241,16 @@ pub(crate) fn create_assets(
         let Some(entry_module) = entries.get(entry_index).copied() else {
             continue;
         };
-        assets.extend(emit_asset(
-            chunk.filename().to_string(),
-            render_initial_asset(
-                options,
-                module_graph,
-                chunk_graph,
-                chunk,
-                entry_module,
-                &module_render_ids,
-            ),
-            options.sourcemap,
-        ));
+        let modules = module_render_manifest(chunk_graph, chunk, code_generation_results);
+        manifest_entries.push(RenderManifestEntry {
+            filename: chunk.filename().to_string(),
+            render: AssetRenderManifest::InitialChunk {
+                modules,
+                chunk_filename_map: render_chunk_filename_map(chunk_graph),
+                entry_id: code_generation_results.module_render_ids[&entry_module].clone(),
+                chunk_id: chunk.render_id().to_string(),
+            },
+        });
     }
 
     for chunk in chunk_graph.chunks() {
@@ -134,17 +263,86 @@ pub(crate) fn create_assets(
         if is_initial {
             continue;
         }
+        manifest_entries.push(RenderManifestEntry {
+            filename: chunk.filename().to_string(),
+            render: AssetRenderManifest::AsyncChunk {
+                modules: module_render_manifest(chunk_graph, chunk, code_generation_results),
+                chunk_id: chunk.render_id().to_string(),
+            },
+        });
+    }
+
+    RenderManifest {
+        entries: manifest_entries,
+    }
+}
+
+pub(crate) fn render_assets(
+    options: &CompilerOptions,
+    manifest: &RenderManifest,
+    code_generation_results: &CodeGenerationResults,
+) -> Vec<Asset> {
+    let mut assets = Vec::new();
+    for entry in &manifest.entries {
+        let rendered_source = render_asset(&entry.render, code_generation_results);
         assets.extend(emit_asset(
-            chunk.filename().to_string(),
-            render_async_chunk_asset(module_graph, chunk_graph, chunk, &module_render_ids),
+            entry.filename.clone(),
+            &rendered_source,
             options.sourcemap,
         ));
     }
-
     assets
 }
 
-fn emit_asset(filename: String, mut source: ConcatSource, sourcemap: bool) -> Vec<Asset> {
+fn module_render_manifest(
+    chunk_graph: &ChunkGraph,
+    chunk: &Chunk,
+    code_generation_results: &CodeGenerationResults,
+) -> Vec<ModuleRenderManifest> {
+    let runtime = RuntimeSpec::for_chunk(chunk_graph, chunk);
+    chunk_graph
+        .chunk_modules(chunk.id())
+        .iter()
+        .filter_map(|module_id| {
+            let code_generation_key =
+                code_generation_results.key_for(*module_id, runtime.clone())?;
+            code_generation_results
+                .results
+                .contains_key(&code_generation_key)
+                .then(|| ModuleRenderManifest {
+                    render_id: code_generation_results.module_render_ids[module_id].clone(),
+                    code_generation_key,
+                })
+        })
+        .collect()
+}
+
+fn render_asset(
+    manifest: &AssetRenderManifest,
+    code_generation_results: &CodeGenerationResults,
+) -> RenderedSource {
+    let source = match manifest {
+        AssetRenderManifest::InitialChunk {
+            modules,
+            chunk_filename_map,
+            entry_id,
+            chunk_id,
+        } => render_initial_asset(
+            modules,
+            chunk_filename_map,
+            entry_id,
+            chunk_id,
+            code_generation_results,
+        ),
+        AssetRenderManifest::AsyncChunk { modules, chunk_id } => {
+            render_async_chunk_asset(modules, chunk_id, code_generation_results)
+        }
+    };
+    RenderedSource::new(source)
+}
+
+fn emit_asset(filename: String, rendered: &RenderedSource, sourcemap: bool) -> Vec<Asset> {
+    let mut source = rendered.source().clone();
     let map_filename = format!("{filename}.map");
     if sourcemap {
         source.add(RawStringSource::from(format!(
@@ -178,18 +376,15 @@ fn emit_asset(filename: String, mut source: ConcatSource, sourcemap: bool) -> Ve
 }
 
 fn render_initial_asset(
-    _options: &CompilerOptions,
-    module_graph: &ModuleGraph,
-    chunk_graph: &ChunkGraph,
-    chunk: &Chunk,
-    entry_module: ModuleId,
-    module_render_ids: &HashMap<ModuleId, String>,
+    modules: &[ModuleRenderManifest],
+    chunk_filename_map: &str,
+    entry_id: &str,
+    chunk_id: &str,
+    code_generation_results: &CodeGenerationResults,
 ) -> ConcatSource {
-    let modules = render_module_table(module_graph, chunk_graph, chunk, module_render_ids);
-    let _runtime_requirements = RuntimeRequirements::for_initial_chunk(chunk_graph, chunk);
-    let chunk_filename_map = render_chunk_filename_map(chunk_graph);
-    let entry_id = json_string(&module_render_ids[&entry_module]);
-    let chunk_id = json_string(chunk.render_id());
+    let modules = render_module_table(modules, code_generation_results);
+    let entry_id = json_string(entry_id);
+    let chunk_id = json_string(chunk_id);
 
     let mut source = ConcatSource::default();
     source.add(RawStringSource::from(
@@ -270,13 +465,12 @@ module.exports = __webpack_require__({entry_id});
 }
 
 fn render_async_chunk_asset(
-    module_graph: &ModuleGraph,
-    chunk_graph: &ChunkGraph,
-    chunk: &Chunk,
-    module_render_ids: &HashMap<ModuleId, String>,
+    modules: &[ModuleRenderManifest],
+    chunk_id: &str,
+    code_generation_results: &CodeGenerationResults,
 ) -> ConcatSource {
-    let modules = render_module_table(module_graph, chunk_graph, chunk, module_render_ids);
-    let chunk_id = json_string(chunk.render_id());
+    let modules = render_module_table(modules, code_generation_results);
+    let chunk_id = json_string(chunk_id);
     let mut source = ConcatSource::default();
     source.add(RawStringSource::from(format!(
         r#""use strict";
@@ -291,15 +485,16 @@ exports.modules = ({{
 }
 
 fn render_module_table(
-    module_graph: &ModuleGraph,
-    chunk_graph: &ChunkGraph,
-    chunk: &Chunk,
-    module_render_ids: &HashMap<ModuleId, String>,
+    modules: &[ModuleRenderManifest],
+    code_generation_results: &CodeGenerationResults,
 ) -> ConcatSource {
     let mut source = ConcatSource::default();
     let mut first = true;
-    for module_id in chunk_graph.chunk_modules(chunk.id()) {
-        let Some(module) = module_graph.module(*module_id) else {
+    for module in modules {
+        let Some(result) = code_generation_results
+            .results
+            .get(&module.code_generation_key)
+        else {
             continue;
         };
         if first {
@@ -307,25 +502,26 @@ fn render_module_table(
         } else {
             source.add(RawStringSource::from(",\n".to_string()));
         }
-        let render_id = &module_render_ids[module_id];
-        let factory = render_module_factory(module_graph, chunk_graph, module, module_render_ids);
         source.add(RawStringSource::from(format!(
             "{}: ",
-            json_string(render_id)
+            json_string(&module.render_id)
         )));
-        source.add(factory);
+        source.add(result.source.clone());
     }
     source
 }
 
-fn render_module_factory(
-    module_graph: &ModuleGraph,
-    chunk_graph: &ChunkGraph,
-    module: &Module,
-    module_render_ids: &HashMap<ModuleId, String>,
-) -> ConcatSource {
+fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult {
+    let CodeGenerationInput {
+        module,
+        module_graph,
+        chunk_graph,
+        module_render_ids,
+    } = input;
     if let Some(error) = module.build_error() {
-        return render_failed_module_factory(error);
+        return CodeGenerationResult {
+            source: render_failed_module_factory(error),
+        };
     }
 
     let module_id = module.id();
@@ -388,7 +584,7 @@ fn render_module_factory(
     )));
     factory.add(source);
     factory.add(RawStringSource::from("\n})".to_string()));
-    factory
+    CodeGenerationResult { source: factory }
 }
 
 fn render_failed_module_factory(error: &Error) -> ConcatSource {
@@ -829,4 +1025,89 @@ fn json_string(value: &str) -> String {
         .replace('\n', "\\n")
         .replace('\r', "\\r");
     format!("\"{escaped}\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use rspack_sources::{ConcatSource, OriginalSource, Source};
+
+    use crate::{ChunkGroupKind, Compiler, CompilerOptions, Entry};
+
+    use super::{RenderedSource, RuntimeSpec, emit_asset};
+
+    #[tokio::test]
+    async fn shared_async_chunk_runtime_spec_contains_each_parent_entrypoint()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        fs::write(
+            temp.path().join("a.js"),
+            "export const load = () => import('./feature');",
+        )?;
+        fs::write(
+            temp.path().join("b.js"),
+            "export const load = () => import('./feature');",
+        )?;
+        fs::write(temp.path().join("feature.js"), "export const value = 42;")?;
+        let compilation = Compiler::new(CompilerOptions::new(
+            temp.path(),
+            vec![Entry::new("a", "./a"), Entry::new("b", "./b")],
+        ))
+        .run()
+        .await?;
+        let chunk = compilation
+            .chunk_graph()
+            .chunks()
+            .iter()
+            .find(|chunk| {
+                chunk.groups().iter().any(|group| {
+                    matches!(
+                        compilation.chunk_graph().chunk_groups()[group.index()].kind(),
+                        ChunkGroupKind::Async
+                    )
+                })
+            })
+            .expect("shared async chunk should exist");
+
+        let runtime = RuntimeSpec::for_chunk(compilation.chunk_graph(), chunk);
+
+        assert_eq!(runtime.names().collect::<Vec<_>>(), ["a", "b"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn rendered_source_is_reusable_across_asset_filenames() {
+        let mut source = ConcatSource::default();
+        source.add(OriginalSource::new(
+            "export const value = 42;\n",
+            "fixture.js",
+        ));
+        let rendered = RenderedSource::new(source);
+
+        let first = emit_asset("first.js".to_string(), &rendered, true);
+        let second = emit_asset("second.js".to_string(), &rendered, true);
+
+        assert_eq!(
+            rendered.source().source().into_string_lossy(),
+            "export const value = 42;\n"
+        );
+        assert_eq!(first[0].filename, "first.js");
+        assert!(
+            first[0]
+                .source
+                .ends_with("//# sourceMappingURL=first.js.map\n")
+        );
+        assert_eq!(second[0].filename, "second.js");
+        assert!(
+            second[0]
+                .source
+                .ends_with("//# sourceMappingURL=second.js.map\n")
+        );
+        assert_eq!(first[1].filename, "first.js.map");
+        assert!(first[1].source.contains(r#""file":"first.js""#));
+        assert_eq!(second[1].filename, "second.js.map");
+        assert!(second[1].source.contains(r#""file":"second.js""#));
+    }
 }

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -6,7 +6,7 @@ use crate::{
     Asset, ChunkGraph, CompilerOptions, Error, InfrastructureLogEvent, InfrastructureLogLevel,
     ModuleGraph, ModuleId, Result, UnpackResolver,
     build_cache::BuildCache,
-    code_generation::{self, AssetRenderPlan, CodeGenerationResults, RenderedSource},
+    code_generation::{self, AssetRenderPlan, CodeGenerationResults, RenderedAssetSource},
     make::{self, MakeState},
     snapshot::FileSystemInfo,
 };
@@ -21,7 +21,7 @@ pub struct Compilation {
     chunk_graph: ChunkGraph,
     code_generation_results: Option<CodeGenerationResults>,
     asset_render_plan: Option<AssetRenderPlan>,
-    rendered_asset_sources: Option<Vec<RenderedSource>>,
+    rendered_asset_sources: Option<Vec<RenderedAssetSource>>,
     assets: Vec<Asset>,
     entries: Vec<ModuleId>,
     errors: Vec<Error>,
@@ -190,8 +190,7 @@ impl Compilation {
         self.rendered_asset_sources = Some(code_generation::render_asset_sources(
             self.asset_render_plan
                 .as_ref()
-                .expect("render plan should exist before Asset rendering")
-                .manifest(),
+                .expect("render plan should exist before Asset rendering"),
             self.code_generation_results
                 .as_ref()
                 .expect("code generation results should exist before Asset rendering"),

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -6,7 +6,7 @@ use crate::{
     Asset, ChunkGraph, CompilerOptions, Error, InfrastructureLogEvent, InfrastructureLogLevel,
     ModuleGraph, ModuleId, Result, UnpackResolver,
     build_cache::BuildCache,
-    code_generation::{self, CodeGenerationResults, RenderManifest},
+    code_generation::{self, AssetRenderPlan, CodeGenerationResults, RenderedSource},
     make::{self, MakeState},
     snapshot::FileSystemInfo,
 };
@@ -20,7 +20,8 @@ pub struct Compilation {
     module_graph: ModuleGraph,
     chunk_graph: ChunkGraph,
     code_generation_results: Option<CodeGenerationResults>,
-    asset_render_manifest: Option<RenderManifest>,
+    asset_render_plan: Option<AssetRenderPlan>,
+    rendered_asset_sources: Option<Vec<RenderedSource>>,
     assets: Vec<Asset>,
     entries: Vec<ModuleId>,
     errors: Vec<Error>,
@@ -43,7 +44,8 @@ impl Compilation {
             module_graph: ModuleGraph::default(),
             chunk_graph: ChunkGraph::default(),
             code_generation_results: None,
-            asset_render_manifest: None,
+            asset_render_plan: None,
+            rendered_asset_sources: None,
             assets: Vec::new(),
             entries: Vec::new(),
             errors: Vec::new(),
@@ -117,6 +119,7 @@ impl Compilation {
                     .into_iter()
                     .collect(),
             };
+            self.invalidate_generated_work();
 
             if result.is_ok() {
                 self.log_infrastructure(
@@ -141,6 +144,7 @@ impl Compilation {
             "chunk graph build started",
         );
         self.chunk_graph = ChunkGraph::build(&self.options, &self.module_graph, &self.entries);
+        self.invalidate_generated_work();
         self.log_infrastructure(
             InfrastructureLogLevel::Verbose,
             "unpack.Compilation",
@@ -157,7 +161,8 @@ impl Compilation {
             "asset creation started",
         );
         self.create_asset_render_manifest();
-        self.render_assets();
+        self.render_asset_sources();
+        self.emit_assets();
         self.log_infrastructure(
             InfrastructureLogLevel::Verbose,
             "unpack.Compilation",
@@ -169,7 +174,7 @@ impl Compilation {
         if self.code_generation_results.is_none() {
             self.code_generation();
         }
-        self.asset_render_manifest = Some(code_generation::create_render_manifest(
+        self.asset_render_plan = Some(code_generation::create_render_manifest(
             &self.chunk_graph,
             &self.entries,
             self.code_generation_results
@@ -178,18 +183,33 @@ impl Compilation {
         ));
     }
 
-    pub fn render_assets(&mut self) {
-        if self.asset_render_manifest.is_none() {
+    pub fn render_asset_sources(&mut self) {
+        if self.asset_render_plan.is_none() {
             self.create_asset_render_manifest();
         }
-        self.assets = code_generation::render_assets(
-            &self.options,
-            self.asset_render_manifest
+        self.rendered_asset_sources = Some(code_generation::render_asset_sources(
+            self.asset_render_plan
                 .as_ref()
-                .expect("render manifest should exist before Asset rendering"),
+                .expect("render plan should exist before Asset rendering")
+                .manifest(),
             self.code_generation_results
                 .as_ref()
                 .expect("code generation results should exist before Asset rendering"),
+        ));
+    }
+
+    pub fn emit_assets(&mut self) {
+        if self.rendered_asset_sources.is_none() {
+            self.render_asset_sources();
+        }
+        self.assets = code_generation::create_assets(
+            &self.options,
+            self.asset_render_plan
+                .as_ref()
+                .expect("render plan should exist before Asset emission"),
+            self.rendered_asset_sources
+                .as_ref()
+                .expect("rendered sources should exist before Asset emission"),
         );
     }
 
@@ -201,7 +221,15 @@ impl Compilation {
             &self.module_graph,
             &self.chunk_graph,
         ));
-        self.asset_render_manifest = None;
+        self.asset_render_plan = None;
+        self.rendered_asset_sources = None;
+    }
+
+    fn invalidate_generated_work(&mut self) {
+        self.code_generation_results = None;
+        self.asset_render_plan = None;
+        self.rendered_asset_sources = None;
+        self.assets.clear();
     }
 
     fn log_infrastructure(

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -6,7 +6,7 @@ use crate::{
     Asset, ChunkGraph, CompilerOptions, Error, InfrastructureLogEvent, InfrastructureLogLevel,
     ModuleGraph, ModuleId, Result, UnpackResolver,
     build_cache::BuildCache,
-    code_generation,
+    code_generation::{self, CodeGenerationResults, RenderManifest},
     make::{self, MakeState},
     snapshot::FileSystemInfo,
 };
@@ -19,6 +19,8 @@ pub struct Compilation {
     build_cache: BuildCache,
     module_graph: ModuleGraph,
     chunk_graph: ChunkGraph,
+    code_generation_results: Option<CodeGenerationResults>,
+    asset_render_manifest: Option<RenderManifest>,
     assets: Vec<Asset>,
     entries: Vec<ModuleId>,
     errors: Vec<Error>,
@@ -40,6 +42,8 @@ impl Compilation {
             build_cache,
             module_graph: ModuleGraph::default(),
             chunk_graph: ChunkGraph::default(),
+            code_generation_results: None,
+            asset_render_manifest: None,
             assets: Vec::new(),
             entries: Vec::new(),
             errors: Vec::new(),
@@ -152,17 +156,52 @@ impl Compilation {
             "unpack.Compilation",
             "asset creation started",
         );
-        self.assets = code_generation::create_assets(
-            &self.options,
-            &self.module_graph,
-            &self.chunk_graph,
-            &self.entries,
-        );
+        self.create_asset_render_manifest();
+        self.render_assets();
         self.log_infrastructure(
             InfrastructureLogLevel::Verbose,
             "unpack.Compilation",
             "asset creation completed",
         );
+    }
+
+    pub fn create_asset_render_manifest(&mut self) {
+        if self.code_generation_results.is_none() {
+            self.code_generation();
+        }
+        self.asset_render_manifest = Some(code_generation::create_render_manifest(
+            &self.chunk_graph,
+            &self.entries,
+            self.code_generation_results
+                .as_ref()
+                .expect("code generation results should exist before render manifest creation"),
+        ));
+    }
+
+    pub fn render_assets(&mut self) {
+        if self.asset_render_manifest.is_none() {
+            self.create_asset_render_manifest();
+        }
+        self.assets = code_generation::render_assets(
+            &self.options,
+            self.asset_render_manifest
+                .as_ref()
+                .expect("render manifest should exist before Asset rendering"),
+            self.code_generation_results
+                .as_ref()
+                .expect("code generation results should exist before Asset rendering"),
+        );
+    }
+
+    pub fn code_generation(&mut self) {
+        let span = tracing::trace_span!("Compilation::code_generation");
+        let _enter = span.enter();
+        self.code_generation_results = Some(code_generation::generate_code(
+            &self.options,
+            &self.module_graph,
+            &self.chunk_graph,
+        ));
+        self.asset_render_manifest = None;
     }
 
     fn log_infrastructure(

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -82,6 +82,7 @@ impl Compiler {
             let mut compilation = self.create_compilation();
             compilation.make().await?;
             compilation.build_chunk_graph();
+            compilation.code_generation();
             compilation.create_assets();
             Ok(compilation)
         }

--- a/crates/unpack_core/tests/codegen.rs
+++ b/crates/unpack_core/tests/codegen.rs
@@ -7,6 +7,149 @@ use std::{
 use unpack_core::{ChunkGroupKind, Compiler, CompilerOptions, Entry};
 
 #[tokio::test]
+async fn separates_module_code_generation_from_asset_rendering()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    write(
+        temp.path().join("src/index.js"),
+        r#"
+            export const value = 42;
+        "#,
+    )?;
+
+    let compiler = Compiler::new(CompilerOptions::new(
+        temp.path(),
+        vec![Entry::new("main", "./src/index")],
+    ));
+    let mut compilation = compiler.create_compilation();
+
+    compilation.make().await?;
+    compilation.build_chunk_graph();
+    compilation.code_generation();
+
+    assert_eq!(compilation.assets(), []);
+
+    compilation.create_assets();
+
+    assert_eq!(compilation.errors(), []);
+    assert_eq!(
+        compilation
+            .assets()
+            .iter()
+            .map(|asset| asset.filename.as_str())
+            .collect::<Vec<_>>(),
+        ["main.js", "main.js.map"]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn builds_a_render_manifest_before_creating_asset_bookkeeping()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    write(
+        temp.path().join("src/index.js"),
+        r#"
+            export async function load() {
+                return import("./feature");
+            }
+        "#,
+    )?;
+    write(
+        temp.path().join("src/feature.js"),
+        "export const value = 42;",
+    )?;
+
+    let compiler = Compiler::new(CompilerOptions::new(
+        temp.path(),
+        vec![Entry::new("main", "./src/index")],
+    ));
+    let mut compilation = compiler.create_compilation();
+
+    compilation.make().await?;
+    compilation.build_chunk_graph();
+    compilation.code_generation();
+    compilation.create_asset_render_manifest();
+
+    assert_eq!(compilation.assets(), []);
+
+    compilation.render_assets();
+
+    assert_eq!(compilation.errors(), []);
+    assert_eq!(
+        compilation
+            .assets()
+            .iter()
+            .map(|asset| asset.filename.as_str())
+            .collect::<Vec<_>>(),
+        [
+            "main.js",
+            "main.js.map",
+            "src_feature_js.js",
+            "src_feature_js.js.map"
+        ]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn preserves_byte_exact_static_async_and_sourcemap_outputs()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    write(
+        temp.path().join("src/index.js"),
+        r#"
+            import { eager } from "./eager";
+
+            export async function load() {
+                const feature = await import("./feature");
+                return [eager, feature.value];
+            }
+        "#,
+    )?;
+    write(
+        temp.path().join("src/eager.js"),
+        "export const eager = 'eager';",
+    )?;
+    write(
+        temp.path().join("src/feature.js"),
+        "export const value = 'feature';",
+    )?;
+
+    let compilation = Compiler::new(CompilerOptions::new(
+        temp.path(),
+        vec![Entry::new("main", "./src/index")],
+    ))
+    .run()
+    .await?;
+    let fingerprints = compilation
+        .assets()
+        .iter()
+        .map(|asset| {
+            (
+                asset.filename.as_str(),
+                asset.source.len(),
+                fnv1a64(asset.source.as_bytes()),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        fingerprints,
+        [
+            ("main.js", 3166, 12861121386719719501),
+            ("main.js.map", 480, 10309079247393373181),
+            ("src_feature_js.js", 398, 7014656015713497901),
+            ("src_feature_js.js.map", 164, 2414748877879059404)
+        ]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn emits_node_require_chunks_for_dynamic_import() -> Result<(), Box<dyn std::error::Error>> {
     let temp = tempfile::tempdir()?;
     write(
@@ -374,4 +517,10 @@ fn node_available() -> bool {
         .output()
         .map(|output| output.status.success())
         .unwrap_or(false)
+}
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    bytes.iter().fold(0xcbf29ce484222325, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+    })
 }

--- a/crates/unpack_core/tests/codegen.rs
+++ b/crates/unpack_core/tests/codegen.rs
@@ -74,7 +74,11 @@ async fn builds_a_render_manifest_before_creating_asset_bookkeeping()
 
     assert_eq!(compilation.assets(), []);
 
-    compilation.render_assets();
+    compilation.render_asset_sources();
+
+    assert_eq!(compilation.assets(), []);
+
+    compilation.emit_assets();
 
     assert_eq!(compilation.errors(), []);
     assert_eq!(
@@ -95,55 +99,41 @@ async fn builds_a_render_manifest_before_creating_asset_bookkeeping()
 }
 
 #[tokio::test]
-async fn preserves_byte_exact_static_async_and_sourcemap_outputs()
+async fn rebuilding_graphs_invalidates_generated_and_rendered_work()
 -> Result<(), Box<dyn std::error::Error>> {
     let temp = tempfile::tempdir()?;
     write(
         temp.path().join("src/index.js"),
-        r#"
-            import { eager } from "./eager";
-
-            export async function load() {
-                const feature = await import("./feature");
-                return [eager, feature.value];
-            }
-        "#,
-    )?;
-    write(
-        temp.path().join("src/eager.js"),
-        "export const eager = 'eager';",
-    )?;
-    write(
-        temp.path().join("src/feature.js"),
-        "export const value = 'feature';",
+        "export const value = 'before';",
     )?;
 
-    let compilation = Compiler::new(CompilerOptions::new(
+    let compiler = Compiler::new(CompilerOptions::new(
         temp.path(),
         vec![Entry::new("main", "./src/index")],
-    ))
-    .run()
-    .await?;
-    let fingerprints = compilation
-        .assets()
-        .iter()
-        .map(|asset| {
-            (
-                asset.filename.as_str(),
-                asset.source.len(),
-                fnv1a64(asset.source.as_bytes()),
-            )
-        })
-        .collect::<Vec<_>>();
+    ));
+    let mut compilation = compiler.create_compilation();
+    compilation.make().await?;
+    compilation.build_chunk_graph();
+    compilation.create_assets();
+    assert!(
+        compilation
+            .assets()
+            .iter()
+            .any(|asset| asset.filename == "main.js" && asset.source.contains("before"))
+    );
 
-    assert_eq!(
-        fingerprints,
-        [
-            ("main.js", 3166, 12861121386719719501),
-            ("main.js.map", 480, 10309079247393373181),
-            ("src_feature_js.js", 398, 7014656015713497901),
-            ("src_feature_js.js.map", 164, 2414748877879059404)
-        ]
+    write(
+        temp.path().join("src/index.js"),
+        "export const value = 'after';",
+    )?;
+    compilation.make().await?;
+    compilation.build_chunk_graph();
+    compilation.create_assets();
+    assert!(
+        compilation
+            .assets()
+            .iter()
+            .any(|asset| asset.filename == "main.js" && asset.source.contains("after"))
     );
 
     Ok(())
@@ -517,10 +507,4 @@ fn node_available() -> bool {
         .output()
         .map(|output| output.status.success())
         .unwrap_or(false)
-}
-
-fn fnv1a64(bytes: &[u8]) -> u64 {
-    bytes.iter().fold(0xcbf29ce484222325, |hash, byte| {
-        (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
-    })
 }

--- a/packages/unpack/test/e2e.test.ts
+++ b/packages/unpack/test/e2e.test.ts
@@ -62,6 +62,12 @@ async function runBundleExecutionCase(bundleCase: BundleExecutionCase) {
 
     assert.equal(err, null);
     assert.equal(stats?.hasErrors(), false);
+    assert.ok(
+      stats?.toJson().assets.some((asset) => asset.name === (bundleCase.entryAsset ?? defaultEntryAsset))
+    );
+    assert.ok(
+      (await readdir(outputPath)).includes(bundleCase.entryAsset ?? defaultEntryAsset)
+    );
 
     const result = await executeEntryExpression(
       outputPath,


### PR DESCRIPTION
Closes #140

Introduces owned, explicit module-runtime Code Generation inputs and results with exact dependency-template validation inputs.

Separates per-Asset render manifests, reusable rendered sources, and final filename/source-map/Asset bookkeeping with stable render keys. Graph rebuilds invalidate generated work, while Rust and public JavaScript tests preserve runtime, async chunk, and sourcemap behavior.