### PR TITLE
Move cache idle lifecycle into Compiler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ swc_experimental_ecma_ast = "0.11.0"
 swc_experimental_ecma_parser = "0.11.0"
 tempfile = "3.23.0"
 thiserror = "2.0.17"
-tokio = { version = "1.48.0", features = ["fs", "macros", "rt", "rt-multi-thread", "sync"] }
+tokio = { version = "1.48.0", features = ["fs", "macros", "rt", "rt-multi-thread", "sync", "time"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt"] }

--- a/crates/unpack_core/Cargo.toml
+++ b/crates/unpack_core/Cargo.toml
@@ -23,6 +23,7 @@ tracing = { workspace = true }
 divan = { workspace = true }
 filetime = { workspace = true }
 tempfile = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 
 [[bench]]
 name = "make_phase"

--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -151,6 +151,8 @@ pub struct CacheOptions {
     pub build_dependencies: Vec<BuildDependency>,
     pub max_memory_generations: Option<u32>,
     pub idle_timeout: Option<u32>,
+    pub idle_timeout_for_initial_store: Option<u32>,
+    pub idle_timeout_after_large_changes: Option<u32>,
     pub readonly: bool,
 }
 
@@ -171,6 +173,8 @@ impl CacheOptions {
             build_dependencies: Vec::new(),
             max_memory_generations: None,
             idle_timeout: None,
+            idle_timeout_for_initial_store: None,
+            idle_timeout_after_large_changes: None,
             readonly: false,
         }
     }
@@ -185,6 +189,8 @@ impl CacheOptions {
             build_dependencies: Vec::new(),
             max_memory_generations: None,
             idle_timeout: None,
+            idle_timeout_for_initial_store: None,
+            idle_timeout_after_large_changes: None,
             readonly: false,
         }
     }
@@ -198,7 +204,9 @@ impl CacheOptions {
             version: None,
             build_dependencies: Vec::new(),
             max_memory_generations: None,
-            idle_timeout: None,
+            idle_timeout: Some(60_000),
+            idle_timeout_for_initial_store: Some(5_000),
+            idle_timeout_after_large_changes: Some(1_000),
             readonly: false,
         }
     }
@@ -220,7 +228,20 @@ pub struct BuildDependency {
 #[derive(Debug)]
 struct BuildCacheInner {
     cache: Cache,
-    dirty: bool,
+    dirty_generation: u64,
+    published_generation: u64,
+    initial_store_pending: bool,
+    persistent_guard: Option<PackFileGuardDto>,
+    persistent_guard_error: Option<String>,
+    #[cfg(test)]
+    publish_barrier: Option<PublishBarrier>,
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+struct PublishBarrier {
+    entered: Arc<std::sync::Barrier>,
+    release: Arc<std::sync::Barrier>,
 }
 
 impl BuildCacheInner {
@@ -230,14 +251,22 @@ impl BuildCacheInner {
         build_dependency_snapshot_strategy: SnapshotStrategy,
         resolve_build_dependency_snapshot_strategy: SnapshotStrategy,
     ) -> Self {
+        let cache = Cache::from_options(
+            options,
+            file_system_info,
+            build_dependency_snapshot_strategy,
+            resolve_build_dependency_snapshot_strategy,
+        );
+        let initial_store_pending = !cache.has_persistent_publication();
         Self {
-            cache: Cache::from_options(
-                options,
-                file_system_info,
-                build_dependency_snapshot_strategy,
-                resolve_build_dependency_snapshot_strategy,
-            ),
-            dirty: false,
+            cache,
+            dirty_generation: 0,
+            published_generation: 0,
+            initial_store_pending,
+            persistent_guard: None,
+            persistent_guard_error: None,
+            #[cfg(test)]
+            publish_barrier: None,
         }
     }
 }
@@ -299,6 +328,9 @@ trait CacheLayer: fmt::Debug + Send + Sync {
     fn store(&mut self, address: CacheAddress, entry: CacheEntry);
     fn publish(&mut self, _guard: &PackFileGuardDto) -> io::Result<()> {
         Ok(())
+    }
+    fn has_publication(&self) -> bool {
+        false
     }
     #[allow(dead_code)]
     fn evict(&mut self, address: &CacheAddress) -> bool;
@@ -480,6 +512,10 @@ impl CacheLayer for PackFileCacheLayer {
         PackFileCacheLayer::publish(self, guard.clone())
     }
 
+    fn has_publication(&self) -> bool {
+        self.active
+    }
+
     fn evict(&mut self, address: &CacheAddress) -> bool {
         self.pending.remove(address).is_some()
     }
@@ -636,6 +672,13 @@ impl Cache {
             return Ok(());
         };
         slot.layer.publish(&guard)
+    }
+
+    fn has_persistent_publication(&self) -> bool {
+        self.layers
+            .iter()
+            .find(|slot| slot.kind == CacheLayerKind::Persistent)
+            .is_some_and(|slot| slot.layer.has_publication())
     }
 }
 
@@ -989,27 +1032,93 @@ impl BuildCache {
         }
     }
 
-    pub(crate) fn flush_to_filesystem(&self) -> io::Result<()> {
+    pub(crate) fn store_build_dependencies(&self) {
         if self.options.kind != CacheKind::Filesystem || self.options.readonly {
-            return Ok(());
+            return;
         }
-
-        if !self
-            .inner
-            .lock()
-            .expect("build cache mutex should not be poisoned")
-            .dirty
-        {
-            return Ok(());
-        }
-        let guard = self.current_persistent_guard()?;
+        let guard = self
+            .current_persistent_guard()
+            .map_err(|error| error.to_string());
         let mut inner = self
             .inner
             .lock()
             .expect("build cache mutex should not be poisoned");
+        match guard {
+            Ok(guard) => {
+                inner.persistent_guard = Some(guard);
+                inner.persistent_guard_error = None;
+            }
+            Err(error) => {
+                inner.persistent_guard = None;
+                inner.persistent_guard_error = Some(error);
+            }
+        }
+    }
+
+    pub(crate) fn pending_generation(&self) -> Option<u64> {
+        let inner = self
+            .inner
+            .lock()
+            .expect("build cache mutex should not be poisoned");
+        (inner.dirty_generation > inner.published_generation).then_some(inner.dirty_generation)
+    }
+
+    pub(crate) fn initial_store_pending(&self) -> bool {
+        self.inner
+            .lock()
+            .expect("build cache mutex should not be poisoned")
+            .initial_store_pending
+    }
+
+    pub(crate) fn publish_generation(&self, target_generation: u64) -> io::Result<()> {
+        if self.options.kind != CacheKind::Filesystem || self.options.readonly {
+            return Ok(());
+        }
+        let mut inner = self
+            .inner
+            .lock()
+            .expect("build cache mutex should not be poisoned");
+        if target_generation <= inner.published_generation {
+            return Ok(());
+        }
+        #[cfg(test)]
+        if let Some(barrier) = inner.publish_barrier.take() {
+            barrier.entered.wait();
+            barrier.release.wait();
+        }
+        if let Some(error) = &inner.persistent_guard_error {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, error.clone()));
+        }
+        let guard = inner.persistent_guard.clone().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Build Dependency state was not stored before cache publication",
+            )
+        })?;
         inner.cache.publish_persistent(guard)?;
-        inner.dirty = false;
+        inner.published_generation = inner.published_generation.max(target_generation);
+        inner.initial_store_pending = false;
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_publish_barrier(
+        &self,
+        entered: Arc<std::sync::Barrier>,
+        release: Arc<std::sync::Barrier>,
+    ) {
+        self.inner
+            .lock()
+            .expect("build cache mutex should not be poisoned")
+            .publish_barrier = Some(PublishBarrier { entered, release });
+    }
+
+    pub(crate) fn flush_to_filesystem(&self) -> io::Result<()> {
+        self.store_build_dependencies();
+        let Some(target_generation) = self.pending_generation() else {
+            return Ok(());
+        };
+        self.publish_generation(target_generation)
     }
 
     #[cfg(test)]
@@ -1118,7 +1227,7 @@ where
             identifier: key.cache_identifier(),
         };
         if inner.cache.store(self.family, address, etag, value) {
-            inner.dirty = true;
+            inner.dirty_generation = inner.dirty_generation.saturating_add(1);
         }
     }
 
