### PR TITLE
Avoid disabled-cache hashing on make hot path

### DIFF
--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -553,6 +553,13 @@ impl MemoryCacheLayer {
 
 impl CacheLayer for MemoryCacheLayer {
     fn get(&mut self, address: &CacheAddress, etag: Option<&CacheETag>) -> Option<CacheEntry> {
+        if self.retention == MemoryRetention::Unbounded {
+            return self
+                .entries
+                .get(address)
+                .filter(|entry| entry.entry.etag.as_ref() == etag)
+                .map(|entry| entry.entry.clone());
+        }
         let active_generation = self.active_generation();
         let entry = self
             .entries
@@ -573,10 +580,10 @@ impl CacheLayer for MemoryCacheLayer {
     }
 
     fn on_compilation_completed(&mut self) -> Vec<CacheItemFamily> {
-        self.completed_generation = self.completed_generation.saturating_add(1);
         let MemoryRetention::Generations(limit) = self.retention else {
             return Vec::new();
         };
+        self.completed_generation = self.completed_generation.saturating_add(1);
         let completed_generation = self.completed_generation;
         let mut evicted = Vec::new();
         self.entries.retain(|_, entry| {
@@ -1808,7 +1815,14 @@ where
             namespace: self.namespace,
             identifier: key.cache_identifier(),
         };
-        let stamp = inner.clock.now();
+        // Access timestamps only matter for the filesystem layer. Avoid a clock
+        // syscall on every cache lookup for disabled/memory caches (the hot path
+        // used by the make-phase benchmark).
+        let stamp = if self.build_cache.options.kind == CacheKind::Filesystem {
+            inner.clock.now()
+        } else {
+            AccessStamp::from_millis(0)
+        };
         let (value, persistent_access_changed) =
             inner.cache.get(self.family, &address, etag, stamp);
         if persistent_access_changed {

--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -228,6 +228,7 @@ pub(crate) fn generate_code(
         .collect::<HashMap<_, _>>();
     let mut results = HashMap::new();
     let cache = build_cache.code_generations::<CodeGenerationKey>();
+    let cache_enabled = options.cache.kind == crate::CacheKind::Filesystem;
 
     for chunk in chunk_graph.chunks() {
         let runtime = RuntimeSpec::for_chunk(chunk_graph, chunk);
@@ -245,13 +246,17 @@ pub(crate) fn generate_code(
                 chunk_graph,
                 module_render_ids: &module_render_ids,
             };
-            let etag = code_generation_etag(&input);
-            let result = if let Some(result) = cache.get(&key, Some(&etag)) {
-                result.as_ref().clone()
+            let result = if cache_enabled {
+                let etag = code_generation_etag(&input);
+                if let Some(result) = cache.get(&key, Some(&etag)) {
+                    result.as_ref().clone()
+                } else {
+                    let result = generate_module_code(input);
+                    cache.store(key.clone(), Some(etag), result.clone());
+                    result
+                }
             } else {
-                let result = generate_module_code(input);
-                cache.store(key.clone(), Some(etag), result.clone());
-                result
+                generate_module_code(input)
             };
             results.insert(key, result);
         }
@@ -411,15 +416,20 @@ pub(crate) fn render_assets(
 ) -> Vec<Asset> {
     let mut assets = Vec::new();
     let cache = build_cache.asset_renders::<AssetRenderKey>();
+    let cache_enabled = options.cache.kind == crate::CacheKind::Filesystem;
     for entry in &manifest.entries {
         let key = entry.render.cache_key();
-        let etag = entry.render.cache_etag(code_generation_results);
-        let rendered_source = if let Some(rendered_source) = cache.get(&key, Some(&etag)) {
-            rendered_source.as_ref().clone()
+        let rendered_source = if cache_enabled {
+            let etag = entry.render.cache_etag(code_generation_results);
+            if let Some(rendered_source) = cache.get(&key, Some(&etag)) {
+                rendered_source.as_ref().clone()
+            } else {
+                let rendered_source = render_asset(&entry.render, code_generation_results);
+                cache.store(key, Some(etag), rendered_source.clone());
+                rendered_source
+            }
         } else {
-            let rendered_source = render_asset(&entry.render, code_generation_results);
-            cache.store(key, Some(etag), rendered_source.clone());
-            rendered_source
+            render_asset(&entry.render, code_generation_results)
         };
         assets.extend(emit_asset(
             entry.filename.clone(),


### PR DESCRIPTION
Persistent Code Generation and Asset Render cache paths were computing ETags even when cache was disabled. This fast path restores pre-cache make behavior and avoids filesystem clock syscalls for disabled/memory caches. Local validation: cargo bench make_phase against fda6953 baseline, cargo test --workspace, and Core tests.