### PR TITLE
Switch persistent cache to PackFile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,15 +80,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cbor4ii"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faed1a83001dc2c9201451030cc317e35bef36c84d3781d7c5bb9f343c397da8"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,7 +1302,6 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 name = "unpack_core"
 version = "0.1.0"
 dependencies = [
- "cbor4ii",
  "codspeed-divan-compat",
  "filetime",
  "futures",
@@ -1319,7 +1309,7 @@ dependencies = [
  "rspack_resolver",
  "rspack_sources",
  "serde",
- "serde_json",
+ "simd-json",
  "swc_experimental_allocator",
  "swc_experimental_ecma_ast",
  "swc_experimental_ecma_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT"
 repository = "https://github.com/unpack-dev/unpack"
 
 [workspace.dependencies]
-cbor4ii = { version = "1.2.2", features = ["serde1"] }
 divan = { package = "codspeed-divan-compat", version = "5.0.1" }
 futures = "0.3.31"
 filetime = "0.2.26"
@@ -20,7 +19,7 @@ regex = "1.12.2"
 rspack_resolver = { version = "0.9.3", default-features = false }
 rspack_sources = "0.101.1"
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
+simd-json = "0.17.0"
 swc_experimental_allocator = "0.11.0"
 swc_experimental_ecma_ast = "0.11.0"
 swc_experimental_ecma_parser = "0.11.0"

--- a/crates/unpack_core/Cargo.toml
+++ b/crates/unpack_core/Cargo.toml
@@ -6,13 +6,12 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-cbor4ii = { workspace = true }
 futures = { workspace = true }
 regex = { workspace = true }
 rspack_resolver = { workspace = true }
 rspack_sources = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
+simd-json = { workspace = true }
 swc_experimental_allocator = { workspace = true }
 swc_experimental_ecma_ast = { workspace = true }
 swc_experimental_ecma_parser = { workspace = true }

--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -1,7 +1,7 @@
 use std::{
     any::Any,
     collections::{BTreeSet, HashMap},
-    fmt, fs, io,
+    fmt, io,
     marker::PhantomData,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
@@ -10,15 +10,15 @@ use std::{
 use crate::{
     ModuleIdentity, SnapshotOptions, SnapshotStrategy,
     cache_hash::stable_hash,
+    pack_file::{
+        CodecRegistry, ModuleBuildRecordCodec, ModuleBuildRecordDto, PackFile, PackFileAddress,
+        PackFileETag, PackFileGuardDto, PackFileWriteBatch, PublicationBase, ResolveRecordCodec,
+        ResolveRecordDto, SnapshotDto,
+    },
     parser::ParsedModule,
     snapshot::{FileSystemInfo, Snapshot, SnapshotCache},
 };
-use serde::{Deserialize, Serialize};
 
-const CACHE_MAGIC: &str = "UNPACK_PERSISTENT_CACHE";
-const PACK_MAGIC: &[u8] = b"UNPACK-CACHE-PACK\0";
-const DEFAULT_PACK_FILE: &str = "packs/modules.cbor";
-const MANIFEST_FILE: &str = "container.json";
 const RESOLVE_CACHE_NAMESPACE: CacheNamespace = CacheNamespace::new("unpack/resolve");
 const MODULE_BUILD_CACHE_NAMESPACE: CacheNamespace = CacheNamespace::new("unpack/module-build");
 
@@ -49,6 +49,10 @@ impl CacheNamespace {
     pub(crate) const fn new(value: &'static str) -> Self {
         Self(value)
     }
+
+    const fn as_str(self) -> &'static str {
+        self.0
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -68,6 +72,10 @@ impl CacheIdentifier {
         }
         Self(bytes)
     }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -77,6 +85,10 @@ impl CacheETag {
     #[allow(dead_code)]
     pub(crate) fn new(value: impl AsRef<[u8]>) -> Self {
         Self(value.as_ref().to_vec())
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.0
     }
 }
 
@@ -95,7 +107,6 @@ pub(crate) enum CacheItemFamily {
 }
 
 impl CacheItemFamily {
-    #[cfg(test)]
     const fn index(self) -> usize {
         match self {
             Self::Resolve => 0,
@@ -106,7 +117,6 @@ impl CacheItemFamily {
     }
 }
 
-#[cfg(test)]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct CacheItemWork {
     pub hits: usize,
@@ -116,13 +126,11 @@ pub(crate) struct CacheItemWork {
     pub evictions: usize,
 }
 
-#[cfg(test)]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct CacheWorkCounters {
     by_family: [CacheItemWork; 4],
 }
 
-#[cfg(test)]
 impl CacheWorkCounters {
     pub(crate) fn for_family(self, family: CacheItemFamily) -> CacheItemWork {
         self.by_family[family.index()]
@@ -212,17 +220,23 @@ pub struct BuildDependency {
 #[derive(Debug)]
 struct BuildCacheInner {
     cache: Cache,
-    filesystem_manifest: Option<CacheManifest>,
-    records_restored: bool,
     dirty: bool,
 }
 
 impl BuildCacheInner {
-    fn new(options: &CacheOptions) -> Self {
+    fn new(
+        options: &CacheOptions,
+        file_system_info: &FileSystemInfo,
+        build_dependency_snapshot_strategy: SnapshotStrategy,
+        resolve_build_dependency_snapshot_strategy: SnapshotStrategy,
+    ) -> Self {
         Self {
-            cache: Cache::from_options(options),
-            filesystem_manifest: None,
-            records_restored: false,
+            cache: Cache::from_options(
+                options,
+                file_system_info,
+                build_dependency_snapshot_strategy,
+                resolve_build_dependency_snapshot_strategy,
+            ),
             dirty: false,
         }
     }
@@ -234,30 +248,35 @@ struct CacheAddress {
     identifier: CacheIdentifier,
 }
 
+impl CacheAddress {
+    fn to_pack_file_address(&self) -> PackFileAddress {
+        PackFileAddress::new(self.namespace.as_str(), self.identifier.as_bytes())
+    }
+}
+
+impl CacheETag {
+    fn to_pack_file_etag(&self) -> PackFileETag {
+        PackFileETag::new(self.as_bytes())
+    }
+}
+
 #[derive(Clone)]
 struct CacheEntry {
     family: CacheItemFamily,
     etag: Option<CacheETag>,
-    source_key: Arc<dyn Any + Send + Sync>,
     value: Arc<dyn Any + Send + Sync>,
 }
 
 impl CacheEntry {
-    fn new<K, V>(family: CacheItemFamily, etag: Option<CacheETag>, key: K, value: V) -> Self
+    fn new<V>(family: CacheItemFamily, etag: Option<CacheETag>, value: V) -> Self
     where
-        K: Send + Sync + 'static,
         V: Send + Sync + 'static,
     {
         Self {
             family,
             etag,
-            source_key: Arc::new(key),
             value: Arc::new(value),
         }
-    }
-
-    fn key<K: Send + Sync + 'static>(&self) -> Option<&K> {
-        self.source_key.downcast_ref::<K>()
     }
 
     fn value<V: Send + Sync + 'static>(&self) -> Option<Arc<V>> {
@@ -276,11 +295,15 @@ impl fmt::Debug for CacheEntry {
 }
 
 trait CacheLayer: fmt::Debug + Send + Sync {
-    fn get(&self, address: &CacheAddress, etag: Option<&CacheETag>) -> Option<CacheEntry>;
+    fn get(&mut self, address: &CacheAddress, etag: Option<&CacheETag>) -> Option<CacheEntry>;
     fn store(&mut self, address: CacheAddress, entry: CacheEntry);
+    fn publish(&mut self, _guard: &PackFileGuardDto) -> io::Result<()> {
+        Ok(())
+    }
     #[allow(dead_code)]
     fn evict(&mut self, address: &CacheAddress) -> bool;
-    fn entries(&self) -> Vec<(CacheAddress, CacheEntry)>;
+    #[cfg(test)]
+    fn entry_count(&self, family: CacheItemFamily) -> usize;
 }
 
 #[derive(Debug, Default)]
@@ -289,7 +312,7 @@ struct MemoryCacheLayer {
 }
 
 impl CacheLayer for MemoryCacheLayer {
-    fn get(&self, address: &CacheAddress, etag: Option<&CacheETag>) -> Option<CacheEntry> {
+    fn get(&mut self, address: &CacheAddress, etag: Option<&CacheETag>) -> Option<CacheEntry> {
         self.entries
             .get(address)
             .filter(|entry| entry.etag.as_ref() == etag)
@@ -304,11 +327,169 @@ impl CacheLayer for MemoryCacheLayer {
         self.entries.remove(address).is_some()
     }
 
-    fn entries(&self) -> Vec<(CacheAddress, CacheEntry)> {
+    #[cfg(test)]
+    fn entry_count(&self, family: CacheItemFamily) -> usize {
         self.entries
-            .iter()
-            .map(|(address, entry)| (address.clone(), entry.clone()))
-            .collect()
+            .values()
+            .filter(|entry| entry.family == family)
+            .count()
+    }
+}
+
+#[derive(Debug)]
+struct PackFileCacheLayer {
+    root: Option<PathBuf>,
+    registry: CodecRegistry,
+    pack_file: Option<PackFile>,
+    publication_base: PublicationBase,
+    active: bool,
+    pending: HashMap<CacheAddress, CacheEntry>,
+}
+
+impl PackFileCacheLayer {
+    fn open(
+        options: &CacheOptions,
+        file_system_info: &FileSystemInfo,
+        build_dependency_snapshot_strategy: SnapshotStrategy,
+        resolve_build_dependency_snapshot_strategy: SnapshotStrategy,
+    ) -> Self {
+        let registry = persistent_codec_registry();
+        let root = options.cache_location.clone();
+        let pack_file = root
+            .as_ref()
+            .map(|root| PackFile::open(root, registry.clone()));
+        let active = pack_file.as_ref().is_some_and(|pack_file| {
+            pack_file.guard().is_some_and(|guard| {
+                persistent_guard_is_valid(
+                    guard,
+                    options,
+                    file_system_info,
+                    build_dependency_snapshot_strategy,
+                    resolve_build_dependency_snapshot_strategy,
+                )
+            })
+        });
+        let publication_base = if active {
+            PublicationBase::PreserveEntries {
+                expected_revision: pack_file
+                    .as_ref()
+                    .expect("active PackFile should be open")
+                    .revision(),
+            }
+        } else {
+            PublicationBase::ReplaceAll
+        };
+        Self {
+            root,
+            registry,
+            pack_file,
+            publication_base,
+            active,
+            pending: HashMap::new(),
+        }
+    }
+
+    fn publish(&mut self, guard: PackFileGuardDto) -> io::Result<()> {
+        let Some(root) = self.root.as_ref() else {
+            self.pending.clear();
+            return Ok(());
+        };
+        let mut batch = PackFileWriteBatch::new();
+        for (address, entry) in &self.pending {
+            let pack_address = address.to_pack_file_address();
+            let pack_etag = entry.etag.as_ref().map(CacheETag::to_pack_file_etag);
+            match entry.family {
+                CacheItemFamily::Resolve => {
+                    let record = entry.value::<ResolveRecord>().ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "Resolve Cache Item contains an unexpected value",
+                        )
+                    })?;
+                    let dto = ResolveRecordDto::try_from(record.as_ref())?;
+                    batch.insert(&self.registry, pack_address, pack_etag, dto)?;
+                }
+                CacheItemFamily::ModuleBuild => {
+                    let record = entry.value::<ModuleBuildRecord>().ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "Module Build Cache Item contains an unexpected value",
+                        )
+                    })?;
+                    let dto = ModuleBuildRecordDto::try_from(record.as_ref())?;
+                    batch.insert(&self.registry, pack_address, pack_etag, dto)?;
+                }
+                CacheItemFamily::CodeGeneration | CacheItemFamily::AssetRender => continue,
+            }
+        }
+        PackFile::publish_batch(root, Some(guard), self.publication_base, batch)?;
+        self.pending.clear();
+        let pack_file = PackFile::open(root, self.registry.clone());
+        self.publication_base = PublicationBase::PreserveEntries {
+            expected_revision: pack_file.revision(),
+        };
+        self.pack_file = Some(pack_file);
+        self.active = true;
+        Ok(())
+    }
+}
+
+impl CacheLayer for PackFileCacheLayer {
+    fn get(&mut self, address: &CacheAddress, etag: Option<&CacheETag>) -> Option<CacheEntry> {
+        if let Some(entry) = self
+            .pending
+            .get(address)
+            .filter(|entry| entry.etag.as_ref() == etag)
+        {
+            return Some(entry.clone());
+        }
+        if !self.active {
+            return None;
+        }
+        let pack_file = self.pack_file.as_mut()?;
+        let pack_address = address.to_pack_file_address();
+        let pack_etag = etag.map(CacheETag::to_pack_file_etag);
+        match address.namespace {
+            RESOLVE_CACHE_NAMESPACE => {
+                let dto = pack_file.get_resolve_record(&pack_address, pack_etag.as_ref())?;
+                let record = ResolveRecord::try_from((*dto).clone()).ok()?;
+                Some(CacheEntry::new(
+                    CacheItemFamily::Resolve,
+                    etag.cloned(),
+                    record,
+                ))
+            }
+            MODULE_BUILD_CACHE_NAMESPACE => {
+                let dto = pack_file.get_module_build_record(&pack_address, pack_etag.as_ref())?;
+                let record = ModuleBuildRecord::try_from((*dto).clone()).ok()?;
+                Some(CacheEntry::new(
+                    CacheItemFamily::ModuleBuild,
+                    etag.cloned(),
+                    record,
+                ))
+            }
+            _ => None,
+        }
+    }
+
+    fn store(&mut self, address: CacheAddress, entry: CacheEntry) {
+        self.pending.insert(address, entry);
+    }
+
+    fn publish(&mut self, guard: &PackFileGuardDto) -> io::Result<()> {
+        PackFileCacheLayer::publish(self, guard.clone())
+    }
+
+    fn evict(&mut self, address: &CacheAddress) -> bool {
+        self.pending.remove(address).is_some()
+    }
+
+    #[cfg(test)]
+    fn entry_count(&self, family: CacheItemFamily) -> usize {
+        self.pending
+            .values()
+            .filter(|entry| entry.family == family)
+            .count()
     }
 }
 
@@ -328,12 +509,16 @@ struct CacheLayerSlot {
 #[derive(Debug)]
 struct Cache {
     layers: Vec<CacheLayerSlot>,
-    #[cfg(test)]
     work: CacheWorkCounters,
 }
 
 impl Cache {
-    fn from_options(options: &CacheOptions) -> Self {
+    fn from_options(
+        options: &CacheOptions,
+        file_system_info: &FileSystemInfo,
+        build_dependency_snapshot_strategy: SnapshotStrategy,
+        resolve_build_dependency_snapshot_strategy: SnapshotStrategy,
+    ) -> Self {
         let mut layers = Vec::new();
         if options.kind != CacheKind::Disabled {
             layers.push(CacheLayerSlot {
@@ -346,19 +531,23 @@ impl Cache {
             layers.push(CacheLayerSlot {
                 kind: CacheLayerKind::Persistent,
                 writable: !options.readonly,
-                layer: Box::<MemoryCacheLayer>::default(),
+                layer: Box::new(PackFileCacheLayer::open(
+                    options,
+                    file_system_info,
+                    build_dependency_snapshot_strategy,
+                    resolve_build_dependency_snapshot_strategy,
+                )),
             });
         }
         Self {
             layers,
-            #[cfg(test)]
             work: CacheWorkCounters::default(),
         }
     }
 
     fn get<V>(
         &mut self,
-        _family: CacheItemFamily,
+        family: CacheItemFamily,
         address: &CacheAddress,
         etag: Option<&CacheETag>,
     ) -> Option<Arc<V>>
@@ -380,38 +569,27 @@ impl Cache {
                         earlier.layer.store(address.clone(), entry.clone());
                     }
                 }
-                #[cfg(test)]
-                {
-                    self.work.for_family_mut(_family).restores += 1;
-                }
+                self.work.for_family_mut(family).restores += 1;
             }
-            #[cfg(test)]
-            {
-                self.work.for_family_mut(_family).hits += 1;
-            }
+            self.work.for_family_mut(family).hits += 1;
             return Some(value);
         }
 
-        #[cfg(test)]
-        {
-            self.work.for_family_mut(_family).misses += 1;
-        }
+        self.work.for_family_mut(family).misses += 1;
         None
     }
 
-    fn store<K, V>(
+    fn store<V>(
         &mut self,
         family: CacheItemFamily,
         address: CacheAddress,
         etag: Option<CacheETag>,
-        key: K,
         value: V,
     ) -> bool
     where
-        K: Send + Sync + 'static,
         V: Send + Sync + 'static,
     {
-        let entry = CacheEntry::new(family, etag, key, value);
+        let entry = CacheEntry::new(family, etag, value);
         let mut stored_persistently = false;
         for slot in &mut self.layers {
             if !slot.writable {
@@ -420,45 +598,8 @@ impl Cache {
             slot.layer.store(address.clone(), entry.clone());
             stored_persistently |= slot.kind == CacheLayerKind::Persistent;
         }
-        #[cfg(test)]
-        {
-            self.work.for_family_mut(family).stores += 1;
-        }
+        self.work.for_family_mut(family).stores += 1;
         stored_persistently
-    }
-
-    fn restore<K, V>(
-        &mut self,
-        family: CacheItemFamily,
-        namespace: CacheNamespace,
-        identifier: CacheIdentifier,
-        etag: Option<CacheETag>,
-        key: K,
-        value: V,
-    ) where
-        K: Send + Sync + 'static,
-        V: Send + Sync + 'static,
-    {
-        let address = CacheAddress {
-            namespace,
-            identifier,
-        };
-        let entry = CacheEntry::new(family, etag, key, value);
-        if let Some(persistent) = self
-            .layers
-            .iter_mut()
-            .find(|slot| slot.kind == CacheLayerKind::Persistent)
-        {
-            persistent.layer.store(address, entry);
-        }
-    }
-
-    fn persistent_entries(&self) -> Vec<(CacheAddress, CacheEntry)> {
-        self.layers
-            .iter()
-            .find(|slot| slot.kind == CacheLayerKind::Persistent)
-            .map(|slot| slot.layer.entries())
-            .unwrap_or_default()
     }
 
     #[cfg(test)]
@@ -477,19 +618,28 @@ impl Cache {
     fn entry_count(&self, family: CacheItemFamily) -> usize {
         self.layers
             .iter()
-            .flat_map(|slot| slot.layer.entries())
-            .filter_map(|(address, entry)| (entry.family == family).then_some(address))
-            .collect::<std::collections::HashSet<_>>()
-            .len()
+            .find(|slot| slot.kind == CacheLayerKind::Memory)
+            .map(|slot| slot.layer.entry_count(family))
+            .unwrap_or_default()
     }
 
-    #[cfg(test)]
     fn work_counters(&self) -> CacheWorkCounters {
         self.work
     }
+
+    fn publish_persistent(&mut self, guard: PackFileGuardDto) -> io::Result<()> {
+        let Some(slot) = self
+            .layers
+            .iter_mut()
+            .find(|slot| slot.kind == CacheLayerKind::Persistent)
+        else {
+            return Ok(());
+        };
+        slot.layer.publish(&guard)
+    }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct ResolveRequest {
     context: PathBuf,
     request: String,
@@ -542,7 +692,7 @@ fn optional_identifier_part(value: Option<&str>) -> Vec<u8> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ResolveRecord {
     identity: ModuleIdentity,
     resource: PathBuf,
@@ -553,6 +703,7 @@ pub(crate) struct ResolveRecord {
 }
 
 impl ResolveRecord {
+    #[cfg(test)]
     pub(crate) fn to_pack_file_dto(&self) -> crate::pack_file::ResolveRecordDto {
         use crate::pack_file::{ModuleIdentityDto, ModuleTypeDto, PathBytes, ResolveRecordDto};
 
@@ -587,6 +738,7 @@ impl ResolveRecord {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn from_pack_file_dto(dto: crate::pack_file::ResolveRecordDto) -> Option<Self> {
         use crate::pack_file::{ModuleTypeDto, ResolveRecordDto};
 
@@ -703,6 +855,28 @@ impl ResolveRecord {
         &self.missing_dependencies
     }
 
+    pub(crate) fn snapshot(&self) -> &Snapshot {
+        &self.snapshot
+    }
+
+    pub(crate) fn from_persistent_parts(
+        identity: ModuleIdentity,
+        resource: PathBuf,
+        file_dependencies: BTreeSet<PathBuf>,
+        context_dependencies: BTreeSet<PathBuf>,
+        missing_dependencies: BTreeSet<PathBuf>,
+        snapshot: Snapshot,
+    ) -> Self {
+        Self {
+            identity,
+            resource,
+            file_dependencies,
+            context_dependencies,
+            missing_dependencies,
+            snapshot,
+        }
+    }
+
     #[cfg(test)]
     pub(crate) async fn is_valid(
         &self,
@@ -726,11 +900,10 @@ impl ResolveRecord {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ModuleBuildRecord {
     parsed: ParsedModule,
     source: String,
-    #[serde(default)]
     source_hash: Option<u64>,
     snapshot: Snapshot,
 }
@@ -758,6 +931,10 @@ impl ModuleBuildRecord {
         self.source_hash
     }
 
+    pub(crate) fn snapshot(&self) -> &Snapshot {
+        &self.snapshot
+    }
+
     pub(crate) async fn is_valid_with_cache(
         &self,
         file_system_info: &FileSystemInfo,
@@ -775,16 +952,20 @@ impl BuildCache {
         let build_dependency_snapshot_strategy = snapshot_options.build_dependencies;
         let resolve_build_dependency_snapshot_strategy =
             snapshot_options.resolve_build_dependencies;
-        let inner = BuildCacheInner::new(&options);
-        let cache = Self {
+        let file_system_info = FileSystemInfo::from_snapshot_options(&snapshot_options);
+        let inner = BuildCacheInner::new(
+            &options,
+            &file_system_info,
+            build_dependency_snapshot_strategy,
+            resolve_build_dependency_snapshot_strategy,
+        );
+        Self {
             options,
             build_dependency_snapshot_strategy,
             resolve_build_dependency_snapshot_strategy,
-            file_system_info: FileSystemInfo::from_snapshot_options(&snapshot_options),
+            file_system_info,
             inner: Arc::new(Mutex::new(inner)),
-        };
-        cache.restore_from_filesystem();
-        cache
+        }
     }
 
     pub(crate) fn normal_module_factory(&self) -> NormalModuleFactoryCache {
@@ -813,23 +994,21 @@ impl BuildCache {
             return Ok(());
         }
 
-        let (resolve_records, module_builds) = {
-            let inner = self
-                .inner
-                .lock()
-                .expect("build cache mutex should not be poisoned");
-            if !inner.dirty {
-                return Ok(());
-            }
-            legacy_filesystem_records(&inner.cache)
-        };
-
-        self.write_filesystem_cache(&resolve_records, &module_builds)?;
-
-        self.inner
+        if !self
+            .inner
             .lock()
             .expect("build cache mutex should not be poisoned")
-            .dirty = false;
+            .dirty
+        {
+            return Ok(());
+        }
+        let guard = self.current_persistent_guard()?;
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("build cache mutex should not be poisoned");
+        inner.cache.publish_persistent(guard)?;
+        inner.dirty = false;
         Ok(())
     }
 
@@ -852,13 +1031,44 @@ impl BuildCache {
         }
     }
 
-    #[cfg(test)]
     pub(crate) fn work_counters(&self) -> CacheWorkCounters {
         self.inner
             .lock()
             .expect("build cache mutex should not be poisoned")
             .cache
             .work_counters()
+    }
+
+    pub(crate) fn trace_work_counters(&self) {
+        let work = self.work_counters();
+        let resolve = work.for_family(CacheItemFamily::Resolve);
+        let module = work.for_family(CacheItemFamily::ModuleBuild);
+        tracing::info!(
+            target: "unpack_core::cache_work",
+            resolve_hits = resolve.hits,
+            resolve_misses = resolve.misses,
+            resolve_stores = resolve.stores,
+            resolve_restores = resolve.restores,
+            resolve_evictions = resolve.evictions,
+            module_hits = module.hits,
+            module_misses = module.misses,
+            module_stores = module.stores,
+            module_restores = module.restores,
+            module_evictions = module.evictions,
+            "cache_work"
+        );
+    }
+
+    fn current_persistent_guard(&self) -> io::Result<PackFileGuardDto> {
+        Ok(PackFileGuardDto {
+            version: self.cache_version().into_bytes(),
+            build_dependencies: SnapshotDto::try_from(
+                &self.build_dependency_snapshot(self.build_dependency_snapshot_strategy)?,
+            )?,
+            resolve_build_dependencies: SnapshotDto::try_from(
+                &self.build_dependency_snapshot(self.resolve_build_dependency_snapshot_strategy)?,
+            )?,
+        })
     }
 }
 
@@ -880,8 +1090,6 @@ where
         if !self.is_enabled() {
             return None;
         }
-
-        self.build_cache.restore_records_from_filesystem_if_needed();
 
         let mut inner = self
             .build_cache
@@ -909,7 +1117,7 @@ where
             namespace: self.namespace,
             identifier: key.cache_identifier(),
         };
-        if inner.cache.store(self.family, address, etag, key, value) {
+        if inner.cache.store(self.family, address, etag, value) {
             inner.dirty = true;
         }
     }
@@ -930,161 +1138,6 @@ where
 }
 
 impl BuildCache {
-    fn restore_from_filesystem(&self) {
-        if self.options.kind != CacheKind::Filesystem {
-            return;
-        }
-        let Some(cache_location) = &self.options.cache_location else {
-            return;
-        };
-        let Some(manifest) = read_manifest(cache_location) else {
-            return;
-        };
-        if !self.manifest_is_valid(&manifest) {
-            return;
-        }
-
-        let mut inner = self
-            .inner
-            .lock()
-            .expect("build cache mutex should not be poisoned");
-        inner.filesystem_manifest = Some(manifest.clone());
-        drop(inner);
-
-        if !self.options.readonly {
-            self.restore_records_from_filesystem_if_needed();
-        }
-    }
-
-    fn restore_records_from_filesystem_if_needed(&self) {
-        if self.options.kind != CacheKind::Filesystem {
-            return;
-        }
-        let Some(cache_location) = &self.options.cache_location else {
-            self.mark_records_restored();
-            return;
-        };
-        let manifest = {
-            let inner = self
-                .inner
-                .lock()
-                .expect("build cache mutex should not be poisoned");
-            if inner.records_restored {
-                return;
-            }
-            inner.filesystem_manifest.clone()
-        };
-        let Some(manifest) = manifest else {
-            self.mark_records_restored();
-            return;
-        };
-
-        let Some(pack) = read_pack(cache_location, &manifest.pack_file) else {
-            self.mark_records_restored();
-            return;
-        };
-        if pack.magic != CACHE_MAGIC || pack.cache_version != self.cache_version() {
-            self.mark_records_restored();
-            return;
-        }
-
-        let mut inner = self
-            .inner
-            .lock()
-            .expect("build cache mutex should not be poisoned");
-        for (request, record) in pack.resolve_records {
-            inner.cache.restore(
-                CacheItemFamily::Resolve,
-                RESOLVE_CACHE_NAMESPACE,
-                request.cache_identifier(),
-                None,
-                request,
-                record,
-            );
-        }
-        for (identity, record) in pack.module_builds {
-            inner.cache.restore(
-                CacheItemFamily::ModuleBuild,
-                MODULE_BUILD_CACHE_NAMESPACE,
-                identity.cache_identifier(),
-                None,
-                identity,
-                record,
-            );
-        }
-        inner.records_restored = true;
-    }
-
-    fn mark_records_restored(&self) {
-        self.inner
-            .lock()
-            .expect("build cache mutex should not be poisoned")
-            .records_restored = true;
-    }
-
-    fn write_filesystem_cache(
-        &self,
-        resolve_records: &HashMap<ResolveRequest, Arc<ResolveRecord>>,
-        module_builds: &HashMap<ModuleIdentity, Arc<ModuleBuildRecord>>,
-    ) -> io::Result<()> {
-        let Some(cache_location) = &self.options.cache_location else {
-            return Ok(());
-        };
-
-        let pack_file = PathBuf::from(DEFAULT_PACK_FILE);
-        let pack_path = cache_location.join(&pack_file);
-        if let Some(parent) = pack_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-
-        let cache_version = self.cache_version();
-        let pack = CachePackDto {
-            magic: CACHE_MAGIC.to_string(),
-            cache_version: cache_version.clone(),
-            resolve_records: resolve_records
-                .iter()
-                .map(|(request, record)| (request.clone(), (**record).clone()))
-                .collect(),
-            module_builds: module_builds
-                .iter()
-                .map(|(identity, record)| (identity.clone(), (**record).clone()))
-                .collect(),
-        };
-        let pack_payload = cbor4ii::serde::to_vec(Vec::new(), &pack)
-            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
-        let mut pack_bytes = PACK_MAGIC.to_vec();
-        pack_bytes.extend(pack_payload);
-        fs::write(pack_path, pack_bytes)?;
-
-        let manifest = CacheManifest {
-            magic: CACHE_MAGIC.to_string(),
-            cache_version,
-            pack_file: pack_file.to_string_lossy().replace('\\', "/"),
-            build_dependencies: self
-                .build_dependency_snapshot(self.build_dependency_snapshot_strategy)?,
-            resolve_build_dependencies: self
-                .build_dependency_snapshot(self.resolve_build_dependency_snapshot_strategy)?,
-        };
-        fs::create_dir_all(cache_location)?;
-        let manifest_json = serde_json::to_vec_pretty(&manifest)
-            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
-        fs::write(cache_location.join(MANIFEST_FILE), manifest_json)?;
-        Ok(())
-    }
-
-    fn manifest_is_valid(&self, manifest: &CacheManifest) -> bool {
-        manifest.magic == CACHE_MAGIC
-            && manifest.cache_version == self.cache_version()
-            && self.build_dependency_snapshot_is_valid(
-                &manifest.build_dependencies,
-                self.build_dependency_snapshot_strategy,
-            )
-            && self.build_dependency_snapshot_is_valid(
-                &manifest.resolve_build_dependencies,
-                self.resolve_build_dependency_snapshot_strategy,
-            )
-    }
-
     fn cache_version(&self) -> String {
         self.options.version.clone().unwrap_or_default()
     }
@@ -1103,85 +1156,45 @@ impl BuildCache {
 
         Ok(self.file_system_info.merge_snapshots(snapshots.iter()))
     }
+}
 
-    fn build_dependency_snapshot_is_valid(
-        &self,
-        snapshot: &Snapshot,
-        strategy: SnapshotStrategy,
-    ) -> bool {
-        snapshot.has_exact_paths(self.build_dependency_paths())
-            && self
-                .file_system_info
-                .is_snapshot_valid_sync(snapshot, strategy)
+fn persistent_codec_registry() -> CodecRegistry {
+    CodecRegistry::new()
+        .with_resolve_record(ResolveRecordCodec::current())
+        .with_module_build_record(ModuleBuildRecordCodec::current())
+}
+
+fn persistent_guard_is_valid(
+    guard: &PackFileGuardDto,
+    options: &CacheOptions,
+    file_system_info: &FileSystemInfo,
+    build_dependency_snapshot_strategy: SnapshotStrategy,
+    resolve_build_dependency_snapshot_strategy: SnapshotStrategy,
+) -> bool {
+    if guard.version != options.version.clone().unwrap_or_default().as_bytes() {
+        return false;
     }
-
-    fn build_dependency_paths(&self) -> Vec<PathBuf> {
-        self.options
-            .build_dependencies
-            .iter()
-            .flat_map(|dependency| dependency.files.iter().cloned())
-            .collect()
-    }
-}
-
-fn legacy_filesystem_records(
-    cache: &Cache,
-) -> (
-    HashMap<ResolveRequest, Arc<ResolveRecord>>,
-    HashMap<ModuleIdentity, Arc<ModuleBuildRecord>>,
-) {
-    let mut resolve_records = HashMap::new();
-    let mut module_builds = HashMap::new();
-    for (_, entry) in cache.persistent_entries() {
-        match entry.family {
-            CacheItemFamily::Resolve => {
-                if let (Some(key), Some(value)) = (
-                    entry.key::<ResolveRequest>(),
-                    entry.value::<ResolveRecord>(),
-                ) {
-                    resolve_records.insert(key.clone(), value);
-                }
-            }
-            CacheItemFamily::ModuleBuild => {
-                if let (Some(key), Some(value)) = (
-                    entry.key::<ModuleIdentity>(),
-                    entry.value::<ModuleBuildRecord>(),
-                ) {
-                    module_builds.insert(key.clone(), value);
-                }
-            }
-            CacheItemFamily::CodeGeneration | CacheItemFamily::AssetRender => {}
-        }
-    }
-    (resolve_records, module_builds)
-}
-
-fn read_manifest(cache_location: &Path) -> Option<CacheManifest> {
-    let bytes = fs::read(cache_location.join(MANIFEST_FILE)).ok()?;
-    serde_json::from_slice(&bytes).ok()
-}
-
-fn read_pack(cache_location: &Path, pack_file: &str) -> Option<CachePackDto> {
-    let bytes = fs::read(cache_location.join(pack_file)).ok()?;
-    let payload = bytes.strip_prefix(PACK_MAGIC)?;
-    cbor4ii::serde::from_slice(payload).ok()
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct CacheManifest {
-    magic: String,
-    cache_version: String,
-    pack_file: String,
-    build_dependencies: Snapshot,
-    resolve_build_dependencies: Snapshot,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct CachePackDto {
-    magic: String,
-    cache_version: String,
-    resolve_records: Vec<(ResolveRequest, ResolveRecord)>,
-    module_builds: Vec<(ModuleIdentity, ModuleBuildRecord)>,
+    let Ok(build_dependencies) = Snapshot::try_from(guard.build_dependencies.clone()) else {
+        return false;
+    };
+    let Ok(resolve_build_dependencies) =
+        Snapshot::try_from(guard.resolve_build_dependencies.clone())
+    else {
+        return false;
+    };
+    let paths = options
+        .build_dependencies
+        .iter()
+        .flat_map(|dependency| dependency.files.iter().cloned())
+        .collect::<Vec<_>>();
+    build_dependencies.has_exact_paths(paths.clone())
+        && file_system_info
+            .is_snapshot_valid_sync(&build_dependencies, build_dependency_snapshot_strategy)
+        && resolve_build_dependencies.has_exact_paths(paths)
+        && file_system_info.is_snapshot_valid_sync(
+            &resolve_build_dependencies,
+            resolve_build_dependency_snapshot_strategy,
+        )
 }
 
 #[cfg(test)]
@@ -1352,26 +1365,6 @@ mod tests {
                 evictions: 1,
             }
         );
-    }
-
-    #[test]
-    fn module_build_record_without_source_hash_deserializes_with_empty_hash()
-    -> std::result::Result<(), Box<dyn std::error::Error>> {
-        let record: ModuleBuildRecord = serde_json::from_value(serde_json::json!({
-            "parsed": {
-                "dependencies": [],
-                "blocks": [],
-                "presentational_dependencies": []
-            },
-            "source": "export const value = 1;",
-            "snapshot": {
-                "entries": []
-            }
-        }))?;
-
-        assert_eq!(record.source_hash(), None);
-
-        Ok(())
     }
 
     #[tokio::test]

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -78,7 +78,7 @@ impl Compiler {
     }
 
     pub async fn run(&self) -> Result<Compilation> {
-        async {
+        let result = async {
             let mut compilation = self.create_compilation();
             compilation.make().await?;
             compilation.build_chunk_graph();
@@ -87,7 +87,9 @@ impl Compiler {
             Ok(compilation)
         }
         .instrument(tracing::trace_span!("Compiler::run"))
-        .await
+        .await;
+        self.build_cache.trace_work_counters();
+        result
     }
 
     pub fn flush_cache(&self) -> std::result::Result<(), String> {
@@ -123,7 +125,10 @@ mod tests {
     use std::{collections::BTreeMap, fs, path::Path};
 
     use super::*;
-    use crate::build_cache::{CacheItemFamily, CacheItemWork};
+    use crate::{
+        build_cache::{CacheItemFamily, CacheItemWork},
+        pack_file::PackFile,
+    };
 
     #[tokio::test]
     async fn repeated_runs_reuse_memory_module_build_records_without_sharing_compilations()
@@ -247,6 +252,14 @@ mod tests {
                 .expect("main asset should exist")
                 .contains("after")
         );
+        assert_ne!(
+            first.module_graph().modules().as_ptr(),
+            second.module_graph().modules().as_ptr()
+        );
+        assert_ne!(
+            first.chunk_graph().chunks().as_ptr(),
+            second.chunk_graph().chunks().as_ptr()
+        );
 
         Ok(())
     }
@@ -274,18 +287,13 @@ mod tests {
         let first = first_compiler.run().await?;
         first_compiler.flush_cache()?;
         assert_eq!(first.errors(), []);
-        assert!(cache_location.join("container.json").exists());
-        assert!(cache_location.join("packs/modules.cbor").exists());
-        assert!(!cache_location.join("packs/compilation.cbor").exists());
-        let manifest = fs::read_to_string(cache_location.join("container.json"))?;
-        assert!(manifest.contains("UNPACK_PERSISTENT_CACHE"));
-        assert!(manifest.contains("test-version"));
-        let manifest_json: serde_json::Value = serde_json::from_str(&manifest)?;
-        assert!(manifest_json.get("schema_version").is_none());
+        assert!(PackFile::index_path(&cache_location).exists());
+        assert!(!cache_location.join("container.json").exists());
+        assert!(!cache_location.join("packs/modules.cbor").exists());
 
         let second_compiler = Compiler::new(options);
-        assert_eq!(second_compiler.build_cache.stats().resolve_entries, 2);
-        assert_eq!(second_compiler.build_cache.stats().module_entries, 2);
+        assert_eq!(second_compiler.build_cache.stats().resolve_entries, 0);
+        assert_eq!(second_compiler.build_cache.stats().module_entries, 0);
 
         let second = second_compiler.run().await?;
         let second_cache = second_compiler.build_cache.stats();
@@ -350,48 +358,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn filesystem_cache_readonly_rebuilds_without_module_pack()
-    -> std::result::Result<(), Box<dyn std::error::Error>> {
-        let temp = tempfile::tempdir()?;
-        write(
-            temp.path().join("index.js"),
-            r#"
-                import "./dep";
-                export const result = "ok";
-            "#,
-        )?;
-        write(temp.path().join("dep.js"), "export const value = 1;")?;
-        let cache_temp = tempfile::tempdir()?;
-        let cache_location = cache_temp.path().join("default");
-
-        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
-        options.cache = CacheOptions::filesystem();
-        options.cache.cache_location = Some(cache_location.clone());
-
-        let first_compiler = Compiler::new(options.clone());
-        let first = first_compiler.run().await?;
-        first_compiler.flush_cache()?;
-
-        let module_pack = cache_location.join("packs/modules.cbor");
-        assert!(module_pack.exists());
-        assert!(!cache_location.join("packs/compilation.cbor").exists());
-        fs::remove_file(module_pack)?;
-
-        let mut readonly_options = options;
-        readonly_options.cache.readonly = true;
-        let readonly_compiler = Compiler::new(readonly_options);
-        assert_eq!(readonly_compiler.build_cache.stats().resolve_entries, 0);
-        assert_eq!(readonly_compiler.build_cache.stats().module_entries, 0);
-
-        let second = readonly_compiler.run().await?;
-        assert_eq!(asset_sources(&first), asset_sources(&second));
-        assert_eq!(readonly_compiler.build_cache.stats().resolve_entries, 2);
-        assert_eq!(readonly_compiler.build_cache.stats().module_entries, 2);
-
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn filesystem_cache_readonly_restores_but_skips_persistent_updates()
     -> std::result::Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
@@ -413,10 +379,7 @@ mod tests {
         let first_compiler = Compiler::new(options.clone());
         first_compiler.run().await?;
         first_compiler.flush_cache()?;
-        let manifest_path = cache_location.join("container.json");
-        let pack_path = cache_location.join("packs/modules.cbor");
-        let manifest_before = fs::read(&manifest_path)?;
-        let pack_before = fs::read(&pack_path)?;
+        let cache_before = directory_snapshot(&cache_location)?;
 
         write(temp.path().join("dep.js"), "export const value = 'after';")?;
 
@@ -437,8 +400,7 @@ mod tests {
                 .expect("main asset should exist")
                 .contains("after")
         );
-        assert_eq!(fs::read(&manifest_path)?, manifest_before);
-        assert_eq!(fs::read(&pack_path)?, pack_before);
+        assert_eq!(directory_snapshot(&cache_location)?, cache_before);
 
         Ok(())
     }
@@ -459,8 +421,7 @@ mod tests {
         compiler.run().await?;
         compiler.flush_cache()?;
 
-        assert!(!cache_location.join("container.json").exists());
-        assert!(!cache_location.join("packs/modules.cbor").exists());
+        assert!(!cache_location.exists());
 
         Ok(())
     }
@@ -485,16 +446,38 @@ mod tests {
         let first_compiler = Compiler::new(options.clone());
         first_compiler.run().await?;
         first_compiler.flush_cache()?;
+        let warm_compiler = Compiler::new(options.clone());
+        warm_compiler.run().await?;
         assert_eq!(
-            Compiler::new(options.clone())
+            warm_compiler
                 .build_cache
-                .stats()
-                .module_entries,
-            1
+                .work_counters()
+                .for_family(CacheItemFamily::ModuleBuild),
+            CacheItemWork {
+                hits: 1,
+                misses: 0,
+                stores: 0,
+                restores: 1,
+                evictions: 0,
+            }
         );
 
         write(&config, "export default 'after';")?;
-        assert_eq!(Compiler::new(options).build_cache.stats().module_entries, 0);
+        let cold_compiler = Compiler::new(options);
+        cold_compiler.run().await?;
+        assert_eq!(
+            cold_compiler
+                .build_cache
+                .work_counters()
+                .for_family(CacheItemFamily::ModuleBuild),
+            CacheItemWork {
+                hits: 0,
+                misses: 1,
+                stores: 1,
+                restores: 0,
+                evictions: 0,
+            }
+        );
 
         Ok(())
     }
@@ -555,5 +538,31 @@ mod tests {
             .iter()
             .map(|asset| (asset.filename.clone(), asset.source.clone()))
             .collect()
+    }
+
+    fn directory_snapshot(root: &Path) -> std::io::Result<BTreeMap<PathBuf, Vec<u8>>> {
+        fn visit(
+            root: &Path,
+            directory: &Path,
+            files: &mut BTreeMap<PathBuf, Vec<u8>>,
+        ) -> std::io::Result<()> {
+            for entry in fs::read_dir(directory)? {
+                let entry = entry?;
+                let path = entry.path();
+                if path.is_dir() {
+                    visit(root, &path, files)?;
+                } else {
+                    files.insert(
+                        path.strip_prefix(root).unwrap_or(&path).to_path_buf(),
+                        fs::read(path)?,
+                    );
+                }
+            }
+            Ok(())
+        }
+
+        let mut files = BTreeMap::new();
+        visit(root, root, &mut files)?;
+        Ok(files)
     }
 }

--- a/crates/unpack_core/src/pack_file.rs
+++ b/crates/unpack_core/src/pack_file.rs
@@ -1,9 +1,8 @@
-#![allow(dead_code)]
-
 #[cfg(test)]
 mod tests {
     use std::{collections::BTreeSet, fs, path::Path};
 
+    use crate::cache_hash::stable_hash;
     use tempfile::tempdir;
 
     use super::*;
@@ -163,6 +162,229 @@ mod tests {
             pack_file.get::<DummyItem>(&address, None).as_deref(),
             Some(&DummyItem(b"payload".to_vec()))
         );
+        Ok(())
+    }
+
+    #[test]
+    fn module_build_records_round_trip_every_parsed_module_variant()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempdir()?;
+        let address = PackFileAddress::new("unpack/module-build", b"module-identity");
+        let record = module_build_record();
+        let registry =
+            CodecRegistry::new().with_module_build_record(ModuleBuildRecordCodec::current());
+
+        PackFile::publish_module_build_records(
+            temp.path(),
+            &registry,
+            [(address.clone(), None, record.clone())],
+        )?;
+
+        assert_eq!(MODULE_BUILD_RECORD_TYPE_ID.as_bytes(), b"unpack.moduleb.1");
+        let mut pack_file = PackFile::open(temp.path(), registry);
+        assert_eq!(
+            pack_file.get_module_build_record(&address, None).as_deref(),
+            Some(&record)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn module_build_codec_rejects_unknown_tags_hash_mismatches_and_invalid_numeric_values()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let codec = ModuleBuildRecordCodec::current();
+        let record = module_build_record();
+
+        let mut unknown_tag = codec.encode(&record)?;
+        let first_dependency_tag = 4 + record.source.len() + 8 + 4;
+        unknown_tag[first_dependency_tag] = 0xff;
+        assert!(codec.decode(&unknown_tag).is_none());
+
+        let mut wrong_hash = record.clone();
+        wrong_hash.source_hash ^= 1;
+        assert!(codec.encode(&wrong_hash).is_err());
+
+        let mut invalid_range = record.clone();
+        if let DependencyDto::Entry { module } = &mut invalid_range.parsed.dependencies[0] {
+            module.range = Some(SourceRangeDto { start: 2, end: 1 });
+        }
+        assert!(codec.encode(&invalid_range).is_err());
+
+        let mut overflow = record;
+        if let DependencyDto::Entry { module } = &mut overflow.parsed.dependencies[0] {
+            module.source_order = Some(u64::MAX);
+        }
+        assert!(codec.encode(&overflow).is_err());
+
+        let mut missing_import_range = module_build_record();
+        if let DependencyDto::Import { module } = missing_import_range
+            .parsed
+            .dependencies
+            .last_mut()
+            .expect("fixture should contain Import")
+        {
+            module.range = None;
+        }
+        assert!(codec.encode(&missing_import_range).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn heterogeneous_batch_publishes_one_guarded_revision_and_honors_its_explicit_base()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempdir()?;
+        let resolve_address = PackFileAddress::new("unpack/resolve", b"request");
+        let module_address = PackFileAddress::new("unpack/module-build", b"identity");
+        let registry = CodecRegistry::new()
+            .with_resolve_record(ResolveRecordCodec::current())
+            .with_module_build_record(ModuleBuildRecordCodec::current());
+        let guard_v1 = PackFileGuardDto {
+            version: b"v1".to_vec(),
+            build_dependencies: resolve_record("build-dependency.js").snapshot,
+            resolve_build_dependencies: resolve_record("resolve-build-dependency.js").snapshot,
+        };
+        let mut initial = PackFileWriteBatch::new();
+        initial.insert(
+            &registry,
+            resolve_address.clone(),
+            None,
+            resolve_record("resolved.js"),
+        )?;
+        initial.insert(
+            &registry,
+            module_address.clone(),
+            None,
+            module_build_record(),
+        )?;
+        PackFile::publish_batch(
+            temp.path(),
+            Some(guard_v1.clone()),
+            PublicationBase::ReplaceAll,
+            initial,
+        )?;
+
+        let first_index = decode_index(&fs::read(PackFile::index_path(temp.path()))?)
+            .expect("decode first heterogeneous index");
+        assert_eq!(first_index.revision, 1);
+        assert_eq!(first_index.guard.as_ref(), Some(&guard_v1));
+        assert_eq!(first_index.entries.len(), 2);
+        assert_eq!(
+            first_index
+                .entries
+                .values()
+                .map(|entry| &entry.content.file)
+                .collect::<std::collections::BTreeSet<_>>()
+                .len(),
+            1
+        );
+
+        let guard_v2 = PackFileGuardDto {
+            version: b"v2".to_vec(),
+            ..guard_v1
+        };
+        let mut update = PackFileWriteBatch::new();
+        update.insert(
+            &registry,
+            resolve_address.clone(),
+            None,
+            resolve_record("resolved-v2.js"),
+        )?;
+        PackFile::publish_batch(
+            temp.path(),
+            Some(guard_v2.clone()),
+            PublicationBase::PreserveEntries {
+                expected_revision: 1,
+            },
+            update,
+        )?;
+
+        let mut reopened = PackFile::open(temp.path(), registry.clone());
+        assert_eq!(reopened.revision(), 2);
+        assert_eq!(reopened.guard(), Some(&guard_v2));
+        assert_eq!(
+            reopened
+                .get_resolve_record(&resolve_address, None)
+                .as_deref(),
+            Some(&resolve_record("resolved-v2.js"))
+        );
+        assert_eq!(
+            reopened
+                .get_module_build_record(&module_address, None)
+                .as_deref(),
+            Some(&module_build_record())
+        );
+
+        let committed_index = fs::read(PackFile::index_path(temp.path()))?;
+        let mut stale = PackFileWriteBatch::new();
+        stale.insert(
+            &registry,
+            resolve_address.clone(),
+            None,
+            resolve_record("must-not-publish.js"),
+        )?;
+        assert!(
+            PackFile::publish_batch(
+                temp.path(),
+                Some(guard_v2.clone()),
+                PublicationBase::PreserveEntries {
+                    expected_revision: 1,
+                },
+                stale,
+            )
+            .is_err()
+        );
+        assert_eq!(
+            fs::read(PackFile::index_path(temp.path()))?,
+            committed_index
+        );
+
+        let mut cold = PackFileWriteBatch::new();
+        cold.insert(
+            &registry,
+            module_address.clone(),
+            None,
+            module_build_record(),
+        )?;
+        PackFile::publish_batch(
+            temp.path(),
+            Some(guard_v2),
+            PublicationBase::ReplaceAll,
+            cold,
+        )?;
+        let mut replaced = PackFile::open(temp.path(), registry);
+        assert_eq!(replaced.revision(), 3);
+        assert!(
+            replaced
+                .get_resolve_record(&resolve_address, None)
+                .is_none()
+        );
+        assert!(
+            replaced
+                .get_module_build_record(&module_address, None)
+                .is_some()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn production_records_convert_to_and_from_their_persistent_dtos()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut resolve_dto = resolve_record("conversion.js");
+        if let SnapshotEntryDto::File { modified, .. } = &mut resolve_dto.snapshot.entries[0] {
+            *modified = Some(TimestampDto {
+                seconds: -1,
+                nanoseconds: 999_999_999,
+            });
+        }
+        resolve_dto
+            .file_dependencies
+            .sort_by(|left, right| left.0.cmp(&right.0));
+        let resolve_record = ResolveRecord::try_from(resolve_dto.clone())?;
+        assert_eq!(ResolveRecordDto::try_from(&resolve_record)?, resolve_dto);
+
+        let module_dto = module_build_record();
+        let module_record = ModuleBuildRecord::try_from(module_dto.clone())?;
+        assert_eq!(ModuleBuildRecordDto::try_from(&module_record)?, module_dto);
         Ok(())
     }
 
@@ -508,6 +730,76 @@ mod tests {
         }
     }
 
+    fn module_build_record() -> ModuleBuildRecordDto {
+        let source =
+            "export default 1;                                                              "
+                .to_string();
+        let module = ModuleDependencyDto {
+            request: "./dep".to_string(),
+            user_request: "./dep".to_string(),
+            source_order: Some(1),
+            range: Some(SourceRangeDto { start: 0, end: 1 }),
+            weak: false,
+        };
+        let dependencies = vec![
+            DependencyDto::Entry {
+                module: module.clone(),
+            },
+            DependencyDto::HarmonyImportSideEffect {
+                module: module.clone(),
+                import_var: Some("__dep__".to_string()),
+            },
+            DependencyDto::HarmonyImportSpecifier {
+                module: module.clone(),
+                ids: vec!["value".to_string()],
+                name: "local".to_string(),
+                usage_range: SourceRangeDto { start: 1, end: 2 },
+                shorthand: true,
+            },
+            DependencyDto::HarmonyExportHeader {
+                declaration_range: Some(SourceRangeDto { start: 2, end: 3 }),
+                statement_range: SourceRangeDto { start: 2, end: 4 },
+            },
+            DependencyDto::HarmonyExportSpecifier {
+                id: "local".to_string(),
+                name: "public".to_string(),
+            },
+            DependencyDto::HarmonyExportExpression {
+                range: SourceRangeDto { start: 4, end: 5 },
+                statement_range: SourceRangeDto { start: 4, end: 6 },
+                declaration_id: Some("default".to_string()),
+            },
+            DependencyDto::HarmonyExportImportedSpecifier {
+                module: module.clone(),
+                ids: vec!["value".to_string()],
+                name: Some("renamed".to_string()),
+                is_star: false,
+            },
+            DependencyDto::Null,
+            DependencyDto::Const {
+                expression: "void 0".to_string(),
+                range: SourceRangeDto { start: 6, end: 7 },
+            },
+            DependencyDto::Import {
+                module: module.clone(),
+            },
+        ];
+        ModuleBuildRecordDto {
+            parsed: ParsedModuleDto {
+                dependencies: dependencies.clone(),
+                blocks: vec![AsyncDependenciesBlockDto {
+                    dependencies: vec![DependencyDto::Import {
+                        module: module.clone(),
+                    }],
+                }],
+                presentational_dependencies: dependencies,
+            },
+            source_hash: stable_hash(&source),
+            source,
+            snapshot: resolve_record("module.js").snapshot,
+        }
+    }
+
     fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
         haystack
             .windows(needle.len())
@@ -555,17 +847,26 @@ mod tests {
     }
 }
 // Private PackFile storage primitives.
-//
-// This module is intentionally not selected by the production cache options yet. Its module
-// boundary exists so the storage contract can be exercised before the backend cutover.
 
 use std::{
     any::Any,
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     fmt, fs,
     io::{self, Read, Seek, SeekFrom, Write},
     path::{Component, Path, PathBuf},
     sync::Arc,
+};
+
+use crate::{
+    AsyncDependenciesBlock, ConstDependency, Dependency, EntryDependency,
+    HarmonyExportExpressionDependency, HarmonyExportHeaderDependency,
+    HarmonyExportImportedSpecifierDependency, HarmonyExportSpecifierDependency,
+    HarmonyImportSideEffectDependency, HarmonyImportSpecifierDependency, ImportDependency,
+    ModuleDependency, ModuleIdentity, ModuleType, NullDependency, SourceRange,
+    build_cache::{ModuleBuildRecord, ResolveRecord},
+    cache_hash::stable_hash,
+    parser::ParsedModule,
+    snapshot::Snapshot,
 };
 
 #[cfg(unix)]
@@ -582,8 +883,11 @@ const MAX_CONTENT_BYTES: usize = 32 * 1024 * 1024;
 const MAX_RECORD_BYTES: usize = 16 * 1024 * 1024;
 const MAX_FIELD_BYTES: usize = 1024 * 1024;
 const MAX_COLLECTION_ENTRIES: usize = 100_000;
-const RESOLVE_RECORD_CODEC_ID: StableCodecId = StableCodecId(*b"unpack.rslv.c001");
-pub(crate) const RESOLVE_RECORD_TYPE_ID: StableTypeId = StableTypeId(*b"unpack.resolve.1");
+const RESOLVE_RECORD_CODEC_ID: StableCodecId = StableCodecId::new(*b"unpack.rslv.c001");
+const MODULE_BUILD_RECORD_CODEC_ID: StableCodecId = StableCodecId::new(*b"unpack.modb.c001");
+pub(crate) const RESOLVE_RECORD_TYPE_ID: StableTypeId = StableTypeId::new(*b"unpack.resolve.1");
+pub(crate) const MODULE_BUILD_RECORD_TYPE_ID: StableTypeId =
+    StableTypeId::new(*b"unpack.moduleb.1");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct StableTypeId([u8; 16]);
@@ -748,12 +1052,543 @@ pub(crate) enum ManagedItemStateDto {
     Package { name: String, version: String },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ModuleBuildRecordDto {
+    pub(crate) parsed: ParsedModuleDto,
+    pub(crate) source: String,
+    pub(crate) source_hash: u64,
+    pub(crate) snapshot: SnapshotDto,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParsedModuleDto {
+    pub(crate) dependencies: Vec<DependencyDto>,
+    pub(crate) blocks: Vec<AsyncDependenciesBlockDto>,
+    pub(crate) presentational_dependencies: Vec<DependencyDto>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AsyncDependenciesBlockDto {
+    pub(crate) dependencies: Vec<DependencyDto>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SourceRangeDto {
+    pub(crate) start: u32,
+    pub(crate) end: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ModuleDependencyDto {
+    pub(crate) request: String,
+    pub(crate) user_request: String,
+    pub(crate) source_order: Option<u64>,
+    pub(crate) range: Option<SourceRangeDto>,
+    pub(crate) weak: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DependencyDto {
+    Entry {
+        module: ModuleDependencyDto,
+    },
+    HarmonyImportSideEffect {
+        module: ModuleDependencyDto,
+        import_var: Option<String>,
+    },
+    HarmonyImportSpecifier {
+        module: ModuleDependencyDto,
+        ids: Vec<String>,
+        name: String,
+        usage_range: SourceRangeDto,
+        shorthand: bool,
+    },
+    HarmonyExportHeader {
+        declaration_range: Option<SourceRangeDto>,
+        statement_range: SourceRangeDto,
+    },
+    HarmonyExportSpecifier {
+        id: String,
+        name: String,
+    },
+    HarmonyExportExpression {
+        range: SourceRangeDto,
+        statement_range: SourceRangeDto,
+        declaration_id: Option<String>,
+    },
+    HarmonyExportImportedSpecifier {
+        module: ModuleDependencyDto,
+        ids: Vec<String>,
+        name: Option<String>,
+        is_star: bool,
+    },
+    Null,
+    Const {
+        expression: String,
+        range: SourceRangeDto,
+    },
+    Import {
+        module: ModuleDependencyDto,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PackFileGuardDto {
+    pub(crate) version: Vec<u8>,
+    pub(crate) build_dependencies: SnapshotDto,
+    pub(crate) resolve_build_dependencies: SnapshotDto,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PublicationBase {
+    PreserveEntries { expected_revision: u64 },
+    ReplaceAll,
+}
+
+#[derive(Debug)]
+struct PendingPackFileItem {
+    etag: Option<PackFileETag>,
+    type_id: StableTypeId,
+    codec_id: StableCodecId,
+    payload: Vec<u8>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct PackFileWriteBatch {
+    items: BTreeMap<PackFileAddress, PendingPackFileItem>,
+}
+
+impl PackFileWriteBatch {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn insert<T: PackFileItem>(
+        &mut self,
+        registry: &CodecRegistry,
+        address: PackFileAddress,
+        etag: Option<PackFileETag>,
+        value: T,
+    ) -> io::Result<()> {
+        let (codec_id, payload) = registry.encode(&value)?;
+        self.items.insert(
+            address,
+            PendingPackFileItem {
+                etag,
+                type_id: T::TYPE_ID,
+                codec_id,
+                payload,
+            },
+        );
+        Ok(())
+    }
+}
+
+impl From<&ModuleIdentity> for ModuleIdentityDto {
+    fn from(identity: &ModuleIdentity) -> Self {
+        Self {
+            module_type: match identity.module_type {
+                ModuleType::JavaScriptAuto => ModuleTypeDto::JavaScriptAuto,
+            },
+            resource: PathBytes::from_path(&identity.resource),
+            query: identity.query.clone(),
+            fragment: identity.fragment.clone(),
+            layer: identity.layer.clone(),
+            loaders: identity.loaders.clone(),
+        }
+    }
+}
+
+impl TryFrom<ModuleIdentityDto> for ModuleIdentity {
+    type Error = io::Error;
+
+    fn try_from(identity: ModuleIdentityDto) -> io::Result<Self> {
+        Ok(Self {
+            module_type: match identity.module_type {
+                ModuleTypeDto::JavaScriptAuto => ModuleType::JavaScriptAuto,
+            },
+            resource: path_from_bytes(identity.resource)?,
+            query: identity.query,
+            fragment: identity.fragment,
+            layer: identity.layer,
+            loaders: identity.loaders,
+        })
+    }
+}
+
+impl TryFrom<&Snapshot> for SnapshotDto {
+    type Error = io::Error;
+
+    fn try_from(snapshot: &Snapshot) -> io::Result<Self> {
+        Ok(snapshot.to_pack_file_dto())
+    }
+}
+
+impl TryFrom<SnapshotDto> for Snapshot {
+    type Error = io::Error;
+
+    fn try_from(snapshot: SnapshotDto) -> io::Result<Self> {
+        Snapshot::from_pack_file_dto(snapshot).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "PackFile Snapshot contains inconsistent or duplicate entries",
+            )
+        })
+    }
+}
+
+impl TryFrom<&ResolveRecord> for ResolveRecordDto {
+    type Error = io::Error;
+
+    fn try_from(record: &ResolveRecord) -> io::Result<Self> {
+        Ok(Self {
+            identity: ModuleIdentityDto::from(record.identity()),
+            resource: PathBytes::from_path(record.resource()),
+            file_dependencies: record
+                .file_dependencies()
+                .iter()
+                .map(|path| PathBytes::from_path(path))
+                .collect(),
+            context_dependencies: record
+                .context_dependencies()
+                .iter()
+                .map(|path| PathBytes::from_path(path))
+                .collect(),
+            missing_dependencies: record
+                .missing_dependencies()
+                .iter()
+                .map(|path| PathBytes::from_path(path))
+                .collect(),
+            snapshot: SnapshotDto::try_from(record.snapshot())?,
+        })
+    }
+}
+
+impl TryFrom<ResolveRecordDto> for ResolveRecord {
+    type Error = io::Error;
+
+    fn try_from(record: ResolveRecordDto) -> io::Result<Self> {
+        Ok(ResolveRecord::from_persistent_parts(
+            ModuleIdentity::try_from(record.identity)?,
+            path_from_bytes(record.resource)?,
+            paths_from_bytes(record.file_dependencies)?,
+            paths_from_bytes(record.context_dependencies)?,
+            paths_from_bytes(record.missing_dependencies)?,
+            Snapshot::try_from(record.snapshot)?,
+        ))
+    }
+}
+
+impl TryFrom<&ModuleBuildRecord> for ModuleBuildRecordDto {
+    type Error = io::Error;
+
+    fn try_from(record: &ModuleBuildRecord) -> io::Result<Self> {
+        let (parsed, source, source_hash) = record.cloned_parts();
+        let source_hash = source_hash.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Module Build Record is missing its required source hash",
+            )
+        })?;
+        let dto = Self {
+            parsed: ParsedModuleDto::try_from(&parsed)?,
+            source,
+            source_hash,
+            snapshot: SnapshotDto::try_from(record.snapshot())?,
+        };
+        validate_module_build_record(&dto)?;
+        Ok(dto)
+    }
+}
+
+impl TryFrom<ModuleBuildRecordDto> for ModuleBuildRecord {
+    type Error = io::Error;
+
+    fn try_from(record: ModuleBuildRecordDto) -> io::Result<Self> {
+        validate_module_build_record(&record)?;
+        Ok(ModuleBuildRecord::new(
+            ParsedModule::try_from(&record.parsed)?,
+            record.source,
+            Snapshot::try_from(record.snapshot)?,
+        ))
+    }
+}
+
+fn validate_module_build_record(record: &ModuleBuildRecordDto) -> io::Result<()> {
+    if record.source_hash != stable_hash(&record.source) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Module Build Record source hash does not match its source",
+        ));
+    }
+    if !parsed_module_ranges_are_valid(&record.parsed, &record.source) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Module Build Record contains an invalid source range",
+        ));
+    }
+    Ok(())
+}
+
+fn path_from_bytes(path: PathBytes) -> io::Result<PathBuf> {
+    path.to_path_buf().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "PackFile path bytes are invalid on this platform",
+        )
+    })
+}
+
+fn paths_from_bytes(paths: Vec<PathBytes>) -> io::Result<BTreeSet<PathBuf>> {
+    paths
+        .into_iter()
+        .map(path_from_bytes)
+        .collect::<io::Result<BTreeSet<_>>>()
+}
+
+impl TryFrom<&ParsedModule> for ParsedModuleDto {
+    type Error = io::Error;
+
+    fn try_from(parsed: &ParsedModule) -> io::Result<Self> {
+        Ok(Self {
+            dependencies: parsed
+                .dependencies
+                .iter()
+                .map(dependency_to_dto)
+                .collect::<io::Result<_>>()?,
+            blocks: parsed
+                .blocks
+                .iter()
+                .map(|block| {
+                    Ok(AsyncDependenciesBlockDto {
+                        dependencies: block
+                            .dependencies()
+                            .iter()
+                            .map(dependency_to_dto)
+                            .collect::<io::Result<_>>()?,
+                    })
+                })
+                .collect::<io::Result<_>>()?,
+            presentational_dependencies: parsed
+                .presentational_dependencies
+                .iter()
+                .map(dependency_to_dto)
+                .collect::<io::Result<_>>()?,
+        })
+    }
+}
+
+impl TryFrom<&ParsedModuleDto> for ParsedModule {
+    type Error = io::Error;
+
+    fn try_from(parsed: &ParsedModuleDto) -> io::Result<Self> {
+        Ok(Self {
+            dependencies: parsed
+                .dependencies
+                .iter()
+                .map(dependency_from_dto)
+                .collect::<io::Result<_>>()?,
+            blocks: parsed
+                .blocks
+                .iter()
+                .map(|block| {
+                    Ok(AsyncDependenciesBlock::new(
+                        block
+                            .dependencies
+                            .iter()
+                            .map(dependency_from_dto)
+                            .collect::<io::Result<_>>()?,
+                    ))
+                })
+                .collect::<io::Result<_>>()?,
+            presentational_dependencies: parsed
+                .presentational_dependencies
+                .iter()
+                .map(dependency_from_dto)
+                .collect::<io::Result<_>>()?,
+        })
+    }
+}
+
+fn dependency_to_dto(dependency: &Dependency) -> io::Result<DependencyDto> {
+    Ok(match dependency {
+        Dependency::Entry(dependency) => DependencyDto::Entry {
+            module: module_dependency_to_dto(&dependency.module)?,
+        },
+        Dependency::HarmonyImportSideEffect(dependency) => DependencyDto::HarmonyImportSideEffect {
+            module: module_dependency_to_dto(&dependency.module)?,
+            import_var: dependency.import_var.clone(),
+        },
+        Dependency::HarmonyImportSpecifier(dependency) => DependencyDto::HarmonyImportSpecifier {
+            module: module_dependency_to_dto(&dependency.module)?,
+            ids: dependency.ids.clone(),
+            name: dependency.name.clone(),
+            usage_range: dependency.usage_range.into(),
+            shorthand: dependency.shorthand,
+        },
+        Dependency::HarmonyExportHeader(dependency) => DependencyDto::HarmonyExportHeader {
+            declaration_range: dependency.declaration_range.map(Into::into),
+            statement_range: dependency.statement_range.into(),
+        },
+        Dependency::HarmonyExportSpecifier(dependency) => DependencyDto::HarmonyExportSpecifier {
+            id: dependency.id.clone(),
+            name: dependency.name.clone(),
+        },
+        Dependency::HarmonyExportExpression(dependency) => DependencyDto::HarmonyExportExpression {
+            range: dependency.range.into(),
+            statement_range: dependency.statement_range.into(),
+            declaration_id: dependency.declaration_id.clone(),
+        },
+        Dependency::HarmonyExportImportedSpecifier(dependency) => {
+            DependencyDto::HarmonyExportImportedSpecifier {
+                module: module_dependency_to_dto(&dependency.module)?,
+                ids: dependency.ids.clone(),
+                name: dependency.name.clone(),
+                is_star: dependency.is_star,
+            }
+        }
+        Dependency::Null(_) => DependencyDto::Null,
+        Dependency::Const(dependency) => DependencyDto::Const {
+            expression: dependency.expression.clone(),
+            range: dependency.range.into(),
+        },
+        Dependency::Import(dependency) => DependencyDto::Import {
+            module: module_dependency_to_dto(&dependency.module)?,
+        },
+    })
+}
+
+fn dependency_from_dto(dependency: &DependencyDto) -> io::Result<Dependency> {
+    Ok(match dependency {
+        DependencyDto::Entry { module } => Dependency::Entry(EntryDependency {
+            module: module_dependency_from_dto(module)?,
+        }),
+        DependencyDto::HarmonyImportSideEffect { module, import_var } => {
+            Dependency::HarmonyImportSideEffect(HarmonyImportSideEffectDependency {
+                module: module_dependency_from_dto(module)?,
+                import_var: import_var.clone(),
+            })
+        }
+        DependencyDto::HarmonyImportSpecifier {
+            module,
+            ids,
+            name,
+            usage_range,
+            shorthand,
+        } => Dependency::HarmonyImportSpecifier(HarmonyImportSpecifierDependency {
+            module: module_dependency_from_dto(module)?,
+            ids: ids.clone(),
+            name: name.clone(),
+            usage_range: (*usage_range).into(),
+            shorthand: *shorthand,
+        }),
+        DependencyDto::HarmonyExportHeader {
+            declaration_range,
+            statement_range,
+        } => Dependency::HarmonyExportHeader(HarmonyExportHeaderDependency {
+            declaration_range: declaration_range.map(Into::into),
+            statement_range: (*statement_range).into(),
+        }),
+        DependencyDto::HarmonyExportSpecifier { id, name } => {
+            Dependency::HarmonyExportSpecifier(HarmonyExportSpecifierDependency {
+                id: id.clone(),
+                name: name.clone(),
+            })
+        }
+        DependencyDto::HarmonyExportExpression {
+            range,
+            statement_range,
+            declaration_id,
+        } => Dependency::HarmonyExportExpression(HarmonyExportExpressionDependency {
+            range: (*range).into(),
+            statement_range: (*statement_range).into(),
+            declaration_id: declaration_id.clone(),
+        }),
+        DependencyDto::HarmonyExportImportedSpecifier {
+            module,
+            ids,
+            name,
+            is_star,
+        } => Dependency::HarmonyExportImportedSpecifier(HarmonyExportImportedSpecifierDependency {
+            module: module_dependency_from_dto(module)?,
+            ids: ids.clone(),
+            name: name.clone(),
+            is_star: *is_star,
+        }),
+        DependencyDto::Null => Dependency::Null(NullDependency),
+        DependencyDto::Const { expression, range } => Dependency::Const(ConstDependency {
+            expression: expression.clone(),
+            range: (*range).into(),
+        }),
+        DependencyDto::Import { module } => Dependency::Import(ImportDependency {
+            module: module_dependency_from_dto(module)?,
+        }),
+    })
+}
+
+fn module_dependency_to_dto(dependency: &ModuleDependency) -> io::Result<ModuleDependencyDto> {
+    Ok(ModuleDependencyDto {
+        request: dependency.request.clone(),
+        user_request: dependency.user_request.clone(),
+        source_order: dependency
+            .source_order
+            .map(u64::try_from)
+            .transpose()
+            .map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Module dependency source order is too large",
+                )
+            })?,
+        range: dependency.range.map(Into::into),
+        weak: dependency.weak,
+    })
+}
+
+fn module_dependency_from_dto(dependency: &ModuleDependencyDto) -> io::Result<ModuleDependency> {
+    Ok(ModuleDependency {
+        request: dependency.request.clone(),
+        user_request: dependency.user_request.clone(),
+        source_order: dependency
+            .source_order
+            .map(usize::try_from)
+            .transpose()
+            .map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Module dependency source order overflows this platform",
+                )
+            })?,
+        range: dependency.range.map(Into::into),
+        weak: dependency.weak,
+    })
+}
+
+impl From<SourceRange> for SourceRangeDto {
+    fn from(range: SourceRange) -> Self {
+        Self {
+            start: range.start,
+            end: range.end,
+        }
+    }
+}
+
+impl From<SourceRangeDto> for SourceRange {
+    fn from(range: SourceRangeDto) -> Self {
+        Self::new(range.start, range.end)
+    }
+}
+
 pub(crate) trait PackFileItem: Clone + Send + Sync + 'static {
     const TYPE_ID: StableTypeId;
 }
 
 impl PackFileItem for ResolveRecordDto {
     const TYPE_ID: StableTypeId = RESOLVE_RECORD_TYPE_ID;
+}
+
+impl PackFileItem for ModuleBuildRecordDto {
+    const TYPE_ID: StableTypeId = MODULE_BUILD_RECORD_TYPE_ID;
 }
 
 pub(crate) trait ItemCodec<T: PackFileItem>: fmt::Debug + Send + Sync + 'static {
@@ -805,7 +1640,7 @@ where
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct CodecRegistry {
     codecs: HashMap<StableTypeId, Arc<dyn ErasedItemCodec>>,
 }
@@ -820,6 +1655,12 @@ impl CodecRegistry {
         self
     }
 
+    pub(crate) fn with_module_build_record(mut self, codec: ModuleBuildRecordCodec) -> Self {
+        self.register::<ModuleBuildRecordDto, _>(codec);
+        self
+    }
+
+    #[allow(dead_code)]
     pub(crate) fn with_codec<T, C>(mut self, codec: C) -> Self
     where
         T: PackFileItem,
@@ -889,10 +1730,12 @@ impl ResolveRecordCodec {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn to_dto(self, record: &crate::build_cache::ResolveRecord) -> ResolveRecordDto {
         record.to_pack_file_dto()
     }
 
+    #[cfg(test)]
     pub(crate) fn from_dto(
         self,
         dto: ResolveRecordDto,
@@ -920,6 +1763,350 @@ impl ItemCodec<ResolveRecordDto> for ResolveRecordCodec {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ModuleBuildRecordCodec {
+    codec_id: StableCodecId,
+}
+
+impl ModuleBuildRecordCodec {
+    pub(crate) const fn current() -> Self {
+        Self {
+            codec_id: MODULE_BUILD_RECORD_CODEC_ID,
+        }
+    }
+}
+
+impl ItemCodec<ModuleBuildRecordDto> for ModuleBuildRecordCodec {
+    fn codec_id(&self) -> StableCodecId {
+        self.codec_id
+    }
+
+    fn encode(&self, value: &ModuleBuildRecordDto) -> io::Result<Vec<u8>> {
+        encode_module_build_record(value)
+    }
+
+    fn decode(&self, bytes: &[u8]) -> Option<ModuleBuildRecordDto> {
+        decode_module_build_record(bytes)
+    }
+}
+
+fn encode_module_build_record(record: &ModuleBuildRecordDto) -> io::Result<Vec<u8>> {
+    validate_module_build_record(record)?;
+
+    let mut encoder = Encoder::default();
+    encoder.write_string(&record.source)?;
+    encoder.write_u64(record.source_hash);
+    encode_parsed_module(&mut encoder, &record.parsed)?;
+    encode_snapshot(&mut encoder, &record.snapshot)?;
+    Ok(encoder.finish())
+}
+
+fn decode_module_build_record(bytes: &[u8]) -> Option<ModuleBuildRecordDto> {
+    let mut decoder = Decoder::new(bytes);
+    let source = decoder.read_string()?;
+    let source_hash = decoder.read_u64()?;
+    let parsed = decode_parsed_module(&mut decoder)?;
+    let snapshot = decode_snapshot(&mut decoder)?;
+    decoder.finish()?;
+    let record = ModuleBuildRecordDto {
+        parsed,
+        source,
+        source_hash,
+        snapshot,
+    };
+    validate_module_build_record(&record).ok()?;
+    Some(record)
+}
+
+fn encode_parsed_module(encoder: &mut Encoder, parsed: &ParsedModuleDto) -> io::Result<()> {
+    encode_dependencies(encoder, &parsed.dependencies)?;
+    encoder.write_count(parsed.blocks.len())?;
+    for block in &parsed.blocks {
+        encode_dependencies(encoder, &block.dependencies)?;
+    }
+    encode_dependencies(encoder, &parsed.presentational_dependencies)
+}
+
+fn decode_parsed_module(decoder: &mut Decoder<'_>) -> Option<ParsedModuleDto> {
+    let dependencies = decode_dependencies(decoder)?;
+    let block_count = decoder.read_count()?;
+    let mut blocks = Vec::with_capacity(block_count);
+    for _ in 0..block_count {
+        blocks.push(AsyncDependenciesBlockDto {
+            dependencies: decode_dependencies(decoder)?,
+        });
+    }
+    Some(ParsedModuleDto {
+        dependencies,
+        blocks,
+        presentational_dependencies: decode_dependencies(decoder)?,
+    })
+}
+
+fn encode_dependencies(encoder: &mut Encoder, dependencies: &[DependencyDto]) -> io::Result<()> {
+    encoder.write_count(dependencies.len())?;
+    for dependency in dependencies {
+        encode_dependency(encoder, dependency)?;
+    }
+    Ok(())
+}
+
+fn decode_dependencies(decoder: &mut Decoder<'_>) -> Option<Vec<DependencyDto>> {
+    let count = decoder.read_count()?;
+    let mut dependencies = Vec::with_capacity(count);
+    for _ in 0..count {
+        dependencies.push(decode_dependency(decoder)?);
+    }
+    Some(dependencies)
+}
+
+fn encode_dependency(encoder: &mut Encoder, dependency: &DependencyDto) -> io::Result<()> {
+    match dependency {
+        DependencyDto::Entry { module } => {
+            encoder.write_u8(0);
+            encode_module_dependency(encoder, module)
+        }
+        DependencyDto::HarmonyImportSideEffect { module, import_var } => {
+            encoder.write_u8(1);
+            encode_module_dependency(encoder, module)?;
+            encoder.write_optional_string(import_var.as_deref())
+        }
+        DependencyDto::HarmonyImportSpecifier {
+            module,
+            ids,
+            name,
+            usage_range,
+            shorthand,
+        } => {
+            encoder.write_u8(2);
+            encode_module_dependency(encoder, module)?;
+            encoder.write_strings(ids)?;
+            encoder.write_string(name)?;
+            encode_source_range(encoder, *usage_range);
+            encoder.write_bool(*shorthand);
+            Ok(())
+        }
+        DependencyDto::HarmonyExportHeader {
+            declaration_range,
+            statement_range,
+        } => {
+            encoder.write_u8(3);
+            encode_optional_source_range(encoder, *declaration_range);
+            encode_source_range(encoder, *statement_range);
+            Ok(())
+        }
+        DependencyDto::HarmonyExportSpecifier { id, name } => {
+            encoder.write_u8(4);
+            encoder.write_string(id)?;
+            encoder.write_string(name)
+        }
+        DependencyDto::HarmonyExportExpression {
+            range,
+            statement_range,
+            declaration_id,
+        } => {
+            encoder.write_u8(5);
+            encode_source_range(encoder, *range);
+            encode_source_range(encoder, *statement_range);
+            encoder.write_optional_string(declaration_id.as_deref())
+        }
+        DependencyDto::HarmonyExportImportedSpecifier {
+            module,
+            ids,
+            name,
+            is_star,
+        } => {
+            encoder.write_u8(6);
+            encode_module_dependency(encoder, module)?;
+            encoder.write_strings(ids)?;
+            encoder.write_optional_string(name.as_deref())?;
+            encoder.write_bool(*is_star);
+            Ok(())
+        }
+        DependencyDto::Null => {
+            encoder.write_u8(7);
+            Ok(())
+        }
+        DependencyDto::Const { expression, range } => {
+            encoder.write_u8(8);
+            encoder.write_string(expression)?;
+            encode_source_range(encoder, *range);
+            Ok(())
+        }
+        DependencyDto::Import { module } => {
+            encoder.write_u8(9);
+            encode_module_dependency(encoder, module)
+        }
+    }
+}
+
+fn decode_dependency(decoder: &mut Decoder<'_>) -> Option<DependencyDto> {
+    Some(match decoder.read_u8()? {
+        0 => DependencyDto::Entry {
+            module: decode_module_dependency(decoder)?,
+        },
+        1 => DependencyDto::HarmonyImportSideEffect {
+            module: decode_module_dependency(decoder)?,
+            import_var: decoder.read_optional_string()?,
+        },
+        2 => DependencyDto::HarmonyImportSpecifier {
+            module: decode_module_dependency(decoder)?,
+            ids: decoder.read_strings()?,
+            name: decoder.read_string()?,
+            usage_range: decode_source_range(decoder)?,
+            shorthand: decoder.read_bool()?,
+        },
+        3 => DependencyDto::HarmonyExportHeader {
+            declaration_range: decode_optional_source_range(decoder)?,
+            statement_range: decode_source_range(decoder)?,
+        },
+        4 => DependencyDto::HarmonyExportSpecifier {
+            id: decoder.read_string()?,
+            name: decoder.read_string()?,
+        },
+        5 => DependencyDto::HarmonyExportExpression {
+            range: decode_source_range(decoder)?,
+            statement_range: decode_source_range(decoder)?,
+            declaration_id: decoder.read_optional_string()?,
+        },
+        6 => DependencyDto::HarmonyExportImportedSpecifier {
+            module: decode_module_dependency(decoder)?,
+            ids: decoder.read_strings()?,
+            name: decoder.read_optional_string()?,
+            is_star: decoder.read_bool()?,
+        },
+        7 => DependencyDto::Null,
+        8 => DependencyDto::Const {
+            expression: decoder.read_string()?,
+            range: decode_source_range(decoder)?,
+        },
+        9 => DependencyDto::Import {
+            module: decode_module_dependency(decoder)?,
+        },
+        _ => return None,
+    })
+}
+
+fn encode_module_dependency(
+    encoder: &mut Encoder,
+    dependency: &ModuleDependencyDto,
+) -> io::Result<()> {
+    encoder.write_string(&dependency.request)?;
+    encoder.write_string(&dependency.user_request)?;
+    encoder.write_optional_u64(dependency.source_order);
+    encode_optional_source_range(encoder, dependency.range);
+    encoder.write_bool(dependency.weak);
+    Ok(())
+}
+
+fn decode_module_dependency(decoder: &mut Decoder<'_>) -> Option<ModuleDependencyDto> {
+    Some(ModuleDependencyDto {
+        request: decoder.read_string()?,
+        user_request: decoder.read_string()?,
+        source_order: decoder.read_optional_u64()?,
+        range: decode_optional_source_range(decoder)?,
+        weak: decoder.read_bool()?,
+    })
+}
+
+fn encode_source_range(encoder: &mut Encoder, range: SourceRangeDto) {
+    encoder.write_u32(range.start);
+    encoder.write_u32(range.end);
+}
+
+fn decode_source_range(decoder: &mut Decoder<'_>) -> Option<SourceRangeDto> {
+    Some(SourceRangeDto {
+        start: decoder.read_u32()?,
+        end: decoder.read_u32()?,
+    })
+}
+
+fn encode_optional_source_range(encoder: &mut Encoder, range: Option<SourceRangeDto>) {
+    match range {
+        Some(range) => {
+            encoder.write_u8(1);
+            encode_source_range(encoder, range);
+        }
+        None => encoder.write_u8(0),
+    }
+}
+
+fn decode_optional_source_range(decoder: &mut Decoder<'_>) -> Option<Option<SourceRangeDto>> {
+    match decoder.read_u8()? {
+        0 => Some(None),
+        1 => Some(Some(decode_source_range(decoder)?)),
+        _ => None,
+    }
+}
+
+fn parsed_module_ranges_are_valid(parsed: &ParsedModuleDto, source: &str) -> bool {
+    parsed
+        .dependencies
+        .iter()
+        .chain(
+            parsed
+                .blocks
+                .iter()
+                .flat_map(|block| block.dependencies.iter()),
+        )
+        .chain(parsed.presentational_dependencies.iter())
+        .all(|dependency| dependency_ranges_are_valid(dependency, source))
+}
+
+fn dependency_ranges_are_valid(dependency: &DependencyDto, source: &str) -> bool {
+    let module_range_is_valid = |module: &ModuleDependencyDto| {
+        module.source_order.is_none_or(|source_order| {
+            usize::try_from(source_order)
+                .is_ok_and(|source_order| source_order <= MAX_COLLECTION_ENTRIES)
+        }) && module
+            .range
+            .is_none_or(|range| source_range_is_valid(range, source))
+    };
+    match dependency {
+        DependencyDto::Entry { module }
+        | DependencyDto::HarmonyImportSideEffect { module, .. }
+        | DependencyDto::HarmonyExportImportedSpecifier { module, .. } => {
+            module_range_is_valid(module)
+        }
+        DependencyDto::Import { module } => module.range.is_some() && module_range_is_valid(module),
+        DependencyDto::HarmonyImportSpecifier {
+            module,
+            usage_range,
+            ..
+        } => module_range_is_valid(module) && source_range_is_valid(*usage_range, source),
+        DependencyDto::HarmonyExportHeader {
+            declaration_range,
+            statement_range,
+        } => {
+            declaration_range.is_none_or(|range| source_range_is_valid(range, source))
+                && source_range_is_valid(*statement_range, source)
+        }
+        DependencyDto::HarmonyExportExpression {
+            range,
+            statement_range,
+            ..
+        } => {
+            source_range_is_valid(*range, source) && source_range_is_valid(*statement_range, source)
+        }
+        DependencyDto::Const { range, .. } => source_range_is_valid(*range, source),
+        DependencyDto::HarmonyExportSpecifier { .. } | DependencyDto::Null => true,
+    }
+}
+
+fn source_range_is_valid(range: SourceRangeDto, source: &str) -> bool {
+    let start = usize::try_from(range.start).ok();
+    let end = usize::try_from(range.end).ok();
+    match (start, end) {
+        (Some(start), Some(end)) => {
+            start <= end
+                && end <= source.len()
+                && source.is_char_boundary(start)
+                && source.is_char_boundary(end)
+        }
+        _ => false,
+    }
+}
+
 fn encode_resolve_record(record: &ResolveRecordDto) -> io::Result<Vec<u8>> {
     let mut encoder = Encoder::default();
     encoder.write_u8(match record.identity.module_type {
@@ -934,8 +2121,13 @@ fn encode_resolve_record(record: &ResolveRecordDto) -> io::Result<Vec<u8>> {
     encoder.write_paths(&record.file_dependencies)?;
     encoder.write_paths(&record.context_dependencies)?;
     encoder.write_paths(&record.missing_dependencies)?;
-    encoder.write_count(record.snapshot.entries.len())?;
-    for entry in &record.snapshot.entries {
+    encode_snapshot(&mut encoder, &record.snapshot)?;
+    Ok(encoder.finish())
+}
+
+fn encode_snapshot(encoder: &mut Encoder, snapshot: &SnapshotDto) -> io::Result<()> {
+    encoder.write_count(snapshot.entries.len())?;
+    for entry in &snapshot.entries {
         match entry {
             SnapshotEntryDto::File {
                 path,
@@ -985,7 +2177,7 @@ fn encode_resolve_record(record: &ResolveRecordDto) -> io::Result<Vec<u8>> {
             }
         }
     }
-    Ok(encoder.finish())
+    Ok(())
 }
 
 fn decode_resolve_record(bytes: &[u8]) -> Option<ResolveRecordDto> {
@@ -1006,6 +2198,19 @@ fn decode_resolve_record(bytes: &[u8]) -> Option<ResolveRecordDto> {
     let file_dependencies = decoder.read_paths()?;
     let context_dependencies = decoder.read_paths()?;
     let missing_dependencies = decoder.read_paths()?;
+    let snapshot = decode_snapshot(&mut decoder)?;
+    decoder.finish()?;
+    Some(ResolveRecordDto {
+        identity,
+        resource,
+        file_dependencies,
+        context_dependencies,
+        missing_dependencies,
+        snapshot,
+    })
+}
+
+fn decode_snapshot(decoder: &mut Decoder<'_>) -> Option<SnapshotDto> {
     let entry_count = decoder.read_count()?;
     let mut entries = Vec::with_capacity(entry_count);
     for _ in 0..entry_count {
@@ -1045,15 +2250,7 @@ fn decode_resolve_record(bytes: &[u8]) -> Option<ResolveRecordDto> {
             _ => return None,
         });
     }
-    decoder.finish()?;
-    Some(ResolveRecordDto {
-        identity,
-        resource,
-        file_dependencies,
-        context_dependencies,
-        missing_dependencies,
-        snapshot: SnapshotDto { entries },
-    })
+    Some(SnapshotDto { entries })
 }
 
 #[derive(Debug, Default)]
@@ -1333,6 +2530,7 @@ impl<'a> Decoder<'a> {
 #[derive(Debug, Clone, Default)]
 struct PackFileIndex {
     revision: u64,
+    guard: Option<PackFileGuardDto>,
     entries: BTreeMap<PackFileAddress, PackFileIndexEntry>,
 }
 
@@ -1371,9 +2569,13 @@ pub(crate) struct PackFile {
 }
 
 impl PackFile {
+    pub(crate) fn index_path(root: impl AsRef<Path>) -> PathBuf {
+        root.as_ref().join(INDEX_FILE)
+    }
+
     pub(crate) fn open(root: impl AsRef<Path>, registry: CodecRegistry) -> Self {
         let root = root.as_ref().to_path_buf();
-        let index_path = root.join(INDEX_FILE);
+        let index_path = Self::index_path(&root);
         let index = read_bounded(&index_path, MAX_INDEX_BYTES)
             .and_then(|bytes| decode_index(&bytes))
             .unwrap_or_default();
@@ -1389,8 +2591,17 @@ impl PackFile {
         }
     }
 
-    pub(crate) fn entry_count(&self) -> usize {
+    #[cfg(test)]
+    fn entry_count(&self) -> usize {
         self.index.entries.len()
+    }
+
+    pub(crate) fn revision(&self) -> u64 {
+        self.index.revision
+    }
+
+    pub(crate) fn guard(&self) -> Option<&PackFileGuardDto> {
+        self.index.guard.as_ref()
     }
 
     pub(crate) fn get<T: PackFileItem>(
@@ -1440,7 +2651,16 @@ impl PackFile {
         self.get(address, etag)
     }
 
-    pub(crate) fn publish_items<T, I>(
+    pub(crate) fn get_module_build_record(
+        &mut self,
+        address: &PackFileAddress,
+        etag: Option<&PackFileETag>,
+    ) -> Option<Arc<ModuleBuildRecordDto>> {
+        self.get(address, etag)
+    }
+
+    #[cfg(test)]
+    fn publish_items<T, I>(
         root: impl AsRef<Path>,
         registry: &CodecRegistry,
         items: I,
@@ -1452,13 +2672,35 @@ impl PackFile {
         publish_items(root.as_ref(), registry, items, PublishFault::None)
     }
 
-    pub(crate) fn publish_resolve_records<I>(
+    pub(crate) fn publish_batch(
+        root: impl AsRef<Path>,
+        guard: Option<PackFileGuardDto>,
+        base: PublicationBase,
+        batch: PackFileWriteBatch,
+    ) -> io::Result<()> {
+        publish_batch(root.as_ref(), guard, base, batch, PublishFault::None)
+    }
+
+    #[cfg(test)]
+    fn publish_resolve_records<I>(
         root: impl AsRef<Path>,
         registry: &CodecRegistry,
         records: I,
     ) -> io::Result<()>
     where
         I: IntoIterator<Item = (PackFileAddress, Option<PackFileETag>, ResolveRecordDto)>,
+    {
+        Self::publish_items(root, registry, records)
+    }
+
+    #[cfg(test)]
+    fn publish_module_build_records<I>(
+        root: impl AsRef<Path>,
+        registry: &CodecRegistry,
+        records: I,
+    ) -> io::Result<()>
+    where
+        I: IntoIterator<Item = (PackFileAddress, Option<PackFileETag>, ModuleBuildRecordDto)>,
     {
         Self::publish_items(root, registry, records)
     }
@@ -1489,6 +2731,7 @@ enum PublishFault {
     BeforeIndexReplace,
 }
 
+#[cfg(test)]
 fn publish_items<T, I>(
     root: &Path,
     registry: &CodecRegistry,
@@ -1499,13 +2742,47 @@ where
     T: PackFileItem,
     I: IntoIterator<Item = (PackFileAddress, Option<PackFileETag>, T)>,
 {
-    let items = items
-        .into_iter()
-        .map(|(address, etag, value)| (address, (etag, value)))
-        .collect::<BTreeMap<_, _>>();
     let current = read_bounded(&root.join(INDEX_FILE), MAX_INDEX_BYTES)
         .and_then(|bytes| decode_index(&bytes))
         .unwrap_or_default();
+    let mut batch = PackFileWriteBatch::new();
+    for (address, etag, value) in items {
+        batch.insert(registry, address, etag, value)?;
+    }
+    let expected_revision = current.revision;
+    publish_batch(
+        root,
+        current.guard,
+        PublicationBase::PreserveEntries { expected_revision },
+        batch,
+        fault,
+    )
+}
+
+fn publish_batch(
+    root: &Path,
+    guard: Option<PackFileGuardDto>,
+    base: PublicationBase,
+    batch: PackFileWriteBatch,
+    fault: PublishFault,
+) -> io::Result<()> {
+    let current = read_bounded(&root.join(INDEX_FILE), MAX_INDEX_BYTES)
+        .and_then(|bytes| decode_index(&bytes))
+        .unwrap_or_default();
+    let mut entries = match base {
+        PublicationBase::PreserveEntries { expected_revision }
+            if current.revision == expected_revision =>
+        {
+            current.entries
+        }
+        PublicationBase::PreserveEntries { .. } => {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "PackFile publication base revision changed",
+            ));
+        }
+        PublicationBase::ReplaceAll => BTreeMap::new(),
+    };
     let revision = current
         .revision
         .checked_add(1)
@@ -1517,10 +2794,8 @@ where
     let filename = format!("pack-{revision:016x}.bin");
     let relative_path = PathBuf::from(CONTENT_DIRECTORY).join(&filename);
     let mut content_pack = Vec::new();
-    let mut entries = current.entries;
-    for (address, (etag, value)) in items {
-        let (codec_id, payload) = registry.encode(&value)?;
-        let frame = encode_content(T::TYPE_ID, codec_id, &payload)?;
+    for (address, item) in batch.items {
+        let frame = encode_content(item.type_id, item.codec_id, &item.payload)?;
         let offset = u64::try_from(content_pack.len()).map_err(|_| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -1541,9 +2816,9 @@ where
         entries.insert(
             address,
             PackFileIndexEntry {
-                etag,
-                type_id: T::TYPE_ID,
-                codec_id,
+                etag: item.etag,
+                type_id: item.type_id,
+                codec_id: item.codec_id,
                 content: ContentReference {
                     file: relative_path.clone(),
                     offset,
@@ -1569,7 +2844,11 @@ where
         return Err(injected_publish_error("after content commit"));
     }
 
-    let index = PackFileIndex { revision, entries };
+    let index = PackFileIndex {
+        revision,
+        guard,
+        entries,
+    };
     let index_bytes = encode_index(&index)?;
     let temporary_index = root.join(format!(".{INDEX_FILE}-{revision:016x}.tmp"));
     write_synced(&temporary_index, &index_bytes)?;
@@ -1631,6 +2910,15 @@ fn read_content_reference(path: &Path, reference: &ContentReference) -> Option<V
 fn encode_index(index: &PackFileIndex) -> io::Result<Vec<u8>> {
     let mut body = Encoder::default();
     body.write_u64(index.revision);
+    match &index.guard {
+        Some(guard) => {
+            body.write_u8(1);
+            body.write_bytes(&guard.version)?;
+            encode_snapshot(&mut body, &guard.build_dependencies)?;
+            encode_snapshot(&mut body, &guard.resolve_build_dependencies)?;
+        }
+        None => body.write_u8(0),
+    }
     body.write_count(index.entries.len())?;
     for (address, entry) in &index.entries {
         body.write_bytes(&address.namespace)?;
@@ -1652,6 +2940,15 @@ fn decode_index(bytes: &[u8]) -> Option<PackFileIndex> {
     let body = decode_frame(bytes, INDEX_MAGIC, MAX_INDEX_BYTES)?;
     let mut decoder = Decoder::new(body);
     let revision = decoder.read_u64()?;
+    let guard = match decoder.read_u8()? {
+        0 => None,
+        1 => Some(PackFileGuardDto {
+            version: decoder.read_bytes()?,
+            build_dependencies: decode_snapshot(&mut decoder)?,
+            resolve_build_dependencies: decode_snapshot(&mut decoder)?,
+        }),
+        _ => return None,
+    };
     let count = decoder.read_count()?;
     let mut entries = BTreeMap::new();
     for _ in 0..count {
@@ -1688,7 +2985,11 @@ fn decode_index(bytes: &[u8]) -> Option<PackFileIndex> {
         );
     }
     decoder.finish()?;
-    Some(PackFileIndex { revision, entries })
+    Some(PackFileIndex {
+        revision,
+        guard,
+        entries,
+    })
 }
 
 fn encode_content(

--- a/crates/unpack_core/src/snapshot.rs
+++ b/crates/unpack_core/src/snapshot.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     fs, io,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
@@ -335,49 +335,67 @@ impl Snapshot {
     }
 
     pub(crate) fn from_pack_file_dto(dto: SnapshotDto) -> Option<Self> {
-        let entries = dto
-            .entries
-            .into_iter()
-            .map(|entry| match entry {
+        let mut seen_paths = BTreeSet::new();
+        let mut entries = Vec::with_capacity(dto.entries.len());
+        for entry in dto.entries {
+            let path = match &entry {
+                SnapshotEntryDto::File { path, .. }
+                | SnapshotEntryDto::Context { path, .. }
+                | SnapshotEntryDto::MissingExistence { path }
+                | SnapshotEntryDto::ImmutablePath { path }
+                | SnapshotEntryDto::ManagedPath { path, .. } => path.to_path_buf()?,
+            };
+            if !seen_paths.insert(path.clone()) {
+                return None;
+            }
+            entries.push(match entry {
                 SnapshotEntryDto::File {
                     path,
                     exists,
                     modified,
                     source_hash,
-                } => Some(SnapshotEntry::File(SnapshottedFile {
-                    path: path.to_path_buf()?,
-                    snapshot: FileSnapshot {
-                        exists,
-                        modified: match modified {
-                            Some(value) => Some(system_time_from_dto(value)?),
-                            None => None,
+                } => {
+                    if !exists && (modified.is_some() || source_hash.is_some()) {
+                        return None;
+                    }
+                    SnapshotEntry::File(SnapshottedFile {
+                        path: path.to_path_buf()?,
+                        snapshot: FileSnapshot {
+                            exists,
+                            modified: match modified {
+                                Some(value) => Some(system_time_from_dto(value)?),
+                                None => None,
+                            },
+                            source_hash,
                         },
-                        source_hash,
-                    },
-                })),
+                    })
+                }
                 SnapshotEntryDto::Context {
                     path,
                     exists,
                     timestamp_hash,
                     content_hash,
-                } => Some(SnapshotEntry::Context(SnapshottedContext {
-                    path: path.to_path_buf()?,
-                    snapshot: ContextSnapshot {
-                        exists,
-                        timestamp_hash,
-                        content_hash,
-                    },
-                })),
-                SnapshotEntryDto::MissingExistence { path } => {
-                    Some(SnapshotEntry::MissingExistence {
+                } => {
+                    if !exists && (timestamp_hash.is_some() || content_hash.is_some()) {
+                        return None;
+                    }
+                    SnapshotEntry::Context(SnapshottedContext {
                         path: path.to_path_buf()?,
+                        snapshot: ContextSnapshot {
+                            exists,
+                            timestamp_hash,
+                            content_hash,
+                        },
                     })
                 }
-                SnapshotEntryDto::ImmutablePath { path } => Some(SnapshotEntry::ImmutablePath {
+                SnapshotEntryDto::MissingExistence { path } => SnapshotEntry::MissingExistence {
                     path: path.to_path_buf()?,
-                }),
+                },
+                SnapshotEntryDto::ImmutablePath { path } => SnapshotEntry::ImmutablePath {
+                    path: path.to_path_buf()?,
+                },
                 SnapshotEntryDto::ManagedPath { path, root, state } => {
-                    Some(SnapshotEntry::ManagedPath(ManagedPathSnapshot {
+                    SnapshotEntry::ManagedPath(ManagedPathSnapshot {
                         path: path.to_path_buf()?,
                         root: root.to_path_buf()?,
                         state: match state {
@@ -387,10 +405,10 @@ impl Snapshot {
                                 ManagedItemState::Package { name, version }
                             }
                         },
-                    }))
+                    })
                 }
-            })
-            .collect::<Option<Vec<_>>>()?;
+            });
+        }
         Some(Self { entries })
     }
 
@@ -1042,10 +1060,15 @@ impl ManagedItemState {
         }
 
         let package_json = root.join("package.json");
-        let source = fs::read(&package_json).ok()?;
-        let json = serde_json::from_slice::<serde_json::Value>(&source).ok()?;
-        let name = json.get("name")?.as_str()?.to_string();
-        let version = json.get("version")?.as_str()?.to_string();
+        #[derive(Deserialize)]
+        struct PackageIdentity {
+            name: String,
+            version: String,
+        }
+
+        let mut source = fs::read(&package_json).ok()?;
+        let PackageIdentity { name, version } =
+            simd_json::serde::from_slice::<PackageIdentity>(&mut source).ok()?;
 
         Some(Self::Package { name, version })
     }

--- a/docs/implementation/snapshot-build-cache-alignment.md
+++ b/docs/implementation/snapshot-build-cache-alignment.md
@@ -87,7 +87,7 @@ Replace file-only snapshots with aggregate snapshot records.
 - Add context snapshots with directory modified time plus stable directory-entry digest in timestamp mode.
 - Add missing existence snapshots that only validate absence/presence.
 - Add snapshot merge with webpack-like map override and set union behavior.
-- Keep the serialized snapshot schema Unpack-private while relying on cache magic, user cache version, and DTO deserialization failure to reject incompatible persistent cache data.
+- Keep the serialized snapshot schema Unpack-private and encode it through bounded explicit PackFile DTO codecs; cache magic, user cache version, type identifiers, and decode rejection guard incompatible data.
 
 Done when module, resolve, build-dependency, and resolve-build-dependency validation can all store the same aggregate snapshot type.
 

--- a/docs/implementation/watch-and-incremental-build.md
+++ b/docs/implementation/watch-and-incremental-build.md
@@ -44,7 +44,7 @@ Add filesystem cache as an opt-in cache layer.
 
 - Store persistent cache items in cache packs under a cache location.
 - Store container metadata for cache version, build-dependency snapshot, and cache item metadata.
-- Store manifest metadata as JSON and pack shards as `cbor4ii`-encoded cache DTOs.
+- Store container guards and Cache Item metadata in an Unpack-private binary index, with explicit codecs and lazily referenced content packs.
 - Queue persistent writes and flush them during compiler idle.
 - Close waits for pending cache flushes or reports infrastructure errors.
 

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, realpath, rm, utimes, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -519,17 +519,13 @@ test("accepts filesystem cache option shape", async () => {
 
     assert.equal(first.err, null);
     assert.equal(first.stats?.hasErrors(), false);
-    const manifest = JSON.parse(
-      await readFile(join(fixture, ".cache/unpack/test-cache/container.json"), "utf8")
-    ) as {
-      magic?: string;
-      build_dependencies?: { entries?: unknown[] };
-      resolve_build_dependencies?: { entries?: unknown[] };
-    };
-    assert.equal(manifest.magic, "UNPACK_PERSISTENT_CACHE");
-    assert.equal(manifest.build_dependencies?.entries?.length, 1);
-    assert.equal(manifest.resolve_build_dependencies?.entries?.length, 1);
-    assert.ok(await readFile(join(fixture, ".cache/unpack/test-cache/packs/modules.cbor")));
+    assert.ok(await stat(join(fixture, ".cache/unpack/test-cache/index.pack")));
+    await assert.rejects(
+      stat(join(fixture, ".cache/unpack/test-cache/container.json"))
+    );
+    await assert.rejects(
+      stat(join(fixture, ".cache/unpack/test-cache/packs/modules.cbor"))
+    );
 
     const secondCompiler = unpack({
       context: fixture,
@@ -564,13 +560,10 @@ test("filesystem cache flushes after idle timeout", async () => {
   try {
     const result = await runExistingCompiler(compiler);
     assert.equal(result.err, null);
-    await assert.rejects(readFile(join(cacheLocation, "container.json"), "utf8"));
+    await assert.rejects(stat(join(cacheLocation, "index.pack")));
 
     await delay(100);
-    assert.match(
-      await readFile(join(cacheLocation, "container.json"), "utf8"),
-      /UNPACK_PERSISTENT_CACHE/
-    );
+    assert.ok(await stat(join(cacheLocation, "index.pack")));
   } finally {
     await closeCompiler(compiler);
     await rm(fixture, { recursive: true, force: true });
@@ -597,10 +590,7 @@ test("compiler close waits for pending filesystem cache flush", async () => {
     assert.equal(result.err, null);
 
     await closeCompiler(compiler);
-    assert.match(
-      await readFile(join(cacheLocation, "container.json"), "utf8"),
-      /UNPACK_PERSISTENT_CACHE/
-    );
+    assert.ok(await stat(join(cacheLocation, "index.pack")));
   } finally {
     await rm(fixture, { recursive: true, force: true });
   }
@@ -628,8 +618,7 @@ test("filesystem cache readonly skips persistent writes", async () => {
     await delay(50);
 
     await closeCompiler(compiler);
-    await assert.rejects(readFile(join(cacheLocation, "container.json"), "utf8"));
-    await assert.rejects(readFile(join(cacheLocation, "packs/modules.cbor"), "utf8"));
+    await assert.rejects(stat(cacheLocation));
   } finally {
     await rm(fixture, { recursive: true, force: true });
   }

--- a/packages/unpack/test/cache-process-driver.ts
+++ b/packages/unpack/test/cache-process-driver.ts
@@ -25,7 +25,8 @@ async function observeBuild(
     hasStats: false,
     hasErrors: null,
     assets: [],
-    outputPath: null
+    outputPath: null,
+    cacheWork: null
   } satisfies CacheProcessObservation;
 
   let compiler: ReturnType<typeof unpack> | ReturnType<typeof webpack>;

--- a/packages/unpack/test/cache-process-harness.ts
+++ b/packages/unpack/test/cache-process-harness.ts
@@ -30,6 +30,20 @@ export interface CacheProcessObservation {
   hasErrors: boolean | null;
   assets: string[];
   outputPath: string | null;
+  cacheWork: CacheWorkObservation | null;
+}
+
+export interface CacheItemWorkObservation {
+  hits: number;
+  misses: number;
+  stores: number;
+  restores: number;
+  evictions: number;
+}
+
+export interface CacheWorkObservation {
+  resolve: CacheItemWorkObservation;
+  moduleBuild: CacheItemWorkObservation;
 }
 
 export async function runColdWarmBuilds(
@@ -51,12 +65,47 @@ export async function runCacheProcess(
     [driver, JSON.stringify(request)],
     {
       cwd: options.cwd,
-      maxBuffer: 1024 * 1024
+      maxBuffer: 1024 * 1024,
+      env: {
+        ...process.env,
+        UNPACK_INTERNAL_TRACING: "unpack_core::cache_work=info"
+      }
     }
   );
   const output = stdout.trim().split("\n").at(-1);
   if (!output) {
     throw new Error(`cache process produced no observation${stderr ? `: ${stderr}` : ""}`);
   }
-  return JSON.parse(output) as CacheProcessObservation;
+  return {
+    ...(JSON.parse(output) as CacheProcessObservation),
+    cacheWork: parseCacheWork(stderr)
+  };
+}
+
+function parseCacheWork(stderr: string): CacheWorkObservation | null {
+  const line = stderr
+    .trim()
+    .split("\n")
+    .findLast((candidate) => candidate.includes("cache_work"));
+  if (line === undefined) {
+    return null;
+  }
+  const field = (name: string) => {
+    const value = new RegExp(`(?:^|\\s)${name}=(\\d+)`).exec(line)?.[1];
+    if (value === undefined) {
+      throw new Error(`cache work trace is missing ${name}: ${line}`);
+    }
+    return Number(value);
+  };
+  const item = (prefix: "resolve" | "module") => ({
+    hits: field(`${prefix}_hits`),
+    misses: field(`${prefix}_misses`),
+    stores: field(`${prefix}_stores`),
+    restores: field(`${prefix}_restores`),
+    evictions: field(`${prefix}_evictions`)
+  });
+  return {
+    resolve: item("resolve"),
+    moduleBuild: item("module")
+  };
 }

--- a/packages/unpack/test/persistent-cache-contract.test.ts
+++ b/packages/unpack/test/persistent-cache-contract.test.ts
@@ -251,6 +251,188 @@ test("selective cold and warm observations run Unpack and pinned webpack in inde
   }
 });
 
+test("unchanged Resolve and Module Build work restores in an independent process", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "import './dep.js'; export const result = 'ok';",
+    "src/dep.js": "export const value = 1;"
+  });
+  const cacheLocation = join(fixture, ".cache/unpack/cross-process-hits");
+
+  try {
+    const { cold, warm } = await runColdWarmBuilds({
+      bundler: "unpack",
+      options: {
+        context: fixture,
+        mode: "development",
+        outputPath: join(fixture, "dist"),
+        cache: { type: "filesystem", cacheLocation }
+      }
+    });
+
+    assertColdWarmPublicOutcome({ cold, warm });
+    assert.deepEqual(cold.cacheWork, {
+      resolve: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
+      moduleBuild: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 }
+    });
+    assert.deepEqual(warm.cacheWork, {
+      resolve: { hits: 2, misses: 0, stores: 0, restores: 2, evictions: 0 },
+      moduleBuild: { hits: 2, misses: 0, stores: 0, restores: 2, evictions: 0 }
+    });
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("a source mutation rebuilds only the affected Module Build record", async () => {
+  const fixture = await createFixture({
+    "src/index.js": [
+      "import { changed } from './changed.js';",
+      "import { stable } from './stable.js';",
+      "export const result = `${changed}:${stable}`;"
+    ].join("\n"),
+    "src/changed.js": "export const changed = 'before';",
+    "src/stable.js": "export const stable = 'stable';"
+  });
+  const cacheLocation = join(fixture, ".cache/unpack/selective-module-build");
+  const request = {
+    bundler: "unpack" as const,
+    options: {
+      context: fixture,
+      mode: "none" as const,
+      outputPath: join(fixture, "dist"),
+      cache: { type: "filesystem", cacheLocation },
+      snapshot: {
+        module: { timestamp: false, hash: true },
+        resolve: { timestamp: false, hash: false }
+      }
+    }
+  };
+
+  try {
+    const cold = await runCacheProcess(request);
+    assert.equal(cold.error, null);
+    assert.deepEqual(cold.cacheWork, {
+      resolve: { hits: 0, misses: 3, stores: 3, restores: 0, evictions: 0 },
+      moduleBuild: { hits: 0, misses: 3, stores: 3, restores: 0, evictions: 0 }
+    });
+
+    await writeFile(
+      join(fixture, "src/changed.js"),
+      "export const changed = 'after';",
+      "utf8"
+    );
+    const changed = await runCacheProcess(request);
+
+    assert.equal(changed.error, null);
+    assert.deepEqual(changed.cacheWork, {
+      resolve: { hits: 3, misses: 0, stores: 0, restores: 3, evictions: 0 },
+      moduleBuild: { hits: 3, misses: 0, stores: 1, restores: 3, evictions: 0 }
+    });
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /after/);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /stable/);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("cache version is an exact container guard at the same location", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "import './dep.js'; export const result = 'versioned';",
+    "src/dep.js": "export const value = 1;"
+  });
+  const cacheLocation = join(fixture, ".cache/unpack/version-guard");
+  const build = (version: string) =>
+    runCacheProcess({
+      bundler: "unpack",
+      options: {
+        context: fixture,
+        mode: "none",
+        outputPath: join(fixture, "dist"),
+        cache: { type: "filesystem", cacheLocation, version }
+      }
+    });
+
+  try {
+    const firstV1 = await build("v1");
+    const firstV2 = await build("v2");
+    const warmV2 = await build("v2");
+
+    for (const cold of [firstV1, firstV2]) {
+      assert.equal(cold.error, null);
+      assert.deepEqual(cold.cacheWork, {
+        resolve: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
+        moduleBuild: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 }
+      });
+    }
+    assert.deepEqual(warmV2.cacheWork, {
+      resolve: { hits: 2, misses: 0, stores: 0, restores: 2, evictions: 0 },
+      moduleBuild: { hits: 2, misses: 0, stores: 0, restores: 2, evictions: 0 }
+    });
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("legacy JSON and CBOR cache files remain untouched and are treated as cold", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "import './dep.js'; export const result = 'legacy-cold';",
+    "src/dep.js": "export const value = 1;"
+  });
+  const cacheLocation = join(fixture, ".cache/unpack/legacy");
+  const manifestPath = join(cacheLocation, "container.json");
+  const packPath = join(cacheLocation, "packs/modules.cbor");
+  const manifest = Buffer.from(
+    JSON.stringify({
+      magic: "UNPACK_PERSISTENT_CACHE",
+      cache_version: "",
+      pack_file: "packs/modules.cbor",
+      build_dependencies: { entries: [] },
+      resolve_build_dependencies: { entries: [] }
+    })
+  );
+  // A valid legacy CachePackDto encoded as CBOR with empty record arrays. Keep
+  // these bytes static so the removed legacy serializer never returns as a test dependency.
+  const pack = Buffer.concat([
+    Buffer.from("UNPACK-CACHE-PACK\0"),
+    Buffer.from([0xa4, 0x65]),
+    Buffer.from("magic"),
+    Buffer.from([0x77]),
+    Buffer.from("UNPACK_PERSISTENT_CACHE"),
+    Buffer.from([0x6d]),
+    Buffer.from("cache_version"),
+    Buffer.from([0x60, 0x6f]),
+    Buffer.from("resolve_records"),
+    Buffer.from([0x80, 0x6d]),
+    Buffer.from("module_builds"),
+    Buffer.from([0x80])
+  ]);
+  await mkdir(dirname(packPath), { recursive: true });
+  await writeFile(manifestPath, manifest);
+  await writeFile(packPath, pack);
+
+  try {
+    const observation = await runCacheProcess({
+      bundler: "unpack",
+      options: {
+        context: fixture,
+        mode: "none",
+        outputPath: join(fixture, "dist"),
+        cache: { type: "filesystem", cacheLocation }
+      }
+    });
+
+    assert.equal(observation.error, null);
+    assert.deepEqual(observation.cacheWork, {
+      resolve: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
+      moduleBuild: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 }
+    });
+    assert.deepEqual(await readFile(manifestPath), manifest);
+    assert.deepEqual(await readFile(packPath), pack);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 test("cache validation is synchronous for Unpack and pinned webpack", async () => {
   const fixture = await createFixture({
     "src/index.js": "export const value = 1;"


### PR DESCRIPTION
## Summary

- Switch filesystem cache persistence from the legacy JSON manifest and CBOR pack to the private PackFile index/content backend.
- Add Module Build Record PackFile DTO, stable type/codec identifiers, codec validation, and production restore/store wiring alongside Resolve Records.
- Cover cross-process warm cache hits, source mutation invalidation, cache-version cold behavior, and legacy JSON/CBOR cold-cache handling through the public JavaScript API.

Closes #143

## Tests

- cargo test --workspace
- pnpm --filter @unpack-js/core test
- pnpm --filter @unpack-js/benchmarks test
