### PR TITLE
Assign deterministic named render IDs

### DIFF
--- a/crates/unpack_core/src/chunk_graph.rs
+++ b/crates/unpack_core/src/chunk_graph.rs
@@ -1,9 +1,6 @@
-use std::{
-    collections::{HashMap, HashSet, VecDeque},
-    path::{Path, PathBuf},
-};
+use std::collections::{HashMap, HashSet, VecDeque};
 
-use crate::{CompilerOptions, ModuleGraph, ModuleId};
+use crate::{CompilerOptions, ModuleGraph, ModuleId, id_assignment::RenderId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ChunkId(usize);
@@ -34,17 +31,21 @@ impl ChunkGroupId {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Chunk {
     id: ChunkId,
-    render_id: String,
-    filename: String,
+    name: Option<String>,
+    root_modules: Vec<ModuleId>,
+    render_id: Option<RenderId>,
+    filename_override: Option<String>,
     groups: Vec<ChunkGroupId>,
 }
 
 impl Chunk {
-    fn new(id: ChunkId, render_id: String, filename: String) -> Self {
+    fn new(id: ChunkId, name: Option<String>, root_modules: Vec<ModuleId>) -> Self {
         Self {
             id,
-            render_id,
-            filename,
+            name,
+            root_modules,
+            render_id: None,
+            filename_override: None,
             groups: Vec::new(),
         }
     }
@@ -53,12 +54,14 @@ impl Chunk {
         self.id
     }
 
-    pub fn render_id(&self) -> &str {
-        &self.render_id
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
     }
 
-    pub fn filename(&self) -> &str {
-        &self.filename
+    pub(crate) fn render_id(&self) -> &RenderId {
+        self.render_id
+            .as_ref()
+            .expect("chunk Render ID should be assigned before it is read")
     }
 
     pub fn groups(&self) -> &[ChunkGroupId] {
@@ -69,6 +72,18 @@ impl Chunk {
         if !self.groups.contains(&group) {
             self.groups.push(group);
         }
+    }
+
+    pub(crate) fn root_modules(&self) -> &[ModuleId] {
+        &self.root_modules
+    }
+
+    pub(crate) fn filename_override(&self) -> Option<&str> {
+        self.filename_override.as_deref()
+    }
+
+    fn assign_render_id(&mut self, render_id: RenderId) {
+        self.render_id = Some(render_id);
     }
 
     pub fn split(&self, new_chunk: &mut Chunk, chunk_groups: &mut [ChunkGroup]) {
@@ -163,6 +178,7 @@ pub struct ChunkGraph {
     entrypoints: Vec<ChunkGroupId>,
     chunk_modules: Vec<Vec<ModuleId>>,
     module_chunks: Vec<Vec<ChunkId>>,
+    module_render_ids: Vec<Option<RenderId>>,
     block_chunk_groups: HashMap<AsyncBlockOrigin, ChunkGroupId>,
 }
 
@@ -174,15 +190,13 @@ impl ChunkGraph {
     ) -> Self {
         let mut graph = Self::default();
         let mut async_groups_by_target = HashMap::new();
-        let render_context = RenderPathContext::new(options.context.as_path());
-
         for (entry_index, entry_module) in entries.iter().copied().enumerate() {
             let entry_name = options
                 .entries
                 .get(entry_index)
                 .map(|entry| entry.name.clone())
                 .unwrap_or_else(|| format!("entry{entry_index}"));
-            let entry_chunk = graph.add_chunk(entry_name.clone(), format!("{entry_name}.js"));
+            let entry_chunk = graph.add_chunk(Some(entry_name.clone()), vec![entry_module]);
             let entry_group = graph.add_chunk_group(
                 ChunkGroupKind::Entrypoint {
                     name: entry_name.clone(),
@@ -230,8 +244,7 @@ impl ChunkGraph {
                 {
                     group
                 } else {
-                    let render_id = chunk_render_id(&render_context, module_graph, target);
-                    let chunk = graph.add_chunk(render_id.clone(), format!("{render_id}.js"));
+                    let chunk = graph.add_chunk(None, vec![target]);
                     let group = graph.add_chunk_group(ChunkGroupKind::Async, Some(origin));
                     graph.connect_chunk_and_group(chunk, group);
                     async_groups_by_target.insert(target, group);
@@ -256,9 +269,9 @@ impl ChunkGraph {
         graph
     }
 
-    fn add_chunk(&mut self, render_id: String, filename: String) -> ChunkId {
+    fn add_chunk(&mut self, name: Option<String>, root_modules: Vec<ModuleId>) -> ChunkId {
         let id = ChunkId::new(self.chunks.len());
-        self.chunks.push(Chunk::new(id, render_id, filename));
+        self.chunks.push(Chunk::new(id, name, root_modules));
         self.chunk_modules.push(Vec::new());
         id
     }
@@ -290,7 +303,10 @@ impl ChunkGraph {
         filename: impl Into<String>,
     ) -> Option<ChunkId> {
         let original = self.chunks.get(chunk.index())?.clone();
-        let new_chunk = self.add_chunk(render_id.into(), filename.into());
+        let render_id = RenderId::String(render_id.into());
+        let new_chunk = self.add_chunk(None, Vec::new());
+        self.chunks[new_chunk.index()].assign_render_id(render_id);
+        self.chunks[new_chunk.index()].filename_override = Some(filename.into());
         original.split(&mut self.chunks[new_chunk.index()], &mut self.chunk_groups);
         Some(new_chunk)
     }
@@ -298,6 +314,8 @@ impl ChunkGraph {
     pub(crate) fn connect_chunk_and_module(&mut self, chunk: ChunkId, module: ModuleId) {
         if self.module_chunks.len() <= module.index() {
             self.module_chunks.resize_with(module.index() + 1, Vec::new);
+            self.module_render_ids
+                .resize_with(module.index() + 1, || None);
         }
         if !self.chunk_modules[chunk.index()].contains(&module) {
             self.chunk_modules[chunk.index()].push(module);
@@ -328,6 +346,24 @@ impl ChunkGraph {
             .get(module.index())
             .map(Vec::as_slice)
             .unwrap_or(&[])
+    }
+
+    pub(crate) fn module_render_id(&self, module: ModuleId) -> Option<&RenderId> {
+        self.module_render_ids
+            .get(module.index())
+            .and_then(Option::as_ref)
+    }
+
+    pub(crate) fn set_module_render_id(&mut self, module: ModuleId, render_id: RenderId) {
+        if self.module_render_ids.len() <= module.index() {
+            self.module_render_ids
+                .resize_with(module.index() + 1, || None);
+        }
+        self.module_render_ids[module.index()] = Some(render_id);
+    }
+
+    pub(crate) fn set_chunk_render_id(&mut self, chunk: ChunkId, render_id: RenderId) {
+        self.chunks[chunk.index()].assign_render_id(render_id);
     }
 
     pub fn block_chunk_group(&self, origin: AsyncBlockOrigin) -> Option<ChunkGroupId> {
@@ -377,57 +413,4 @@ fn import_block_target(module_graph: &ModuleGraph, origin: AsyncBlockOrigin) -> 
                 && connection.dependency.is_import_dependency()
         })
         .map(|connection| connection.module)
-}
-
-fn chunk_render_id(
-    context: &RenderPathContext,
-    module_graph: &ModuleGraph,
-    module: ModuleId,
-) -> String {
-    let resource = module_graph
-        .module(module)
-        .map(|module| module.identity().resource.as_path())
-        .unwrap_or_else(|| Path::new("chunk"));
-    let relative = context.make_relative(resource);
-    sanitize_chunk_id(&relative)
-}
-
-#[derive(Debug, Clone)]
-struct RenderPathContext {
-    raw_context: PathBuf,
-    context: PathBuf,
-}
-
-impl RenderPathContext {
-    fn new(context: &Path) -> Self {
-        Self {
-            raw_context: context.to_path_buf(),
-            context: std::fs::canonicalize(context).unwrap_or_else(|_| context.to_path_buf()),
-        }
-    }
-
-    fn make_relative(&self, resource: &Path) -> String {
-        if let Ok(relative) = resource
-            .strip_prefix(&self.context)
-            .or_else(|_| resource.strip_prefix(&self.raw_context))
-        {
-            return normalize_path(relative);
-        }
-
-        let resource = std::fs::canonicalize(resource).unwrap_or_else(|_| PathBuf::from(resource));
-        let relative = resource.strip_prefix(&self.context).unwrap_or(&resource);
-        normalize_path(relative)
-    }
-}
-
-fn normalize_path(path: &Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
-}
-
-fn sanitize_chunk_id(relative: &str) -> String {
-    relative
-        .trim_start_matches("./")
-        .chars()
-        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
-        .collect()
 }

--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -1,4 +1,3 @@
-use std::path::{Path, PathBuf};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     hash::{Hash, Hasher},
@@ -19,6 +18,7 @@ use crate::{
     code_generation_record::{
         CodeGenerationReplacement, CodeGenerationResult, CodeGenerationSource,
     },
+    id_assignment::RenderId,
     rendered_source::RenderedSource,
 };
 
@@ -123,7 +123,7 @@ impl CacheKey for CodeGenerationKey {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct CodeGenerationResults {
-    module_render_ids: HashMap<ModuleId, String>,
+    module_render_ids: HashMap<ModuleId, RenderId>,
     module_identities: HashMap<ModuleId, ModuleIdentity>,
     results: HashMap<CodeGenerationKey, CodeGenerationResult>,
 }
@@ -141,7 +141,7 @@ struct CodeGenerationInput<'a> {
     module: &'a Module,
     module_graph: &'a ModuleGraph,
     chunk_graph: &'a ChunkGraph,
-    module_render_ids: &'a HashMap<ModuleId, String>,
+    module_render_ids: &'a HashMap<ModuleId, RenderId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -160,25 +160,25 @@ enum AssetRenderManifest {
     InitialChunk {
         modules: Vec<ModuleRenderManifest>,
         chunk_filename_map: String,
-        entry_id: String,
-        chunk_id: String,
+        entry_id: RenderId,
+        chunk_id: RenderId,
     },
     AsyncChunk {
         modules: Vec<ModuleRenderManifest>,
-        chunk_id: String,
+        chunk_id: RenderId,
     },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ModuleRenderManifest {
-    render_id: String,
+    render_id: RenderId,
     code_generation_key: CodeGenerationKey,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AssetRenderKey {
     kind: AssetRenderKind,
-    chunk_id: String,
+    chunk_id: RenderId,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -194,7 +194,7 @@ impl CacheKey for AssetRenderKey {
                 AssetRenderKind::Initial => b"initial".to_vec(),
                 AssetRenderKind::Async => b"async".to_vec(),
             },
-            self.chunk_id.as_bytes().to_vec(),
+            self.chunk_id.to_string().into_bytes(),
         ])
     }
 }
@@ -219,8 +219,23 @@ pub(crate) fn generate_code(
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
 ) -> CodeGenerationResults {
-    let render_context = RenderPathContext::new(options.context.as_path());
-    let module_render_ids = module_render_ids(&render_context, module_graph);
+    let module_render_ids = module_graph
+        .modules()
+        .iter()
+        .filter(|module| !chunk_graph.module_chunks(module.id()).is_empty())
+        .map(|module| {
+            let render_id = chunk_graph
+                .module_render_id(module.id())
+                .unwrap_or_else(|| {
+                    panic!(
+                        "module {:?} must have an assigned Render ID before code generation",
+                        module.id()
+                    )
+                })
+                .clone();
+            (module.id(), render_id)
+        })
+        .collect::<HashMap<_, _>>();
     let module_identities = module_graph
         .modules()
         .iter()
@@ -374,12 +389,12 @@ pub(crate) fn create_render_manifest(
         };
         let modules = module_render_manifest(chunk_graph, chunk, code_generation_results);
         manifest_entries.push(RenderManifestEntry {
-            filename: chunk.filename().to_string(),
+            filename: resolve_chunk_filename(chunk),
             render: AssetRenderManifest::InitialChunk {
                 modules,
                 chunk_filename_map: render_chunk_filename_map(chunk_graph),
                 entry_id: code_generation_results.module_render_ids[&entry_module].clone(),
-                chunk_id: chunk.render_id().to_string(),
+                chunk_id: chunk.render_id().clone(),
             },
         });
     }
@@ -395,14 +410,15 @@ pub(crate) fn create_render_manifest(
             continue;
         }
         manifest_entries.push(RenderManifestEntry {
-            filename: chunk.filename().to_string(),
+            filename: resolve_chunk_filename(chunk),
             render: AssetRenderManifest::AsyncChunk {
                 modules: module_render_manifest(chunk_graph, chunk, code_generation_results),
-                chunk_id: chunk.render_id().to_string(),
+                chunk_id: chunk.render_id().clone(),
             },
         });
     }
 
+    manifest_entries.sort_by(|left, right| left.filename.cmp(&right.filename));
     RenderManifest {
         entries: manifest_entries,
     }
@@ -508,7 +524,7 @@ fn module_render_manifest(
     code_generation_results: &CodeGenerationResults,
 ) -> Vec<ModuleRenderManifest> {
     let runtime = RuntimeSpec::for_chunk(chunk_graph, chunk);
-    chunk_graph
+    let mut modules = chunk_graph
         .chunk_modules(chunk.id())
         .iter()
         .filter_map(|module_id| {
@@ -522,7 +538,9 @@ fn module_render_manifest(
                     code_generation_key,
                 })
         })
-        .collect()
+        .collect::<Vec<_>>();
+    modules.sort_by(|left, right| left.render_id.cmp(&right.render_id));
+    modules
 }
 
 fn render_asset(
@@ -583,13 +601,13 @@ fn emit_asset(filename: String, rendered: &RenderedSource, sourcemap: bool) -> V
 fn render_initial_asset(
     modules: &[ModuleRenderManifest],
     chunk_filename_map: &str,
-    entry_id: &str,
-    chunk_id: &str,
+    entry_id: &RenderId,
+    chunk_id: &RenderId,
     code_generation_results: &CodeGenerationResults,
 ) -> ConcatSource {
     let modules = render_module_table(modules, code_generation_results);
-    let entry_id = json_string(entry_id);
-    let chunk_id = json_string(chunk_id);
+    let entry_id = json_render_id(entry_id);
+    let chunk_id = json_render_id(chunk_id);
 
     let mut source = ConcatSource::default();
     source.add(RawStringSource::from(
@@ -671,11 +689,11 @@ module.exports = __webpack_require__({entry_id});
 
 fn render_async_chunk_asset(
     modules: &[ModuleRenderManifest],
-    chunk_id: &str,
+    chunk_id: &RenderId,
     code_generation_results: &CodeGenerationResults,
 ) -> ConcatSource {
     let modules = render_module_table(modules, code_generation_results);
-    let chunk_id = json_string(chunk_id);
+    let chunk_id = json_render_id(chunk_id);
     let mut source = ConcatSource::default();
     source.add(RawStringSource::from(format!(
         r#""use strict";
@@ -709,7 +727,7 @@ fn render_module_table(
         }
         source.add(RawStringSource::from(format!(
             "{}: ",
-            json_string(&module.render_id)
+            json_render_id(&module.render_id)
         )));
         source.add(result.source().clone());
     }
@@ -731,9 +749,10 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
 
     let module_id = module.id();
     let module_render_id = &module_render_ids[&module_id];
+    let module_render_name = module_render_id.to_string();
     let mut source = ReplaceSource::new(OriginalSource::new(
         module.source(),
-        module_render_id.as_str(),
+        module_render_name.as_str(),
     ));
     let mut init_fragments = Vec::new();
 
@@ -788,7 +807,7 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
             "((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {{\n\"use strict\";\n__webpack_require__.r(__webpack_exports__);\n{init}"
         ),
         original_source: module.source().to_string(),
-        original_name: module_render_id.clone(),
+        original_name: module_render_name,
         replacements: source
             .replacements()
             .iter()
@@ -834,7 +853,7 @@ fn apply_dependency_template(
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
     exports_info: &ExportsInfo,
-    module_render_ids: &HashMap<ModuleId, String>,
+    module_render_ids: &HashMap<ModuleId, RenderId>,
     source: &mut ReplaceSource,
     init_fragments: &mut Vec<InitFragment>,
 ) {
@@ -910,7 +929,7 @@ fn apply_harmony_import_side_effect_dependency(
     module_id: ModuleId,
     dependency_id: Option<usize>,
     module_graph: &ModuleGraph,
-    module_render_ids: &HashMap<ModuleId, String>,
+    module_render_ids: &HashMap<ModuleId, RenderId>,
     init_fragments: &mut Vec<InitFragment>,
 ) {
     let Some(dependency_id) = dependency_id else {
@@ -920,7 +939,7 @@ fn apply_harmony_import_side_effect_dependency(
         return;
     };
     let import_var = import_var(&dep.module.request, dep.module.source_order.unwrap_or(0));
-    let target_id = json_string(&module_render_ids[&target]);
+    let target_id = json_render_id(&module_render_ids[&target]);
     push_init_fragment(
         init_fragments,
         InitFragmentStage::HarmonyImport,
@@ -933,7 +952,7 @@ fn apply_harmony_import_specifier_dependency(
     module_id: ModuleId,
     dependency_id: Option<usize>,
     module_graph: &ModuleGraph,
-    module_render_ids: &HashMap<ModuleId, String>,
+    module_render_ids: &HashMap<ModuleId, RenderId>,
     source: &mut ReplaceSource,
 ) {
     let Some(dependency_id) = dependency_id else {
@@ -1013,7 +1032,7 @@ fn apply_harmony_export_imported_specifier_dependency(
     dependency_id: Option<usize>,
     module_graph: &ModuleGraph,
     exports_info: &ExportsInfo,
-    module_render_ids: &HashMap<ModuleId, String>,
+    module_render_ids: &HashMap<ModuleId, RenderId>,
     init_fragments: &mut Vec<InitFragment>,
 ) {
     let Some(dependency_id) = dependency_id else {
@@ -1053,7 +1072,7 @@ fn apply_import_dependency(
     dependency_id: Option<usize>,
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
-    module_render_ids: &HashMap<ModuleId, String>,
+    module_render_ids: &HashMap<ModuleId, RenderId>,
     source: &mut ReplaceSource,
 ) {
     let Some(block_index) = origin_block else {
@@ -1067,7 +1086,7 @@ fn apply_import_dependency(
     else {
         return;
     };
-    let target_id = json_string(&module_render_ids[&target]);
+    let target_id = json_render_id(&module_render_ids[&target]);
     let origin = AsyncBlockOrigin {
         module: module_id,
         block_index,
@@ -1078,7 +1097,7 @@ fn apply_import_dependency(
             .chunks()
             .first()
             .and_then(|chunk_id| chunk_graph.chunk(*chunk_id))
-            .map(|chunk| json_string(chunk.render_id()))
+            .map(|chunk| json_render_id(chunk.render_id()))
             .unwrap_or_else(|| "\"\"".to_string());
         format!(
             "__webpack_require__.e({chunk_id}).then(__webpack_require__.bind(__webpack_require__, {target_id}))"
@@ -1095,77 +1114,28 @@ fn replace(source: &mut ReplaceSource, range: SourceRange, content: String) {
     source.replace(range.start, range.end, content, None);
 }
 
-#[derive(Debug, Clone)]
-struct RenderPathContext {
-    raw_context: PathBuf,
-    context: PathBuf,
-}
-
-impl RenderPathContext {
-    fn new(context: &Path) -> Self {
-        Self {
-            raw_context: context.to_path_buf(),
-            context: std::fs::canonicalize(context).unwrap_or_else(|_| context.to_path_buf()),
-        }
-    }
-
-    fn make_relative(&self, resource: &Path) -> String {
-        if let Ok(relative) = resource
-            .strip_prefix(&self.context)
-            .or_else(|_| resource.strip_prefix(&self.raw_context))
-        {
-            return normalize_path(relative);
-        }
-
-        let resource = std::fs::canonicalize(resource).unwrap_or_else(|_| PathBuf::from(resource));
-        let relative = resource.strip_prefix(&self.context).unwrap_or(&resource);
-        normalize_path(relative)
-    }
-}
-
-fn module_render_ids(
-    context: &RenderPathContext,
-    module_graph: &ModuleGraph,
-) -> HashMap<ModuleId, String> {
-    module_graph
-        .modules()
-        .iter()
-        .map(|module| (module.id(), module_render_id(context, module)))
-        .collect()
-}
-
-fn module_render_id(context: &RenderPathContext, module: &Module) -> String {
-    let mut resource = context.make_relative(&module.identity().resource);
-    if !resource.starts_with("./") {
-        resource = format!("./{resource}");
-    }
-    if let Some(query) = &module.identity().query {
-        resource.push('?');
-        resource.push_str(query);
-    }
-    if let Some(fragment) = &module.identity().fragment {
-        resource.push('#');
-        resource.push_str(fragment);
-    }
-    resource
-}
-
-fn normalize_path(path: &Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
-}
-
 fn render_chunk_filename_map(chunk_graph: &ChunkGraph) -> String {
     let mut entries = BTreeMap::new();
     for chunk in chunk_graph.chunks() {
-        entries.insert(chunk.render_id().to_string(), chunk.filename().to_string());
+        entries.insert(chunk.render_id().clone(), resolve_chunk_filename(chunk));
     }
     entries
         .into_iter()
         .map(|(chunk_id, filename)| {
-            format!("{}: {}", json_string(&chunk_id), json_string(&filename))
+            format!("{}: {}", json_render_id(&chunk_id), json_string(&filename))
         })
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+fn resolve_chunk_filename(chunk: &Chunk) -> String {
+    if let Some(filename) = chunk.filename_override() {
+        return filename.to_string();
+    }
+    match chunk.name() {
+        Some(name) => format!("{name}.js"),
+        None => format!("{}.js", chunk.render_id()),
+    }
 }
 
 fn import_var(request: &str, source_order: usize) -> String {
@@ -1236,6 +1206,13 @@ fn json_string(value: &str) -> String {
     format!("\"{escaped}\"")
 }
 
+fn json_render_id(render_id: &RenderId) -> String {
+    match render_id {
+        RenderId::String(value) => json_string(value),
+        RenderId::Number(value) => value.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -1249,6 +1226,7 @@ mod tests {
         CacheOptions, ChunkGraph, ChunkGroupKind, Compiler, CompilerOptions, ConstDependency,
         Dependency, Entry, ModuleGraph, ModuleIdentity, SnapshotOptions, SourceRange,
         build_cache::{BuildCache, CacheIdentifier, CacheKey, CacheNamespace},
+        id_assignment::RenderId,
     };
 
     use super::{
@@ -1315,7 +1293,8 @@ mod tests {
                 "value".to_string(),
                 source_hash,
             );
-        let module_render_ids = HashMap::from([(module_id, "./src/index.js".to_string())]);
+        let module_render_ids =
+            HashMap::from([(module_id, RenderId::String("./src/index.js".to_string()))]);
         code_generation_etag(&CodeGenerationInput {
             module: module_graph
                 .module(module_id)
@@ -1337,11 +1316,11 @@ mod tests {
 
         let initial = AssetRenderKey {
             kind: AssetRenderKind::Initial,
-            chunk_id: "main".to_string(),
+            chunk_id: RenderId::String("main".to_string()),
         };
         let asynchronous = AssetRenderKey {
             kind: AssetRenderKind::Async,
-            chunk_id: "main".to_string(),
+            chunk_id: RenderId::String("main".to_string()),
         };
         assert_eq!(
             initial.cache_identifier(),
@@ -1357,12 +1336,12 @@ mod tests {
             RuntimeSpec(BTreeSet::from(["main".to_string()])),
         );
         let module = ModuleRenderManifest {
-            render_id: "./src/feature.js".to_string(),
+            render_id: RenderId::String("./src/feature.js".to_string()),
             code_generation_key: code_generation_key.clone(),
         };
         let render = AssetRenderManifest::AsyncChunk {
             modules: vec![module],
-            chunk_id: "src_feature_js".to_string(),
+            chunk_id: RenderId::String("src_feature_js".to_string()),
         };
         let mut results = CodeGenerationResults::default();
         results.results.insert(
@@ -1380,14 +1359,14 @@ mod tests {
         let initial = AssetRenderManifest::InitialChunk {
             modules: Vec::new(),
             chunk_filename_map: "{\"feature\":\"feature.js\"}".to_string(),
-            entry_id: "./src/index.js".to_string(),
-            chunk_id: "main".to_string(),
+            entry_id: RenderId::String("./src/index.js".to_string()),
+            chunk_id: RenderId::String("main".to_string()),
         };
         let changed_filename_map = AssetRenderManifest::InitialChunk {
             modules: Vec::new(),
             chunk_filename_map: "{\"feature\":\"renamed.js\"}".to_string(),
-            entry_id: "./src/index.js".to_string(),
-            chunk_id: "main".to_string(),
+            entry_id: RenderId::String("./src/index.js".to_string()),
+            chunk_id: RenderId::String("main".to_string()),
         };
         assert_ne!(
             initial.cache_etag(&results),

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -7,6 +7,7 @@ use crate::{
     ModuleGraph, ModuleId, Result, UnpackResolver,
     build_cache::BuildCache,
     code_generation::{self, CodeGenerationResults, RenderManifest},
+    id_assignment::{assign_chunk_render_ids, assign_module_render_ids},
     make::{self, MakeState},
     snapshot::FileSystemInfo,
 };
@@ -19,6 +20,7 @@ pub struct Compilation {
     build_cache: BuildCache,
     module_graph: ModuleGraph,
     chunk_graph: ChunkGraph,
+    render_ids_assigned: bool,
     code_generation_results: Option<CodeGenerationResults>,
     asset_render_manifest: Option<RenderManifest>,
     assets: Vec<Asset>,
@@ -42,6 +44,7 @@ impl Compilation {
             build_cache,
             module_graph: ModuleGraph::default(),
             chunk_graph: ChunkGraph::default(),
+            render_ids_assigned: false,
             code_generation_results: None,
             asset_render_manifest: None,
             assets: Vec::new(),
@@ -148,11 +151,26 @@ impl Compilation {
             "chunk graph build started",
         );
         self.chunk_graph = ChunkGraph::build(&self.options, &self.module_graph, &self.entries);
+        self.render_ids_assigned = false;
         self.log_infrastructure(
             InfrastructureLogLevel::Verbose,
             "unpack.Compilation",
             "chunk graph build completed",
         );
+    }
+
+    pub(crate) fn assign_render_ids(&mut self) {
+        self.assign_module_ids();
+        self.assign_chunk_ids();
+        self.render_ids_assigned = true;
+    }
+
+    fn assign_module_ids(&mut self) {
+        assign_module_render_ids(&self.options, &self.module_graph, &mut self.chunk_graph);
+    }
+
+    fn assign_chunk_ids(&mut self) {
+        assign_chunk_render_ids(&self.options, &self.module_graph, &mut self.chunk_graph);
     }
 
     pub fn create_assets(&mut self) {
@@ -204,6 +222,9 @@ impl Compilation {
     pub fn code_generation(&mut self) {
         let span = tracing::trace_span!("Compilation::code_generation");
         let _enter = span.enter();
+        if !self.render_ids_assigned {
+            self.assign_render_ids();
+        }
         self.code_generation_results = Some(code_generation::generate_code(
             &self.options,
             &self.build_cache,

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -676,6 +676,7 @@ impl Compiler {
             let mut compilation = self.create_compilation();
             compilation.make().await?;
             compilation.build_chunk_graph();
+            compilation.assign_render_ids();
             compilation.code_generation();
             compilation.create_assets();
             Ok(compilation)

--- a/crates/unpack_core/src/id_assignment.rs
+++ b/crates/unpack_core/src/id_assignment.rs
@@ -1,0 +1,432 @@
+use std::{
+    collections::{BTreeMap, HashSet},
+    fmt,
+    path::{Path, PathBuf},
+};
+
+use crate::{ChunkGraph, CompilerOptions, ModuleGraph, cache_hash::stable_hash};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum RenderId {
+    String(String),
+    Number(u32),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NamedIdCandidate<K> {
+    item: K,
+    short_name: String,
+    full_name: String,
+}
+
+impl<K> NamedIdCandidate<K> {
+    fn new(item: K, short_name: String, full_name: String) -> Self {
+        Self {
+            item,
+            short_name,
+            full_name,
+        }
+    }
+}
+
+impl fmt::Display for RenderId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::String(value) => formatter.write_str(value),
+            Self::Number(value) => value.fmt(formatter),
+        }
+    }
+}
+
+pub(crate) fn assign_module_render_ids(
+    options: &CompilerOptions,
+    module_graph: &ModuleGraph,
+    chunk_graph: &mut ChunkGraph,
+) {
+    let context = RenderPathContext::new(&options.context);
+    let candidates = module_graph
+        .modules()
+        .iter()
+        .filter(|module| !chunk_graph.module_chunks(module.id()).is_empty())
+        .map(|module| {
+            let full_name = module_identity_key(&context, module.identity());
+            let short_name = readable_module_name(&context, module.identity());
+            NamedIdCandidate::new(module.id(), short_name, full_name)
+        })
+        .collect();
+
+    for (module, render_id) in assign_named_ids(candidates) {
+        chunk_graph.set_module_render_id(module, render_id);
+    }
+}
+
+pub(crate) fn assign_chunk_render_ids(
+    options: &CompilerOptions,
+    module_graph: &ModuleGraph,
+    chunk_graph: &mut ChunkGraph,
+) {
+    let context = RenderPathContext::new(&options.context);
+    let mut entry_candidates = Vec::new();
+    let mut async_candidates = Vec::new();
+    for chunk in chunk_graph.chunks() {
+        if let Some(name) = chunk.name() {
+            entry_candidates.push(NamedIdCandidate::new(
+                chunk.id(),
+                name.to_string(),
+                format!("entry:{name}"),
+            ));
+            continue;
+        }
+
+        let mut roots = chunk
+            .root_modules()
+            .iter()
+            .filter_map(|module| module_graph.module(*module))
+            .map(|module| {
+                (
+                    readable_module_name(&context, module.identity()),
+                    module_identity_key(&context, module.identity()),
+                )
+            })
+            .collect::<Vec<_>>();
+        roots.sort();
+        let short_name = roots
+            .iter()
+            .map(|(name, _)| request_to_id(name))
+            .filter(|name| !name.is_empty())
+            .collect::<Vec<_>>()
+            .join("-");
+        let full_name = format!(
+            "async:{}",
+            roots
+                .iter()
+                .map(|(_, key)| key.as_str())
+                .collect::<Vec<_>>()
+                .join("|")
+        );
+        async_candidates.push(NamedIdCandidate::new(chunk.id(), short_name, full_name));
+    }
+
+    let mut assignments = assign_named_ids(entry_candidates);
+    let reserved = assignments
+        .iter()
+        .map(|(_, render_id)| render_id.to_string())
+        .collect();
+    assignments.extend(assign_named_ids_with_reserved(async_candidates, reserved));
+    for (chunk_id, render_id) in assignments {
+        chunk_graph.set_chunk_render_id(chunk_id, render_id);
+    }
+}
+
+fn assign_named_ids<K>(candidates: Vec<NamedIdCandidate<K>>) -> Vec<(K, RenderId)>
+where
+    K: Copy + Ord,
+{
+    assign_named_ids_with_reserved(candidates, HashSet::new())
+}
+
+fn assign_named_ids_with_reserved<K>(
+    candidates: Vec<NamedIdCandidate<K>>,
+    mut used: HashSet<String>,
+) -> Vec<(K, RenderId)>
+where
+    K: Copy + Ord,
+{
+    let mut groups = BTreeMap::<String, Vec<(K, String)>>::new();
+    for candidate in candidates {
+        groups
+            .entry(candidate.short_name)
+            .or_default()
+            .push((candidate.item, candidate.full_name));
+    }
+
+    let mut assigned = Vec::new();
+    let mut unnamed = Vec::new();
+
+    for (short_name, mut items) in groups {
+        items.sort_by(|(left_item, left_name), (right_item, right_name)| {
+            left_name.cmp(right_name).then(left_item.cmp(right_item))
+        });
+        if short_name.is_empty() {
+            unnamed.extend(items);
+            continue;
+        }
+        if items.len() == 1 && used.insert(short_name.clone()) {
+            assigned.push((items[0].0, RenderId::String(short_name)));
+            continue;
+        }
+
+        for (item, full_name) in items {
+            let suffix = format!("{:06x}", stable_hash(&full_name) & 0xff_ffff);
+            let base = format!("{short_name}-{suffix}");
+            let mut name = base.clone();
+            let mut index = 0_u32;
+            while !used.insert(name.clone()) {
+                name = format!("{base}-{index}");
+                index += 1;
+            }
+            assigned.push((item, RenderId::String(name)));
+        }
+    }
+
+    unnamed.sort_by(|(left_item, left_name), (right_item, right_name)| {
+        left_name.cmp(right_name).then(left_item.cmp(right_item))
+    });
+    let mut next = 0_u32;
+    for (item, _) in unnamed {
+        while used.contains(&next.to_string()) {
+            next += 1;
+        }
+        used.insert(next.to_string());
+        assigned.push((item, RenderId::Number(next)));
+        next += 1;
+    }
+    assigned.sort_by_key(|(item, _)| *item);
+    assigned
+}
+
+fn readable_module_name(context: &RenderPathContext, identity: &crate::ModuleIdentity) -> String {
+    let resource = context.make_relative(&identity.resource);
+    if resource.is_empty() {
+        return String::new();
+    }
+    let mut name = String::new();
+    for loader in &identity.loaders {
+        name.push_str(&context.make_request_relative(loader));
+        name.push('!');
+    }
+    if !resource.starts_with('.') && !resource.starts_with('/') {
+        name.push_str("./");
+    }
+    name.push_str(&resource);
+    if let Some(query) = &identity.query {
+        name.push('?');
+        name.push_str(query.trim_start_matches('?'));
+    }
+    if let Some(fragment) = &identity.fragment {
+        name.push('#');
+        name.push_str(fragment.trim_start_matches('#'));
+    }
+    if let Some(layer) = &identity.layer {
+        name.push_str("|layer:");
+        name.push_str(layer);
+    }
+    name
+}
+
+fn module_identity_key(context: &RenderPathContext, identity: &crate::ModuleIdentity) -> String {
+    format!(
+        "type={:?};loaders={:?};resource={};query={:?};fragment={:?};layer={:?}",
+        identity.module_type,
+        identity.loaders,
+        context.make_relative(&identity.resource),
+        identity.query,
+        identity.fragment,
+        identity.layer
+    )
+}
+
+fn request_to_id(request: &str) -> String {
+    request
+        .trim_start_matches("./")
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone)]
+struct RenderPathContext {
+    raw_context: PathBuf,
+    context: PathBuf,
+}
+
+impl RenderPathContext {
+    fn new(context: &Path) -> Self {
+        Self {
+            raw_context: context.to_path_buf(),
+            context: std::fs::canonicalize(context).unwrap_or_else(|_| context.to_path_buf()),
+        }
+    }
+
+    fn make_relative(&self, resource: &Path) -> String {
+        if let Ok(relative) = resource
+            .strip_prefix(&self.context)
+            .or_else(|_| resource.strip_prefix(&self.raw_context))
+        {
+            return normalize_path(relative);
+        }
+
+        let resource = std::fs::canonicalize(resource).unwrap_or_else(|_| resource.to_path_buf());
+        let relative = resource.strip_prefix(&self.context).unwrap_or(&resource);
+        normalize_path(relative)
+    }
+
+    fn make_request_relative(&self, request: &str) -> String {
+        let path = Path::new(request);
+        if path.is_absolute() {
+            self.make_relative(path)
+        } else {
+            request.replace('\\', "/")
+        }
+    }
+}
+
+fn normalize_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        CacheOptions, ChunkGraph, CompilerOptions, Entry, ModuleGraph, ModuleIdentity,
+        SnapshotOptions,
+        build_cache::BuildCache,
+        code_generation::{create_render_manifest, generate_code, render_assets},
+    };
+
+    #[test]
+    fn named_ids_are_stable_across_insertion_order_and_collision_safe() {
+        let first = assign_named_ids(vec![
+            NamedIdCandidate::new(0, "same".to_string(), "alpha".to_string()),
+            NamedIdCandidate::new(1, "same".to_string(), "beta".to_string()),
+        ]);
+        let second = assign_named_ids(vec![
+            NamedIdCandidate::new(0, "same".to_string(), "beta".to_string()),
+            NamedIdCandidate::new(1, "same".to_string(), "alpha".to_string()),
+        ]);
+
+        let first_by_identity =
+            BTreeMap::from([("alpha", first[0].1.clone()), ("beta", first[1].1.clone())]);
+        let second_by_identity = BTreeMap::from([
+            ("beta", second[0].1.clone()),
+            ("alpha", second[1].1.clone()),
+        ]);
+
+        assert_eq!(first_by_identity, second_by_identity);
+        assert_ne!(first[0].1, first[1].1);
+    }
+
+    #[test]
+    // Derived from webpack 5.108.1:
+    // lib/ids/IdHelpers.js assignAscendingModuleIds/assignAscendingChunkIds.
+    fn unnamed_items_receive_deterministic_numeric_fallbacks() {
+        let assignments = assign_named_ids(vec![
+            NamedIdCandidate::new(1, String::new(), "beta".to_string()),
+            NamedIdCandidate::new(0, String::new(), "alpha".to_string()),
+        ]);
+
+        assert_eq!(
+            assignments,
+            vec![(0, RenderId::Number(0)), (1, RenderId::Number(1))]
+        );
+    }
+
+    #[test]
+    fn module_names_distinguish_loaders_queries_fragments_and_layers() {
+        let context = RenderPathContext::new(Path::new("/project"));
+        let mut identity = crate::ModuleIdentity::new("/project/src/value.js");
+        identity.loaders = vec!["/project/loaders/first.js".to_string()];
+        identity.query = Some("?one".to_string());
+        identity.fragment = Some("#alpha".to_string());
+        identity.layer = Some("client".to_string());
+
+        assert_eq!(
+            readable_module_name(&context, &identity),
+            "loaders/first.js!./src/value.js?one#alpha|layer:client"
+        );
+    }
+
+    #[test]
+    fn emitted_assets_are_stable_across_module_graph_insertion_orders() {
+        let first = render_synthetic_entries(&["index", "alpha", "omega"]);
+        let second = render_synthetic_entries(&["omega", "index", "alpha"]);
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    // Derived from webpack 5.108.1:
+    // lib/ids/IdHelpers.js assignAscendingModuleIds fallback for unnamed modules.
+    fn emitted_unnamed_module_consumes_numeric_fallback() {
+        let context = Path::new("/project");
+        let options = CompilerOptions::new(context, vec![Entry::new("main", "./index")]);
+        let mut module_graph = ModuleGraph::default();
+        let module = add_built_module(&mut module_graph, ModuleIdentity::new(context), "unnamed");
+        let mut chunk_graph = ChunkGraph::build(&options, &module_graph, &[module]);
+        assign_module_render_ids(&options, &module_graph, &mut chunk_graph);
+        assign_chunk_render_ids(&options, &module_graph, &mut chunk_graph);
+
+        let build_cache = BuildCache::new(CacheOptions::memory(), SnapshotOptions::default());
+        let results = generate_code(&options, &build_cache, &module_graph, &chunk_graph);
+        let manifest = create_render_manifest(&chunk_graph, &[module], &results);
+        let assets = render_assets(&options, &build_cache, &manifest, &results);
+        let main = assets
+            .iter()
+            .find(|asset| asset.filename == "main.js")
+            .expect("main asset should exist");
+
+        assert!(main.source.contains("0: "));
+        assert!(
+            main.source
+                .contains("module.exports = __webpack_require__(0);")
+        );
+    }
+
+    fn render_synthetic_entries(insertion_order: &[&str]) -> Vec<crate::Asset> {
+        let context = Path::new("/project");
+        let entry_names = ["index", "alpha", "omega"];
+        let options = CompilerOptions::new(
+            context,
+            entry_names
+                .iter()
+                .map(|name| Entry::new(*name, format!("./{name}")))
+                .collect(),
+        );
+        let mut module_graph = ModuleGraph::default();
+        let mut modules_by_name = BTreeMap::new();
+        for name in insertion_order {
+            let identity = ModuleIdentity::new(context.join(format!("{name}.js")));
+            let module = add_built_module(&mut module_graph, identity, name);
+            modules_by_name.insert(*name, module);
+        }
+        let entries = entry_names
+            .iter()
+            .map(|name| modules_by_name[name])
+            .collect::<Vec<_>>();
+        let mut chunk_graph = ChunkGraph::build(&options, &module_graph, &entries);
+        assign_module_render_ids(&options, &module_graph, &mut chunk_graph);
+        assign_chunk_render_ids(&options, &module_graph, &mut chunk_graph);
+
+        let build_cache = BuildCache::new(CacheOptions::memory(), SnapshotOptions::default());
+        let results = generate_code(&options, &build_cache, &module_graph, &chunk_graph);
+        let manifest = create_render_manifest(&chunk_graph, &entries, &results);
+        render_assets(&options, &build_cache, &manifest, &results)
+    }
+
+    fn add_built_module(
+        module_graph: &mut ModuleGraph,
+        identity: ModuleIdentity,
+        value: &str,
+    ) -> crate::ModuleId {
+        let module = module_graph.add_module(identity);
+        let source = format!("const value = {value:?};");
+        module_graph
+            .module_mut(module)
+            .expect("synthetic module should exist")
+            .finish_build(
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                source.clone(),
+                stable_hash(&source),
+            );
+        module
+    }
+}

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -8,6 +8,7 @@ mod compiler;
 mod dependency;
 mod error;
 mod exports_info;
+mod id_assignment;
 mod logging;
 mod make;
 mod module;

--- a/crates/unpack_core/tests/codegen.rs
+++ b/crates/unpack_core/tests/codegen.rs
@@ -94,8 +94,188 @@ async fn builds_a_render_manifest_before_creating_asset_bookkeeping()
     Ok(())
 }
 
+// Ported from webpack 5.108.1:
+// test/configCases/optimization/named-modules
+//
+// Webpack's case establishes that named IDs remain recognizable. This variant
+// also covers Unpack's named-ID contract for deterministic collision handling.
 #[tokio::test]
-async fn preserves_byte_exact_static_async_and_sourcemap_outputs()
+async fn assigns_unique_readable_names_to_colliding_async_chunks()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    write(
+        temp.path().join("src/index.js"),
+        r#"
+            export const loadDash = () => import("./a-b");
+            export const loadUnderscore = () => import("./a_b");
+        "#,
+    )?;
+    write(
+        temp.path().join("src/a-b.js"),
+        "export const value = 'dash';",
+    )?;
+    write(
+        temp.path().join("src/a_b.js"),
+        "export const value = 'underscore';",
+    )?;
+
+    let options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./src/index")]);
+    let first = Compiler::new(options.clone()).run().await?;
+    let second = Compiler::new(options).run().await?;
+
+    let first_assets = first
+        .assets()
+        .iter()
+        .map(|asset| (asset.filename.clone(), asset.source.clone()))
+        .collect::<Vec<_>>();
+    let second_assets = second
+        .assets()
+        .iter()
+        .map(|asset| (asset.filename.clone(), asset.source.clone()))
+        .collect::<Vec<_>>();
+    assert_eq!(first_assets, second_assets);
+
+    let async_filenames = first
+        .assets()
+        .iter()
+        .filter(|asset| asset.filename.ends_with(".js") && asset.filename != "main.js")
+        .map(|asset| asset.filename.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(async_filenames.len(), 2);
+    assert_ne!(async_filenames[0], async_filenames[1]);
+    assert!(
+        async_filenames
+            .iter()
+            .all(|filename| filename.starts_with("src_a_b_js"))
+    );
+
+    Ok(())
+}
+
+// Ported from webpack 5.108.1:
+// test/statsCases/named-chunks-plugin-async
+// Collision precedence follows lib/ids/NamedChunkIdsPlugin.js.
+#[tokio::test]
+async fn entry_names_take_precedence_over_colliding_async_names()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    write(
+        temp.path().join("src/index.js"),
+        "export const load = () => import('./feature');",
+    )?;
+    write(
+        temp.path().join("src/feature.js"),
+        "export const value = 'feature';",
+    )?;
+
+    let compilation = Compiler::new(CompilerOptions::new(
+        temp.path(),
+        vec![Entry::new("src_feature_js", "./src/index")],
+    ))
+    .run()
+    .await?;
+    let entry = compilation
+        .assets()
+        .iter()
+        .find(|asset| asset.filename == "src_feature_js.js")
+        .expect("entry asset should keep its configured filename");
+
+    assert!(entry.source.contains("  \"src_feature_js\": 1"));
+    assert!(compilation.assets().iter().any(|asset| {
+        asset.filename.starts_with("src_feature_js-") && asset.filename.ends_with(".js")
+    }));
+
+    Ok(())
+}
+
+// Ported from webpack 5.108.1:
+// test/configCases/module-name/different-issuers-for-same-module
+//
+// Unpack does not expose loaders yet, so the public seam exercises the same
+// identity rule through resource queries and fragments.
+#[tokio::test]
+async fn module_render_ids_distinguish_queries_and_fragments()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    write(
+        temp.path().join("src/index.js"),
+        r#"
+            import { value as alpha } from "./shared?one#alpha";
+            import { value as beta } from "./shared?two#beta";
+            export const values = [alpha, beta];
+        "#,
+    )?;
+    write(
+        temp.path().join("src/shared.js"),
+        "export const value = 'shared';",
+    )?;
+
+    let compilation = Compiler::new(CompilerOptions::new(
+        temp.path(),
+        vec![Entry::new("main", "./src/index")],
+    ))
+    .run()
+    .await?;
+    let main = compilation
+        .assets()
+        .iter()
+        .find(|asset| asset.filename == "main.js")
+        .expect("main asset should exist");
+
+    assert!(
+        main.source.contains(r#""./src/shared.js?one#alpha""#),
+        "main asset did not contain the first assigned ID:\n{}",
+        main.source
+    );
+    assert!(
+        main.source.contains(r#""./src/shared.js?two#beta""#),
+        "main asset did not contain the second assigned ID:\n{}",
+        main.source
+    );
+    assert!(!main.source.contains("??"));
+    assert!(!main.source.contains("##"));
+
+    Ok(())
+}
+
+// Ported from webpack 5.108.1:
+// test/configCases/optimization/named-modules
+#[tokio::test]
+async fn renders_module_factories_in_render_id_order() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    write(
+        temp.path().join("src/index.js"),
+        r#"
+            import { z } from "./z";
+            import { a } from "./a";
+            export const value = a + z;
+        "#,
+    )?;
+    write(temp.path().join("src/a.js"), "export const a = 'a';")?;
+    write(temp.path().join("src/z.js"), "export const z = 'z';")?;
+
+    let compilation = Compiler::new(CompilerOptions::new(
+        temp.path(),
+        vec![Entry::new("main", "./src/index")],
+    ))
+    .run()
+    .await?;
+    let main = compilation
+        .assets()
+        .iter()
+        .find(|asset| asset.filename == "main.js")
+        .expect("main asset should exist");
+    let a = main.source.find(r#""./src/a.js": "#).unwrap();
+    let index = main.source.find(r#""./src/index.js": "#).unwrap();
+    let z = main.source.find(r#""./src/z.js": "#).unwrap();
+
+    assert!(a < index && index < z);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn produces_stable_static_async_and_sourcemap_outputs()
 -> Result<(), Box<dyn std::error::Error>> {
     let temp = tempfile::tempdir()?;
     write(
@@ -139,8 +319,8 @@ async fn preserves_byte_exact_static_async_and_sourcemap_outputs()
     assert_eq!(
         fingerprints,
         [
-            ("main.js", 3166, 12861121386719719501),
-            ("main.js.map", 480, 10309079247393373181),
+            ("main.js", 3166, 13406043872577102803),
+            ("main.js.map", 480, 5745374754696300241),
             ("src_feature_js.js", 398, 7014656015713497901),
             ("src_feature_js.js.map", 164, 2414748877879059404)
         ]


### PR DESCRIPTION
## Summary

- assign Module Render IDs before Chunk Render IDs through an internal named-ID phase
- keep graph handles, Chunk names, Render IDs, and Asset filename resolution separate
- make module tables, filename maps, and Asset manifests deterministic while preserving entry filenames
- port webpack 5.108.1 named-ID coverage for readability, collisions, identity distinctions, insertion-order stability, and numeric fallback

## Why

Render IDs were previously calculated ad hoc during Chunk Graph construction and Code Generation. Sanitized async names could collide, query and fragment delimiters could be duplicated, and module factory order could follow graph insertion order.

## Checks

- pnpm test
- pnpm --filter @unpack-js/core typecheck
- two-axis Standards and Spec review against origin/main

## Performance

Diagnostic large-fixture run: cold 633.055 ms, warm 90.576 ms, no-cache 30.236 ms, output 437,550 bytes. Performance analysis remains non-blocking.

Closes #165