@@ -1225,6 +1334,14 @@ mod tests {
         fn cache_identifier(&self) -> CacheIdentifier {
             CacheIdentifier::new(self.0)
         }
+    }
+
+    #[test]
+    fn filesystem_cache_uses_pinned_idle_timeout_defaults() {
+        let options = CacheOptions::filesystem();
+        assert_eq!(options.idle_timeout, Some(60_000));
+        assert_eq!(options.idle_timeout_for_initial_store, Some(5_000));
+        assert_eq!(options.idle_timeout_after_large_changes, Some(1_000));
     }
 
     #[test]

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -1,4 +1,8 @@
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex, Weak},
+    time::Duration,
+};
 
 use crate::{
     CacheOptions, Compilation, InfrastructureLoggingOptions, ResolveOptions, Result,
@@ -54,14 +58,570 @@ impl CompilerOptions {
 pub struct Compiler {
     options: CompilerOptions,
     build_cache: BuildCache,
+    cache_lifecycle: Arc<CacheLifecycle>,
+}
+
+#[derive(Debug)]
+pub struct PendingCompilation {
+    compilation: Option<Compilation>,
+    cache_activity: Option<CacheRunActivity>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CacheLifecycleOutcome {
+    diagnostic: Option<String>,
+}
+
+impl CacheLifecycleOutcome {
+    pub fn diagnostic(&self) -> Option<&str> {
+        self.diagnostic.as_deref()
+    }
+}
+
+impl PendingCompilation {
+    pub fn compilation(&self) -> &Compilation {
+        self.compilation
+            .as_ref()
+            .expect("pending compilation should exist until finish")
+    }
+
+    pub fn finish(mut self) -> Compilation {
+        let compilation = self
+            .compilation
+            .take()
+            .expect("pending compilation should only be finished once");
+        drop(self.cache_activity.take());
+        compilation
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheIdleReason {
+    Ordinary,
+    LargeChange,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CacheIdleTimeouts {
+    ordinary: Duration,
+    initial_store: Duration,
+    after_large_change: Duration,
+}
+
+impl CacheIdleTimeouts {
+    fn from_options(options: &CacheOptions) -> Self {
+        Self {
+            ordinary: Duration::from_millis(u64::from(options.idle_timeout.unwrap_or(60_000))),
+            initial_store: Duration::from_millis(u64::from(
+                options.idle_timeout_for_initial_store.unwrap_or(5_000),
+            )),
+            after_large_change: Duration::from_millis(u64::from(
+                options.idle_timeout_after_large_changes.unwrap_or(1_000),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CacheActivity {
+    Ready,
+    Active { run_id: u64 },
+    Idle,
+    ShuttingDown,
+    Closed,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ScheduledCacheFlush {
+    token: u64,
+    deadline: tokio::time::Instant,
+    reason: CacheFlushReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CacheFlushReason {
+    InitialStore,
+    Ordinary,
+    LargeChange,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct InFlightCacheFlush {
+    target_generation: u64,
+}
+
+#[derive(Debug)]
+struct CacheLifecycleState {
+    activity: CacheActivity,
+    shutdown_run_id: Option<u64>,
+    scheduled: Option<ScheduledCacheFlush>,
+    flush: Option<InFlightCacheFlush>,
+    diagnostic: Option<String>,
+    shutdown_outcome: Option<CacheLifecycleOutcome>,
+    initial_store_deadline: Option<tokio::time::Instant>,
+    ordinary_deadline: Option<tokio::time::Instant>,
+    large_change_deadline: Option<tokio::time::Instant>,
+    next_run_id: u64,
+    next_timer_token: u64,
+}
+
+#[derive(Debug)]
+struct CacheLifecycle {
+    build_cache: BuildCache,
+    timeouts: CacheIdleTimeouts,
+    state: Mutex<CacheLifecycleState>,
+    changed: tokio::sync::watch::Sender<u64>,
+}
+
+impl CacheLifecycle {
+    fn new(build_cache: BuildCache, options: &CacheOptions) -> Arc<Self> {
+        let (changed, _) = tokio::sync::watch::channel(0);
+        Arc::new(Self {
+            build_cache,
+            timeouts: CacheIdleTimeouts::from_options(options),
+            state: Mutex::new(CacheLifecycleState {
+                activity: CacheActivity::Ready,
+                shutdown_run_id: None,
+                scheduled: None,
+                flush: None,
+                diagnostic: None,
+                shutdown_outcome: None,
+                initial_store_deadline: None,
+                ordinary_deadline: None,
+                large_change_deadline: None,
+                next_run_id: 1,
+                next_timer_token: 1,
+            }),
+            changed,
+        })
+    }
+
+    fn end_idle(self: &Arc<Self>, idle_reason: CacheIdleReason) -> Result<CacheRunActivity> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("cache lifecycle mutex should not be poisoned");
+        match state.activity {
+            CacheActivity::Ready | CacheActivity::Idle => {}
+            CacheActivity::Active { .. } => return Err(crate::Error::CompilerBusy),
+            CacheActivity::ShuttingDown | CacheActivity::Closed => {
+                return Err(crate::Error::CompilerClosed);
+            }
+        }
+        state.scheduled = None;
+        state.ordinary_deadline = None;
+        state.large_change_deadline = None;
+        let run_id = state.next_run_id;
+        state.next_run_id = state.next_run_id.saturating_add(1);
+        state.activity = CacheActivity::Active { run_id };
+        drop(state);
+        self.notify_changed();
+        Ok(CacheRunActivity {
+            lifecycle: Arc::downgrade(self),
+            run_id,
+            idle_reason,
+        })
+    }
+
+    fn begin_idle(self: &Arc<Self>, run_id: u64, idle_reason: CacheIdleReason) {
+        let should_schedule = {
+            let mut state = self
+                .state
+                .lock()
+                .expect("cache lifecycle mutex should not be poisoned");
+            if state.activity == CacheActivity::ShuttingDown
+                && state.shutdown_run_id == Some(run_id)
+            {
+                state.shutdown_run_id = None;
+                false
+            } else if state.activity != (CacheActivity::Active { run_id }) {
+                return;
+            } else {
+                state.activity = CacheActivity::Idle;
+                if self.build_cache.pending_generation().is_some() {
+                    let now = tokio::time::Instant::now();
+                    state.ordinary_deadline = Some(now + self.timeouts.ordinary);
+                    if self.build_cache.initial_store_pending()
+                        && state.initial_store_deadline.is_none()
+                    {
+                        state.initial_store_deadline = Some(now + self.timeouts.initial_store);
+                    }
+                    if idle_reason == CacheIdleReason::LargeChange {
+                        state.large_change_deadline = Some(now + self.timeouts.after_large_change);
+                    }
+                    state.flush.is_none()
+                } else {
+                    state.initial_store_deadline = None;
+                    state.ordinary_deadline = None;
+                    state.large_change_deadline = None;
+                    false
+                }
+            }
+        };
+        self.notify_changed();
+        if should_schedule {
+            self.schedule_idle_timer();
+        }
+    }
+
+    fn schedule_idle_timer(self: &Arc<Self>) {
+        let plan = {
+            let mut state = self
+                .state
+                .lock()
+                .expect("cache lifecycle mutex should not be poisoned");
+            if state.activity != CacheActivity::Idle
+                || state.flush.is_some()
+                || state.scheduled.is_some()
+            {
+                return;
+            }
+            let Some(target_generation) = self.build_cache.pending_generation() else {
+                state.initial_store_deadline = None;
+                state.ordinary_deadline = None;
+                state.large_change_deadline = None;
+                return;
+            };
+            let now = tokio::time::Instant::now();
+            if state.ordinary_deadline.is_none() {
+                state.ordinary_deadline = Some(now + self.timeouts.ordinary);
+            }
+            if self.build_cache.initial_store_pending() && state.initial_store_deadline.is_none() {
+                state.initial_store_deadline = Some(now + self.timeouts.initial_store);
+            }
+            let (reason, deadline) = [
+                (CacheFlushReason::InitialStore, state.initial_store_deadline),
+                (CacheFlushReason::LargeChange, state.large_change_deadline),
+                (CacheFlushReason::Ordinary, state.ordinary_deadline),
+            ]
+            .into_iter()
+            .filter_map(|(reason, deadline)| deadline.map(|deadline| (reason, deadline)))
+            .min_by_key(|(_, deadline)| *deadline)
+            .expect("dirty cache should always have an idle deadline");
+            let token = state.next_timer_token;
+            state.next_timer_token = state.next_timer_token.saturating_add(1);
+            state.scheduled = Some(ScheduledCacheFlush {
+                token,
+                deadline,
+                reason,
+            });
+            (token, deadline, target_generation)
+        };
+        self.notify_changed();
+        let (token, deadline, target_generation) = plan;
+        let lifecycle = Arc::downgrade(self);
+        tokio::spawn(async move {
+            tokio::time::sleep_until(deadline).await;
+            let Some(lifecycle) = lifecycle.upgrade() else {
+                return;
+            };
+            lifecycle.fire_timer(token, target_generation).await;
+        });
+    }
+
+    async fn fire_timer(self: Arc<Self>, token: u64, target_generation: u64) {
+        {
+            let mut state = self
+                .state
+                .lock()
+                .expect("cache lifecycle mutex should not be poisoned");
+            if state.activity != CacheActivity::Idle {
+                return;
+            }
+            let Some(scheduled) = state.scheduled.filter(|scheduled| scheduled.token == token)
+            else {
+                return;
+            };
+            if tokio::time::Instant::now() < scheduled.deadline {
+                return;
+            }
+            state.scheduled = None;
+            match scheduled.reason {
+                CacheFlushReason::InitialStore => state.initial_store_deadline = None,
+                CacheFlushReason::Ordinary => state.ordinary_deadline = None,
+                CacheFlushReason::LargeChange => state.large_change_deadline = None,
+            }
+        }
+        self.notify_changed();
+        let Some(current_target) = self.build_cache.pending_generation() else {
+            return;
+        };
+        {
+            let mut state = self
+                .state
+                .lock()
+                .expect("cache lifecycle mutex should not be poisoned");
+            if state.activity != CacheActivity::Idle || state.flush.is_some() {
+                return;
+            }
+            state.flush = Some(InFlightCacheFlush {
+                target_generation: current_target.max(target_generation),
+            });
+        }
+        self.notify_changed();
+        self.perform_flush(current_target.max(target_generation))
+            .await;
+    }
+
+    async fn perform_flush(self: &Arc<Self>, target_generation: u64) {
+        let build_cache = self.build_cache.clone();
+        let result = match tokio::task::spawn_blocking(move || {
+            build_cache.publish_generation(target_generation)
+        })
+        .await
+        {
+            Ok(result) => result.map_err(|error| error.to_string()),
+            Err(error) => Err(format!("cache publication task failed: {error}")),
+        };
+        let mut state = self
+            .state
+            .lock()
+            .expect("cache lifecycle mutex should not be poisoned");
+        if state
+            .flush
+            .is_some_and(|flush| flush.target_generation == target_generation)
+        {
+            state.flush = None;
+        }
+        let should_schedule = match result {
+            Ok(()) => {
+                if self.build_cache.pending_generation().is_none() {
+                    state.initial_store_deadline = None;
+                    state.ordinary_deadline = None;
+                    state.large_change_deadline = None;
+                    false
+                } else {
+                    state.activity == CacheActivity::Idle && state.scheduled.is_none()
+                }
+            }
+            Err(error) => {
+                state.diagnostic = Some(error);
+                false
+            }
+        };
+        drop(state);
+        self.notify_changed();
+        if should_schedule {
+            self.schedule_idle_timer();
+        }
+    }
+
+    async fn settle(self: &Arc<Self>) -> CacheLifecycleOutcome {
+        let mut changed = self.changed.subscribe();
+        loop {
+            enum Action {
+                Start(u64),
+                Wait,
+                Done(CacheLifecycleOutcome),
+            }
+
+            let action = {
+                let mut state = self
+                    .state
+                    .lock()
+                    .expect("cache lifecycle mutex should not be poisoned");
+                state.scheduled = None;
+                state.ordinary_deadline = None;
+                state.large_change_deadline = None;
+                if let Some(diagnostic) = state.diagnostic.take() {
+                    if matches!(state.activity, CacheActivity::Idle) {
+                        state.activity = CacheActivity::Ready;
+                    }
+                    Action::Done(CacheLifecycleOutcome {
+                        diagnostic: Some(diagnostic),
+                    })
+                } else if matches!(state.activity, CacheActivity::Active { .. })
+                    || state.flush.is_some()
+                {
+                    Action::Wait
+                } else {
+                    drop(state);
+                    let target = self.build_cache.pending_generation();
+                    let mut state = self
+                        .state
+                        .lock()
+                        .expect("cache lifecycle mutex should not be poisoned");
+                    if matches!(state.activity, CacheActivity::Active { .. })
+                        || state.flush.is_some()
+                    {
+                        Action::Wait
+                    } else if let Some(target_generation) = target {
+                        state.flush = Some(InFlightCacheFlush { target_generation });
+                        Action::Start(target_generation)
+                    } else {
+                        if matches!(state.activity, CacheActivity::Idle) {
+                            state.activity = CacheActivity::Ready;
+                        }
+                        Action::Done(CacheLifecycleOutcome::default())
+                    }
+                }
+            };
+
+            match action {
+                Action::Start(target_generation) => {
+                    self.notify_changed();
+                    self.perform_flush(target_generation).await;
+                }
+                Action::Wait => {
+                    if changed.changed().await.is_err() {
+                        return CacheLifecycleOutcome {
+                            diagnostic: Some("cache lifecycle stopped unexpectedly".to_string()),
+                        };
+                    }
+                }
+                Action::Done(outcome) => {
+                    self.notify_changed();
+                    return outcome;
+                }
+            }
+        }
+    }
+
+    async fn shutdown(self: &Arc<Self>) -> CacheLifecycleOutcome {
+        let mut changed = self.changed.subscribe();
+        loop {
+            enum Action {
+                Start(u64),
+                Wait,
+                Retry,
+                Done(CacheLifecycleOutcome),
+            }
+
+            let action = {
+                let mut state = self
+                    .state
+                    .lock()
+                    .expect("cache lifecycle mutex should not be poisoned");
+                match state.activity {
+                    CacheActivity::Closed => {
+                        Action::Done(state.shutdown_outcome.clone().unwrap_or_default())
+                    }
+                    CacheActivity::Ready | CacheActivity::Idle => {
+                        state.activity = CacheActivity::ShuttingDown;
+                        state.scheduled = None;
+                        state.initial_store_deadline = None;
+                        state.ordinary_deadline = None;
+                        state.large_change_deadline = None;
+                        Action::Retry
+                    }
+                    CacheActivity::Active { run_id } => {
+                        state.activity = CacheActivity::ShuttingDown;
+                        state.shutdown_run_id = Some(run_id);
+                        state.scheduled = None;
+                        state.initial_store_deadline = None;
+                        state.ordinary_deadline = None;
+                        state.large_change_deadline = None;
+                        Action::Retry
+                    }
+                    CacheActivity::ShuttingDown => {
+                        if state.shutdown_run_id.is_some() || state.flush.is_some() {
+                            Action::Wait
+                        } else {
+                            let diagnostic = state.diagnostic.take();
+                            drop(state);
+                            let target = self.build_cache.pending_generation();
+                            let mut state = self
+                                .state
+                                .lock()
+                                .expect("cache lifecycle mutex should not be poisoned");
+                            if state.shutdown_run_id.is_some() || state.flush.is_some() {
+                                Action::Wait
+                            } else if diagnostic.is_some() {
+                                let outcome = CacheLifecycleOutcome { diagnostic };
+                                state.activity = CacheActivity::Closed;
+                                state.shutdown_outcome = Some(outcome.clone());
+                                Action::Done(outcome)
+                            } else if let Some(target_generation) = target {
+                                state.flush = Some(InFlightCacheFlush { target_generation });
+                                Action::Start(target_generation)
+                            } else {
+                                let outcome = CacheLifecycleOutcome::default();
+                                state.activity = CacheActivity::Closed;
+                                state.shutdown_outcome = Some(outcome.clone());
+                                Action::Done(outcome)
+                            }
+                        }
+                    }
+                }
+            };
+            match action {
+                Action::Start(target_generation) => {
+                    self.notify_changed();
+                    self.perform_flush(target_generation).await;
+                }
+                Action::Wait => {
+                    if changed.changed().await.is_err() {
+                        return CacheLifecycleOutcome {
+                            diagnostic: Some("cache lifecycle stopped unexpectedly".to_string()),
+                        };
+                    }
+                }
+                Action::Retry => {
+                    self.notify_changed();
+                }
+                Action::Done(outcome) => {
+                    self.notify_changed();
+                    return outcome;
+                }
+            }
+        }
+    }
+
+    #[cfg(test)]
+    async fn wait_for_idle_publication(&self) {
+        let mut changed = self.changed.subscribe();
+        loop {
+            let (flush_in_flight, diagnostic) = {
+                let state = self
+                    .state
+                    .lock()
+                    .expect("cache lifecycle mutex should not be poisoned");
+                (state.flush.is_some(), state.diagnostic.clone())
+            };
+            assert!(
+                diagnostic.is_none(),
+                "cache publication failed: {diagnostic:?}"
+            );
+            if self.build_cache.pending_generation().is_none() && !flush_in_flight {
+                return;
+            }
+            changed
+                .changed()
+                .await
+                .expect("cache lifecycle should remain observable");
+        }
+    }
+
+    fn notify_changed(&self) {
+        self.changed.send_modify(|version| {
+            *version = version.wrapping_add(1);
+        });
+    }
+}
+
+#[derive(Debug)]
+struct CacheRunActivity {
+    lifecycle: Weak<CacheLifecycle>,
+    run_id: u64,
+    idle_reason: CacheIdleReason,
+}
+
+impl Drop for CacheRunActivity {
+    fn drop(&mut self) {
+        if let Some(lifecycle) = self.lifecycle.upgrade() {
+            lifecycle.begin_idle(self.run_id, self.idle_reason);
+        }
+    }
 }
 
 impl Compiler {
     pub fn new(options: CompilerOptions) -> Self {
         let build_cache = BuildCache::new(options.cache.clone(), options.snapshot.clone());
+        let cache_lifecycle = CacheLifecycle::new(build_cache.clone(), &options.cache);
         Self {
             options,
             build_cache,
+            cache_lifecycle,
         }
     }
 
@@ -78,6 +638,17 @@ impl Compiler {
     }
 
     pub async fn run(&self) -> Result<Compilation> {
+        Ok(self
+            .run_until_finalize(CacheIdleReason::Ordinary)
+            .await?
+            .finish())
+    }
+
+    pub async fn run_until_finalize(
+        &self,
+        idle_reason: CacheIdleReason,
+    ) -> Result<PendingCompilation> {
+        let cache_activity = self.cache_lifecycle.end_idle(idle_reason)?;
         let result = async {
             let mut compilation = self.create_compilation();
             compilation.make().await?;
@@ -88,8 +659,14 @@ impl Compiler {
         }
         .instrument(tracing::trace_span!("Compiler::run"))
         .await;
+        if result.is_ok() {
+            self.build_cache.store_build_dependencies();
+        }
         self.build_cache.trace_work_counters();
-        result
+        result.map(|compilation| PendingCompilation {
+            compilation: Some(compilation),
+            cache_activity: Some(cache_activity),
+        })
     }
 
     pub fn flush_cache(&self) -> std::result::Result<(), String> {
@@ -98,6 +675,19 @@ impl Compiler {
         self.build_cache
             .flush_to_filesystem()
             .map_err(|error| error.to_string())
+    }
+
+    pub async fn settle_cache(&self) -> CacheLifecycleOutcome {
+        self.cache_lifecycle.settle().await
+    }
+
+    pub async fn shutdown(&self) -> CacheLifecycleOutcome {
+        self.cache_lifecycle.shutdown().await
+    }
+
+    #[cfg(test)]
+    async fn wait_for_idle_cache_publication(&self) {
+        self.cache_lifecycle.wait_for_idle_publication().await;
     }
 }
 
@@ -122,12 +712,18 @@ fn normalize_context(context: PathBuf) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeMap, fs, path::Path};
+    use std::{
+        collections::BTreeMap,
+        fs,
+        path::Path,
+        sync::{Arc, Barrier},
+    };
 
     use super::*;
     use crate::{
+        BuildDependency,
         build_cache::{CacheItemFamily, CacheItemWork},
-        pack_file::PackFile,
+        pack_file::{CodecRegistry, ModuleBuildRecordCodec, PackFile, ResolveRecordCodec},
     };
 
     #[tokio::test]
@@ -354,6 +950,237 @@ mod tests {
             third.chunk_graph().chunks().as_ptr()
         );
 
+        Ok(())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn compiler_owns_initial_idle_cache_publication()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write(temp.path().join("index.js"), "export const value = 1;")?;
+        let cache_temp = tempfile::tempdir()?;
+        let cache_location = cache_temp.path().join("compiler-owned-idle");
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache = CacheOptions::filesystem();
+        options.cache.cache_location = Some(cache_location.clone());
+        options.cache.idle_timeout = Some(60_000);
+        options.cache.idle_timeout_for_initial_store = Some(20);
+
+        let compiler = Compiler::new(options);
+        compiler.run().await?;
+        assert!(!PackFile::index_path(&cache_location).exists());
+
+        tokio::time::advance(std::time::Duration::from_millis(19)).await;
+        assert!(!PackFile::index_path(&cache_location).exists());
+        tokio::time::advance(std::time::Duration::from_millis(1)).await;
+        compiler.wait_for_idle_cache_publication().await;
+        assert!(PackFile::index_path(&cache_location).exists());
+        Ok(())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cache_idle_begins_only_after_the_run_is_finalized()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write(temp.path().join("index.js"), "export const value = 1;")?;
+        let cache_temp = tempfile::tempdir()?;
+        let cache_location = cache_temp.path().join("finalize-before-idle");
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache = CacheOptions::filesystem();
+        options.cache.cache_location = Some(cache_location.clone());
+        options.cache.idle_timeout_for_initial_store = Some(0);
+
+        let compiler = Compiler::new(options);
+        let pending = compiler
+            .run_until_finalize(CacheIdleReason::Ordinary)
+            .await?;
+        tokio::time::advance(std::time::Duration::from_secs(1)).await;
+        assert!(!PackFile::index_path(&cache_location).exists());
+
+        let compilation = pending.finish();
+        assert_eq!(compilation.errors(), []);
+        compiler.wait_for_idle_cache_publication().await;
+        assert!(PackFile::index_path(&cache_location).exists());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn settling_idle_cache_drains_pending_work_and_keeps_compiler_reusable()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write(temp.path().join("index.js"), "export const value = 1;")?;
+        let cache_temp = tempfile::tempdir()?;
+        let cache_location = cache_temp.path().join("settled-watch-cache");
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache = CacheOptions::filesystem();
+        options.cache.cache_location = Some(cache_location.clone());
+        options.cache.idle_timeout_for_initial_store = Some(60_000);
+
+        let compiler = Compiler::new(options);
+        compiler.run().await?;
+        assert!(!PackFile::index_path(&cache_location).exists());
+
+        let outcome = compiler.settle_cache().await;
+        assert_eq!(outcome.diagnostic(), None);
+        assert!(PackFile::index_path(&cache_location).exists());
+        assert_eq!(compiler.run().await?.errors(), []);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn shutdown_drains_pending_cache_work_is_idempotent_and_prevents_new_runs()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write(temp.path().join("index.js"), "export const value = 1;")?;
+        let cache_temp = tempfile::tempdir()?;
+        let cache_location = cache_temp.path().join("shutdown-cache");
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache = CacheOptions::filesystem();
+        options.cache.cache_location = Some(cache_location.clone());
+        options.cache.idle_timeout_for_initial_store = Some(60_000);
+
+        let compiler = Compiler::new(options);
+        compiler.run().await?;
+        assert!(!PackFile::index_path(&cache_location).exists());
+
+        assert_eq!(compiler.shutdown().await.diagnostic(), None);
+        assert!(PackFile::index_path(&cache_location).exists());
+        assert_eq!(compiler.shutdown().await.diagnostic(), None);
+        assert!(matches!(
+            compiler.run().await,
+            Err(crate::Error::CompilerClosed)
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn memory_cache_shutdown_does_not_wait_for_persistent_publication()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write(temp.path().join("index.js"), "export const value = 1;")?;
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache = CacheOptions::memory();
+
+        let compiler = Compiler::new(options);
+        compiler.run().await?;
+
+        let outcome =
+            tokio::time::timeout(std::time::Duration::from_millis(100), compiler.shutdown())
+                .await?;
+        assert_eq!(outcome.diagnostic(), None);
+        Ok(())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn repeated_run_keeps_the_earliest_initial_store_deadline()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let entry = temp.path().join("index.js");
+        write(&entry, "export const value = 'before';")?;
+        let cache_temp = tempfile::tempdir()?;
+        let cache_location = cache_temp.path().join("initial-deadline");
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache = CacheOptions::filesystem();
+        options.cache.cache_location = Some(cache_location.clone());
+        options.cache.idle_timeout = Some(500);
+        options.cache.idle_timeout_for_initial_store = Some(200);
+
+        let compiler = Compiler::new(options);
+        compiler.run().await?;
+        tokio::time::advance(std::time::Duration::from_millis(150)).await;
+        write(&entry, "export const value = 'after';")?;
+        compiler.run().await?;
+
+        tokio::time::advance(std::time::Duration::from_millis(49)).await;
+        assert!(!PackFile::index_path(&cache_location).exists());
+        tokio::time::advance(std::time::Duration::from_millis(1)).await;
+        compiler.wait_for_idle_cache_publication().await;
+        assert!(PackFile::index_path(&cache_location).exists());
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn store_during_publication_remains_dirty_for_a_later_revision()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let entry = temp.path().join("index.js");
+        write(&entry, "export const value = 'before';")?;
+        let cache_temp = tempfile::tempdir()?;
+        let cache_location = cache_temp.path().join("generation-race");
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache = CacheOptions::filesystem();
+        options.cache.cache_location = Some(cache_location.clone());
+        options.cache.idle_timeout_for_initial_store = Some(60_000);
+
+        let compiler = Compiler::new(options);
+        compiler.run().await?;
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        compiler
+            .build_cache
+            .install_publish_barrier(entered.clone(), release.clone());
+
+        let settling_compiler = compiler.clone();
+        let settling = tokio::spawn(async move { settling_compiler.settle_cache().await });
+        tokio::task::yield_now().await;
+        entered.wait();
+
+        write(&entry, "export const value = 'after';")?;
+        let running_compiler = compiler.clone();
+        let running = tokio::spawn(async move { running_compiler.run().await });
+        tokio::task::yield_now().await;
+        release.wait();
+
+        assert_eq!(settling.await?.diagnostic(), None);
+        assert_eq!(running.await??.errors(), []);
+        let registry = CodecRegistry::new()
+            .with_resolve_record(ResolveRecordCodec::current())
+            .with_module_build_record(ModuleBuildRecordCodec::current());
+        assert_eq!(PackFile::open(&cache_location, registry).revision(), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn build_dependencies_are_stored_before_finalize_and_begin_idle()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write(temp.path().join("index.js"), "export const value = 1;")?;
+        let config = temp.path().join("build.config.js");
+        write(&config, "export default 'before';")?;
+        let cache_temp = tempfile::tempdir()?;
+        let cache_location = cache_temp.path().join("build-dependency-order");
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache = CacheOptions::filesystem();
+        options.cache.cache_location = Some(cache_location);
+        options.cache.idle_timeout_for_initial_store = Some(60_000);
+        options.cache.build_dependencies = vec![BuildDependency {
+            name: "config".to_string(),
+            files: vec![config.clone()],
+        }];
+
+        let compiler = Compiler::new(options.clone());
+        let pending = compiler
+            .run_until_finalize(CacheIdleReason::Ordinary)
+            .await?;
+        write(&config, "export default 'after';")?;
+        pending.finish();
+        assert_eq!(compiler.settle_cache().await.diagnostic(), None);
+
+        let second = Compiler::new(options);
+        second.run().await?;
+        assert_eq!(
+            second
+                .build_cache
+                .work_counters()
+                .for_family(CacheItemFamily::ModuleBuild),
+            CacheItemWork {
+                hits: 0,
+                misses: 1,
+                stores: 1,
+                restores: 0,
+                evictions: 0,
+            }
+        );
         Ok(())
     }
 

--- a/crates/unpack_core/src/error.rs
+++ b/crates/unpack_core/src/error.rs
@@ -6,6 +6,12 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 pub enum Error {
+    #[error("compiler is already running")]
+    CompilerBusy,
+
+    #[error("compiler is shutting down or closed")]
+    CompilerClosed,
+
     #[error("failed to resolve '{request}' from {issuer}: {message}")]
     Resolve {
         issuer: PathBuf,

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -23,7 +23,10 @@ pub use chunk_graph::{
 };
 pub use code_generation::{Asset, RuntimeRequirement, RuntimeRequirements};
 pub use compilation::{Compilation, WatchDependencies};
-pub use compiler::{Compiler, CompilerOptions, DEFAULT_EXTENSIONS, Entry};
+pub use compiler::{
+    CacheIdleReason, CacheLifecycleOutcome, Compiler, CompilerOptions, DEFAULT_EXTENSIONS, Entry,
+    PendingCompilation,
+};
 pub use dependency::{
     AsyncDependenciesBlock, ConstDependency, Dependency, DependencyKind, EntryDependency,
     HarmonyExportExpressionDependency, HarmonyExportHeaderDependency,

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -7,13 +7,13 @@ use std::{
     },
 };
 
-use napi::{Env, Result, Task, bindgen_prelude::AsyncTask};
+use napi::Result;
 use napi_derive::napi;
 use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
 use unpack_core::{
-    Asset, BuildDependency, CacheOptions, Compiler, CompilerOptions, Entry, Error as CoreError,
-    InfrastructureLogEvent, InfrastructureLogLevel, InfrastructureLoggingOptions, SnapshotOptions,
-    SnapshotPathPattern, SnapshotStrategy,
+    Asset, BuildDependency, CacheIdleReason, CacheOptions, Compiler, CompilerOptions, Entry,
+    Error as CoreError, InfrastructureLogEvent, InfrastructureLogLevel,
+    InfrastructureLoggingOptions, SnapshotOptions, SnapshotPathPattern, SnapshotStrategy,
 };
 
 #[global_allocator]
@@ -77,6 +77,10 @@ pub struct NativeCacheOptions {
     pub max_memory_generations: Option<u32>,
     #[napi(js_name = "idleTimeout")]
     pub idle_timeout: Option<u32>,
+    #[napi(js_name = "idleTimeoutForInitialStore")]
+    pub idle_timeout_for_initial_store: Option<u32>,
+    #[napi(js_name = "idleTimeoutAfterLargeChanges")]
+    pub idle_timeout_after_large_changes: Option<u32>,
     #[napi(js_name = "readonly")]
     pub readonly: Option<bool>,
 }
@@ -196,18 +200,31 @@ pub struct NativeCompiler {
 #[napi]
 impl NativeCompiler {
     #[napi]
-    pub async fn run(&self) -> NativeRunResult {
+    pub async fn run(&self, idle_reason: Option<String>) -> NativeRunResult {
         let compiler = self.compiler.clone();
         let output_path = self.output_path.clone();
+        let idle_reason = match idle_reason.as_deref() {
+            Some("largeChange") => CacheIdleReason::LargeChange,
+            _ => CacheIdleReason::Ordinary,
+        };
 
-        run_compiler_inner(compiler, output_path).await
+        run_compiler_inner(compiler, output_path, idle_reason).await
     }
 
-    #[napi(js_name = "flushCache")]
-    pub fn flush_cache(&self) -> AsyncTask<FlushCacheTask> {
-        AsyncTask::new(FlushCacheTask {
-            compiler: self.compiler.clone(),
-        })
+    #[napi(js_name = "settleCache")]
+    pub async fn settle_cache(&self) -> NativeFlushResult {
+        let Some(compiler) = self.compiler.as_deref() else {
+            return closed_cache_lifecycle_result();
+        };
+        cache_lifecycle_result(compiler.settle_cache().await)
+    }
+
+    #[napi]
+    pub async fn shutdown(&self) -> NativeFlushResult {
+        let Some(compiler) = self.compiler.as_deref() else {
+            return closed_cache_lifecycle_result();
+        };
+        cache_lifecycle_result(compiler.shutdown().await)
     }
 
     #[napi]
@@ -292,6 +309,8 @@ fn cache_options_from_native(options: NativeCacheOptions) -> CacheOptions {
         .collect();
     cache.max_memory_generations = options.max_memory_generations;
     cache.idle_timeout = options.idle_timeout;
+    cache.idle_timeout_for_initial_store = options.idle_timeout_for_initial_store;
+    cache.idle_timeout_after_large_changes = options.idle_timeout_after_large_changes;
     cache.readonly = options.readonly.unwrap_or(false);
     cache
 }
@@ -373,59 +392,47 @@ fn infrastructure_logging_options_from_native(
     }
 }
 
-pub struct FlushCacheTask {
-    compiler: Option<Arc<Compiler>>,
+fn closed_cache_lifecycle_result() -> NativeFlushResult {
+    NativeFlushResult {
+        error: Some(NativeInfrastructureError {
+            name: "CompilerClosedError".to_string(),
+            message: "compiler is closed".to_string(),
+        }),
+    }
 }
 
-impl Task for FlushCacheTask {
-    type Output = NativeFlushResult;
-    type JsValue = NativeFlushResult;
-
-    fn compute(&mut self) -> Result<Self::Output> {
-        let Some(compiler) = self.compiler.as_deref() else {
-            return Ok(NativeFlushResult {
-                error: Some(NativeInfrastructureError {
-                    name: "CompilerClosedError".to_string(),
-                    message: "compiler is closed".to_string(),
-                }),
-            });
-        };
-
-        Ok(match compiler.flush_cache() {
-            Ok(()) => NativeFlushResult { error: None },
-            Err(message) => NativeFlushResult {
-                error: Some(NativeInfrastructureError {
-                    name: "CacheFlushError".to_string(),
-                    message,
-                }),
-            },
-        })
-    }
-
-    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
-        Ok(output)
+fn cache_lifecycle_result(outcome: unpack_core::CacheLifecycleOutcome) -> NativeFlushResult {
+    NativeFlushResult {
+        error: outcome
+            .diagnostic()
+            .map(|message| NativeInfrastructureError {
+                name: "CacheFlushError".to_string(),
+                message: message.to_string(),
+            }),
     }
 }
 
 async fn run_compiler_inner(
     compiler: Option<Arc<Compiler>>,
     output_path: PathBuf,
+    idle_reason: CacheIdleReason,
 ) -> NativeRunResult {
     let Some(compiler) = compiler else {
         return infrastructure_error("CompilerClosedError", "compiler is closed");
     };
 
-    let compilation = match compiler.run().await {
-        Ok(compilation) => compilation,
+    let pending = match compiler.run_until_finalize(idle_reason).await {
+        Ok(pending) => pending,
         Err(error) => {
             return infrastructure_error("InfrastructureError", error.to_string());
         }
     };
 
-    let logs = infrastructure_log_events(compilation.infrastructure_log_events());
-    if let Err(error) = emit_assets(&output_path, compilation.assets()) {
+    let logs = infrastructure_log_events(pending.compilation().infrastructure_log_events());
+    if let Err(error) = emit_assets(&output_path, pending.compilation().assets()) {
         return infrastructure_error_with_logs("OutputWriteError", error, logs);
     }
+    let compilation = pending.finish();
 
     NativeRunResult {
         error: None,
@@ -516,7 +523,10 @@ fn stats_error(error: &CoreError) -> NativeStatsError {
             issuer: None,
             stack: Some(message.clone()),
         },
-        CoreError::MissingModule(_) | CoreError::MissingModuleDirectory(_) => NativeStatsError {
+        CoreError::CompilerBusy
+        | CoreError::CompilerClosed
+        | CoreError::MissingModule(_)
+        | CoreError::MissingModuleDirectory(_) => NativeStatsError {
             message: error.to_string(),
             path: None,
             request: None,

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -35,6 +35,8 @@ export interface FilesystemCacheOptions {
   version?: string;
   buildDependencies?: Record<string, string[]>;
   idleTimeout?: number;
+  idleTimeoutForInitialStore?: number;
+  idleTimeoutAfterLargeChanges?: number;
   readonly?: boolean;
   hashAlgorithm?: string;
   managedPaths?: SnapshotPathPattern[];
@@ -148,6 +150,8 @@ interface NormalizedCacheOptions {
   version?: string;
   buildDependencies: NormalizedBuildDependency[];
   idleTimeout?: number;
+  idleTimeoutForInitialStore?: number;
+  idleTimeoutAfterLargeChanges?: number;
   readonly: boolean;
 }
 
@@ -255,8 +259,9 @@ interface NativeFlushResult {
 }
 
 interface NativeCompiler {
-  run(): Promise<NativeRunResult>;
-  flushCache(): Promise<NativeFlushResult>;
+  run(idleReason?: "ordinary" | "largeChange"): Promise<NativeRunResult>;
+  settleCache(): Promise<NativeFlushResult>;
+  shutdown(): Promise<NativeFlushResult>;
   close(): void;
 }
 
@@ -269,21 +274,18 @@ const native = require("./unpack_node.node") as NativeBinding;
 
 class CompilerImpl implements Compiler {
   #closed = false;
+  #closing: Promise<Error | null> | undefined;
   #running = false;
   #watching: WatchingImpl | undefined;
-  #idleFlushTimer: ReturnType<typeof setTimeout> | undefined;
-  #pendingCacheFlush: Promise<NativeFlushResult> | undefined;
-  readonly #writableFilesystemCache: boolean;
-  readonly #cacheIdleTimeout: number;
   readonly #infrastructureLoggingLevel: InfrastructureLoggingLevel;
   readonly #nativeCompiler: NativeCompiler;
+  readonly #writableFilesystemCache: boolean;
 
   constructor(options: NormalizedOptions) {
     this.#nativeCompiler = native.createCompiler(options);
+    this.#infrastructureLoggingLevel = options.infrastructureLogging.level;
     this.#writableFilesystemCache =
       options.cache.type === "filesystem" && !options.cache.readonly;
-    this.#cacheIdleTimeout = options.cache.idleTimeout ?? 0;
-    this.#infrastructureLoggingLevel = options.infrastructureLogging.level;
   }
 
   run(callback: RunCallback): void {
@@ -314,7 +316,7 @@ class CompilerImpl implements Compiler {
     let run: Promise<NativeRunResult>;
     try {
       this.#emitInfrastructureLog("info", "unpack.Compiler", "run started");
-      run = this.#nativeCompiler.run();
+      run = this.#nativeCompiler.run("ordinary");
     } catch (error) {
       this.#running = false;
       const infrastructureError = toError(error, "InfrastructureError");
@@ -334,7 +336,6 @@ class CompilerImpl implements Compiler {
           return;
         }
 
-        this.#scheduleIdleCacheFlush();
         this.#emitInfrastructureLog("info", "unpack.Compiler", "run completed");
         callback(null, new StatsImpl(normalizeNativeStats(result.stats)));
       },
@@ -355,11 +356,10 @@ class CompilerImpl implements Compiler {
       const error = namedError("CompilerClosedError", "compiler is closed");
       this.#emitInfrastructureLog("error", "unpack.Watch", error.message);
       const watching = new WatchingImpl(
-        (watchHandler) => {
+        (_idleReason, watchHandler) => {
           defer(() => watchHandler(error));
         },
-        () => Promise.resolve(null),
-        () => {},
+        async () => null,
         defaultWatchOptions()
       );
       watching.start(handler);
@@ -370,11 +370,10 @@ class CompilerImpl implements Compiler {
       const error = namedError("ConcurrentRunError", "compiler is already running");
       this.#emitInfrastructureLog("error", "unpack.Watch", error.message);
       const watching = new WatchingImpl(
-        (watchHandler) => {
+        (_idleReason, watchHandler) => {
           defer(() => watchHandler(error));
         },
-        () => Promise.resolve(null),
-        () => {},
+        async () => null,
         defaultWatchOptions()
       );
       watching.start(handler);
@@ -382,12 +381,13 @@ class CompilerImpl implements Compiler {
     }
 
     const watching = new WatchingImpl(
-      (watchHandler) => this.#runWatchCompilation(watchHandler),
-      () => this.#flushCacheNow(),
-      () => {
+      (idleReason, watchHandler) => this.#runWatchCompilation(idleReason, watchHandler),
+      async () => {
+        const settleError = await this.#settleCache();
         if (this.#watching === watching) {
           this.#watching = undefined;
         }
+        return settleError;
       },
       normalizedWatchOptions
     );
@@ -419,36 +419,23 @@ class CompilerImpl implements Compiler {
       return;
     }
 
-    try {
-      this.#clearIdleFlushTimer();
-      this.#flushCacheNow().then((flushError) => {
-        if (flushError) {
-          callback(flushError);
-          return;
-        }
-
-        try {
-          this.#nativeCompiler.close();
-          this.#closed = true;
-          callback(null);
-        } catch (error) {
-          const infrastructureError = toError(error, "InfrastructureError");
-          this.#emitInfrastructureLog("error", "unpack.Compiler", infrastructureError.message);
-          callback(infrastructureError);
-        }
-      });
-    } catch (error) {
-      const infrastructureError = toError(error, "InfrastructureError");
-      this.#emitInfrastructureLog("error", "unpack.Compiler", infrastructureError.message);
-      defer(() => callback(infrastructureError));
+    if (this.#closed) {
+      defer(() => callback(null));
+      return;
     }
+
+    this.#closing ??= this.#shutdownAndClose();
+    void this.#closing.then((error) => callback(error));
   }
 
-  async #runWatchCompilation(handler: WatchHandler): Promise<void> {
+  async #runWatchCompilation(
+    idleReason: "ordinary" | "largeChange",
+    handler: WatchHandler
+  ): Promise<void> {
     let run: Promise<NativeRunResult>;
     try {
       this.#emitInfrastructureLog("info", "unpack.Watch", "watch compilation started");
-      run = this.#nativeCompiler.run();
+      run = this.#nativeCompiler.run(idleReason);
     } catch (error) {
       const infrastructureError = toError(error, "InfrastructureError");
       this.#emitInfrastructureLog("error", "unpack.Watch", infrastructureError.message);
@@ -466,7 +453,6 @@ class CompilerImpl implements Compiler {
         return;
       }
 
-      this.#scheduleIdleCacheFlush();
       this.#emitInfrastructureLog("info", "unpack.Watch", "watch compilation completed");
       handler(null, new StatsImpl(normalizeNativeStats(result.stats)));
     } catch (error) {
@@ -476,60 +462,52 @@ class CompilerImpl implements Compiler {
     }
   }
 
-  #scheduleIdleCacheFlush(): void {
-    if (!this.#writableFilesystemCache || this.#closed) {
-      return;
-    }
-
-    this.#clearIdleFlushTimer();
-    this.#idleFlushTimer = setTimeout(() => {
-      this.#idleFlushTimer = undefined;
-      void this.#flushCacheNow();
-    }, this.#cacheIdleTimeout);
-  }
-
-  #clearIdleFlushTimer(): void {
-    if (this.#idleFlushTimer !== undefined) {
-      clearTimeout(this.#idleFlushTimer);
-      this.#idleFlushTimer = undefined;
-    }
-  }
-
-  async #flushCacheNow(): Promise<Error | null> {
-    if (!this.#writableFilesystemCache) {
-      return null;
-    }
-
-    const startsFlush = this.#pendingCacheFlush === undefined;
-    if (startsFlush) {
-      this.#emitInfrastructureLog("info", "unpack.Cache", "cache flush started");
-    }
-    const flush = this.#pendingCacheFlush ?? this.#nativeCompiler.flushCache();
-    this.#pendingCacheFlush = flush;
-
+  async #settleCache(): Promise<Error | null> {
     try {
-      const result = await flush;
+      this.#emitCacheFlushStarted();
+      const result = await this.#nativeCompiler.settleCache();
       if (result.error) {
         const error = namedError(result.error.name, result.error.message);
-        if (startsFlush) {
-          this.#emitInfrastructureLog("warn", "unpack.Cache", error.message);
-        }
+        this.#emitCacheFlushError(error);
         return error;
       }
-      if (startsFlush) {
-        this.#emitInfrastructureLog("info", "unpack.Cache", "cache flush completed");
-      }
+      this.#emitCacheFlushCompleted();
       return null;
     } catch (error) {
       const infrastructureError = toError(error, "InfrastructureError");
-      if (startsFlush) {
-        this.#emitInfrastructureLog("error", "unpack.Cache", infrastructureError.message);
-      }
+      this.#emitCacheFlushError(infrastructureError);
       return infrastructureError;
-    } finally {
-      if (this.#pendingCacheFlush === flush) {
-        this.#pendingCacheFlush = undefined;
+    }
+  }
+
+  async #shutdown(): Promise<Error | null> {
+    try {
+      this.#emitCacheFlushStarted();
+      const result = await this.#nativeCompiler.shutdown();
+      if (result.error) {
+        const error = namedError(result.error.name, result.error.message);
+        this.#emitCacheFlushError(error);
+        return error;
       }
+      this.#emitCacheFlushCompleted();
+      return null;
+    } catch (error) {
+      const infrastructureError = toError(error, "InfrastructureError");
+      this.#emitCacheFlushError(infrastructureError);
+      return infrastructureError;
+    }
+  }
+
+  async #shutdownAndClose(): Promise<Error | null> {
+    const shutdownError = await this.#shutdown();
+    try {
+      this.#nativeCompiler.close();
+      this.#closed = true;
+      return shutdownError;
+    } catch (error) {
+      const infrastructureError = toError(error, "InfrastructureError");
+      this.#emitInfrastructureLog("error", "unpack.Compiler", infrastructureError.message);
+      return infrastructureError;
     }
   }
 
@@ -544,6 +522,24 @@ class CompilerImpl implements Compiler {
     );
   }
 
+  #emitCacheFlushStarted(): void {
+    if (this.#writableFilesystemCache) {
+      this.#emitInfrastructureLog("info", "unpack.Cache", "cache flush started");
+    }
+  }
+
+  #emitCacheFlushCompleted(): void {
+    if (this.#writableFilesystemCache) {
+      this.#emitInfrastructureLog("info", "unpack.Cache", "cache flush completed");
+    }
+  }
+
+  #emitCacheFlushError(error: Error): void {
+    if (this.#writableFilesystemCache) {
+      this.#emitInfrastructureLog("error", "unpack.Cache", error.message);
+    }
+  }
+
   #emitInfrastructureLogs(logs: InfrastructureLogEvent[] | null | undefined): void {
     if (!logs) {
       return;
@@ -556,32 +552,36 @@ class CompilerImpl implements Compiler {
 
 class WatchingImpl implements Watching {
   #closed = false;
+  #closing: Promise<Error | null> | undefined;
   #running = false;
   #invalidated = false;
   #handler: WatchHandler | undefined;
   #rebuildTimer: ReturnType<typeof setTimeout> | undefined;
   readonly #watchers: WatchSubscription[] = [];
-  readonly #runCompilation: (handler: WatchHandler) => Promise<void> | void;
-  readonly #flushCache: () => Promise<Error | null>;
-  readonly #onClose: () => void;
+  readonly #runCompilation: (
+    idleReason: "ordinary" | "largeChange",
+    handler: WatchHandler
+  ) => Promise<void> | void;
+  readonly #onClose: () => Promise<Error | null>;
   readonly #watchOptions: NormalizedWatchOptions;
   readonly #closeCallbacks: CloseCallback[] = [];
 
   constructor(
-    runCompilation: (handler: WatchHandler) => Promise<void> | void,
-    flushCache: () => Promise<Error | null>,
-    onClose: () => void,
+    runCompilation: (
+      idleReason: "ordinary" | "largeChange",
+      handler: WatchHandler
+    ) => Promise<void> | void,
+    onClose: () => Promise<Error | null>,
     watchOptions: NormalizedWatchOptions
   ) {
     this.#runCompilation = runCompilation;
-    this.#flushCache = flushCache;
     this.#onClose = onClose;
     this.#watchOptions = watchOptions;
   }
 
   start(handler: WatchHandler): void {
     this.#handler = handler;
-    this.#run();
+    this.#run("ordinary");
   }
 
   invalidate(): void {
@@ -596,13 +596,13 @@ class WatchingImpl implements Watching {
       return;
     }
 
-    this.#run();
+    this.#run("largeChange");
   }
 
   close(callback: CloseCallback): void {
     assertFunction(callback, "callback");
 
-    if (this.#closed && !this.#running) {
+    if (this.#closed && !this.#running && !this.#closing) {
       defer(() => callback(null));
       return;
     }
@@ -618,7 +618,7 @@ class WatchingImpl implements Watching {
     }
   }
 
-  async #run(): Promise<void> {
+  async #run(idleReason: "ordinary" | "largeChange"): Promise<void> {
     if (this.#closed || this.#running || !this.#handler) {
       return;
     }
@@ -627,7 +627,7 @@ class WatchingImpl implements Watching {
     this.#closeWatchers();
     this.#running = true;
     let latestStats: Stats | undefined;
-    await this.#runCompilation((err, stats) => {
+    await this.#runCompilation(idleReason, (err, stats) => {
       if (!err && stats) {
         latestStats = stats;
       }
@@ -647,16 +647,17 @@ class WatchingImpl implements Watching {
 
     if (this.#invalidated) {
       this.#invalidated = false;
-      await this.#run();
+      await this.#run("largeChange");
     }
   }
 
   async #finishClose(): Promise<void> {
+    this.#closing ??= this.#onClose();
+    const closeError = await this.#closing;
     const callbacks = this.#closeCallbacks.splice(0);
-    const flushError = await this.#flushCache();
-    this.#onClose();
+    this.#closing = undefined;
     for (const callback of callbacks) {
-      callback(flushError);
+      callback(closeError);
     }
   }
 
@@ -953,6 +954,8 @@ function normalizeCacheOptions(
       "version",
       "buildDependencies",
       "idleTimeout",
+      "idleTimeoutForInitialStore",
+      "idleTimeoutAfterLargeChanges",
       "readonly",
       "hashAlgorithm",
       "managedPaths",
@@ -1022,14 +1025,27 @@ function normalizeCacheOptions(
       filesystemCache.buildDependencies,
       context
     ),
-    ...(filesystemCache.idleTimeout === undefined
-      ? {}
-      : {
-          idleTimeout: assertNonNegativeInteger(
+    idleTimeout:
+      filesystemCache.idleTimeout === undefined
+        ? 60_000
+        : assertNonNegativeInteger(
             filesystemCache.idleTimeout,
             "options.cache.idleTimeout"
-          )
-        }),
+          ),
+    idleTimeoutForInitialStore:
+      filesystemCache.idleTimeoutForInitialStore === undefined
+        ? 5_000
+        : assertNonNegativeInteger(
+            filesystemCache.idleTimeoutForInitialStore,
+            "options.cache.idleTimeoutForInitialStore"
+          ),
+    idleTimeoutAfterLargeChanges:
+      filesystemCache.idleTimeoutAfterLargeChanges === undefined
+        ? 1_000
+        : assertNonNegativeInteger(
+            filesystemCache.idleTimeoutAfterLargeChanges,
+            "options.cache.idleTimeoutAfterLargeChanges"
+          ),
     readonly
   };
 }

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -542,7 +542,7 @@ test("accepts filesystem cache option shape", async () => {
   }
 });
 
-test("filesystem cache flushes after idle timeout", async () => {
+test("filesystem cache flushes after the initial-store timeout", async () => {
   const fixture = await createFixture({
     "src/index.js": "export const value = 1;"
   });
@@ -553,7 +553,8 @@ test("filesystem cache flushes after idle timeout", async () => {
     cache: {
       type: "filesystem",
       cacheLocation,
-      idleTimeout: 30
+      idleTimeout: 60_000,
+      idleTimeoutForInitialStore: 30
     }
   });
 
@@ -564,6 +565,45 @@ test("filesystem cache flushes after idle timeout", async () => {
 
     await delay(100);
     assert.ok(await stat(join(cacheLocation, "index.pack")));
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("repeated run uses the ordinary idle cache timeout", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 'before';"
+  });
+  const entry = join(fixture, "src/index.js");
+  const cacheLocation = join(fixture, ".cache/unpack/ordinary-idle");
+  const indexPath = join(cacheLocation, "index.pack");
+  const compiler = unpack({
+    context: fixture,
+    entry: "./src/index.js",
+    cache: {
+      type: "filesystem",
+      cacheLocation,
+      idleTimeout: 150,
+      idleTimeoutForInitialStore: 0,
+      idleTimeoutAfterLargeChanges: 10
+    }
+  });
+
+  try {
+    assert.equal((await runExistingCompiler(compiler)).err, null);
+    await delay(120);
+    const firstRevision = await readFile(indexPath);
+
+    await writeFile(entry, "export const value = 'after';", "utf8");
+    const changedTime = new Date(Date.now() + 2000);
+    await utimes(entry, changedTime, changedTime);
+    assert.equal((await runExistingCompiler(compiler)).err, null);
+
+    await delay(60);
+    assert.deepEqual(await readFile(indexPath), firstRevision);
+    await delay(180);
+    assert.notDeepEqual(await readFile(indexPath), firstRevision);
   } finally {
     await closeCompiler(compiler);
     await rm(fixture, { recursive: true, force: true });
@@ -646,6 +686,37 @@ test("watch performs initial build and close keeps compiler reusable", async () 
   }
 });
 
+test("watch close settles pending filesystem cache work and keeps compiler reusable", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const cacheLocation = join(fixture, ".cache/unpack/watch-close");
+  const compiler = unpack({
+    context: fixture,
+    entry: "./src/index.js",
+    cache: {
+      type: "filesystem",
+      cacheLocation,
+      idleTimeoutForInitialStore: 60_000
+    }
+  });
+
+  try {
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch({}, results.handler);
+    assert.equal((await first).err, null);
+    await assert.rejects(stat(join(cacheLocation, "index.pack")));
+
+    await closeWatching(watching);
+    assert.ok(await stat(join(cacheLocation, "index.pack")));
+    assert.equal((await runExistingCompiler(compiler)).err, null);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 test("watch invalidate triggers rebuild", async () => {
   const fixture = await createFixture({
     "src/index.js": "export const value = 'before';"
@@ -668,6 +739,51 @@ test("watch invalidate triggers rebuild", async () => {
 
     assert.equal((await second).err, null);
     assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /after/);
+    await closeWatching(watching);
+    await closeCompiler(compiler);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("watch invalidation uses the post-large-change cache timeout", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 'before';"
+  });
+  const entry = join(fixture, "src/index.js");
+  const cacheLocation = join(fixture, ".cache/unpack/watch-large-change");
+  const indexPath = join(cacheLocation, "index.pack");
+  const compiler = unpack({
+    context: fixture,
+    entry: "./src/index.js",
+    cache: {
+      type: "filesystem",
+      cacheLocation,
+      idleTimeout: 60_000,
+      idleTimeoutForInitialStore: 0,
+      idleTimeoutAfterLargeChanges: 150
+    }
+  });
+
+  try {
+    const results = collectWatchResults();
+    const first = results.next();
+    const watching = compiler.watch({}, results.handler);
+    assert.equal((await first).err, null);
+    await delay(120);
+    const firstRevision = await readFile(indexPath);
+
+    const second = results.next();
+    await writeFile(entry, "export const value = 'after';", "utf8");
+    const changedTime = new Date(Date.now() + 2000);
+    await utimes(entry, changedTime, changedTime);
+    watching.invalidate();
+    assert.equal((await second).err, null);
+
+    await delay(60);
+    assert.deepEqual(await readFile(indexPath), firstRevision);
+    await delay(180);
+    assert.notDeepEqual(await readFile(indexPath), firstRevision);
     await closeWatching(watching);
     await closeCompiler(compiler);
   } finally {
@@ -950,6 +1066,41 @@ test("infrastructure logging level info reports compiler runs outside stats", as
       "[unpack.Compiler] run completed"
     ]);
     assert.deepEqual(captured.calls.log, []);
+  } finally {
+    captured.restore();
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("infrastructure logging level info reports cache flush lifecycle", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const captured = captureConsole();
+  const compiler = unpack({
+    context: fixture,
+    entry: "./src/index.js",
+    cache: {
+      type: "filesystem",
+      cacheLocation: join(fixture, ".cache/unpack/logging"),
+      idleTimeoutForInitialStore: 60_000
+    },
+    infrastructureLogging: {
+      level: "info"
+    }
+  });
+
+  try {
+    const result = await runExistingCompiler(compiler);
+    assert.equal(result.err, null);
+    await closeCompiler(compiler);
+
+    assert.deepEqual(captured.calls.info, [
+      "[unpack.Compiler] run started",
+      "[unpack.Compiler] run completed",
+      "[unpack.Cache] cache flush started",
+      "[unpack.Cache] cache flush completed"
+    ]);
   } finally {
     captured.restore();
     await rm(fixture, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- Move persistent-cache idle scheduling, dirty generation tracking, settling, and shutdown ownership into the Rust Compiler lifecycle.
- Replace JavaScript-owned cache flush timers with native run/watch idle reasons and shutdown/settle calls while preserving public callback behavior.
- Add tests for initial-store, ordinary-idle, post-large-change, shutdown, in-flight publication, memory-cache shutdown, and cache flush infrastructure logging.

Closes #144

## Tests

- cargo test --workspace
- pnpm --filter @unpack-js/core test
- pnpm --filter @unpack-js/benchmarks test
