### PR TITLE
Introduce sealing and compilation-owned code generation

### DIFF
--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -15,10 +15,9 @@ use crate::{
     InfrastructureLogEvent, InfrastructureLogLevel, ModuleIdentity, SnapshotOptions,
     SnapshotStrategy, UnpackResolver,
     cache_hash::stable_hash,
-    code_generation_record::CodeGenerationResult,
     pack_file::{
-        AccessStamp, AssetRenderRecordCodec, AssetRenderRecordDto, CodeGenerationRecordCodec,
-        CodeGenerationRecordDto, CodecRegistry, DEFAULT_MAX_AGE, ModuleBuildRecordCodec,
+        AccessStamp, AssetRenderRecordCodec, AssetRenderRecordDto, CodecRegistry, DEFAULT_MAX_AGE,
+        ModuleBuildRecordCodec,
         ModuleBuildRecordDto, PackFile, PackFileAddress, PackFileETag, PackFileGuardDto,
         PackFileRetention, PackFileWriteBatch, PublicationBase, ResolveRecordCodec,
         ResolveRecordDto, SnapshotDto,
@@ -35,8 +34,6 @@ use crate::{
 
 const RESOLVE_CACHE_NAMESPACE: CacheNamespace = CacheNamespace::new("unpack/resolve");
 const MODULE_BUILD_CACHE_NAMESPACE: CacheNamespace = CacheNamespace::new("unpack/module-build");
-const CODE_GENERATION_CACHE_NAMESPACE: CacheNamespace =
-    CacheNamespace::new("unpack/code-generation");
 const ASSET_RENDER_CACHE_NAMESPACE: CacheNamespace = CacheNamespace::new("unpack/asset-render");
 const CACHE_PROFILE_LOGGER: &str = "unpack.Cache.Profile";
 const CACHE_WRITER_LOGGER: &str = "unpack.Cache.Writer";
@@ -823,16 +820,9 @@ impl PackFileCacheLayer {
                     let dto = ModuleBuildRecordDto::try_from(record.as_ref())?;
                     batch.insert(&self.registry, pack_address, pack_etag, dto)?;
                 }
-                CacheItemFamily::CodeGeneration => {
-                    let record = entry.value::<CodeGenerationResult>().ok_or_else(|| {
-                        io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            "Code Generation Cache Item contains an unexpected value",
-                        )
-                    })?;
-                    let dto = CodeGenerationRecordDto::from(record.as_ref());
-                    batch.insert(&self.registry, pack_address, pack_etag, dto)?;
-                }
+                CacheItemFamily::CodeGeneration => unreachable!(
+                    "Code Generation Results are Compilation-owned and cannot be persisted"
+                ),
                 CacheItemFamily::AssetRender => {
                     let record = entry.value::<RenderedSource>().ok_or_else(|| {
                         io::Error::new(
@@ -908,16 +898,6 @@ impl CacheLayer for PackFileCacheLayer {
                 let record = ModuleBuildRecord::try_from((*dto).clone()).ok()?;
                 Some(CacheEntry::new(
                     CacheItemFamily::ModuleBuild,
-                    etag.cloned(),
-                    record,
-                ))
-            }
-            CODE_GENERATION_CACHE_NAMESPACE => {
-                let dto =
-                    pack_file.get::<CodeGenerationRecordDto>(&pack_address, pack_etag.as_ref())?;
-                let record = CodeGenerationResult::try_from((*dto).clone()).ok()?;
-                Some(CacheEntry::new(
-                    CacheItemFamily::CodeGeneration,
                     etag.cloned(),
                     record,
                 ))
@@ -1529,13 +1509,6 @@ impl BuildCache {
         self.facade(MODULE_BUILD_CACHE_NAMESPACE, CacheItemFamily::ModuleBuild)
     }
 
-    pub(crate) fn code_generations<K>(&self) -> CacheFacade<K, CodeGenerationResult> {
-        self.facade(
-            CODE_GENERATION_CACHE_NAMESPACE,
-            CacheItemFamily::CodeGeneration,
-        )
-    }
-
     pub(crate) fn asset_renders<K>(&self) -> CacheFacade<K, RenderedSource> {
         self.facade(ASSET_RENDER_CACHE_NAMESPACE, CacheItemFamily::AssetRender)
     }
@@ -1875,7 +1848,6 @@ fn persistent_codec_registry() -> CodecRegistry {
     CodecRegistry::new()
         .with_resolve_record(ResolveRecordCodec::current())
         .with_module_build_record(ModuleBuildRecordCodec::current())
-        .with_code_generation_record(CodeGenerationRecordCodec::current())
         .with_asset_render_record(AssetRenderRecordCodec::current())
 }
 

--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -11,8 +11,7 @@ use crate::{
     Dependency, Error, ExportsInfo, HarmonyExportExpressionDependency,
     HarmonyExportHeaderDependency, HarmonyExportImportedSpecifierDependency,
     HarmonyExportSpecifierDependency, HarmonyImportSideEffectDependency,
-    HarmonyImportSpecifierDependency, ImportDependency, Module, ModuleGraph, ModuleId,
-    ModuleIdentity, SourceRange,
+    HarmonyImportSpecifierDependency, ImportDependency, Module, ModuleGraph, ModuleId, SourceRange,
     build_cache::{BuildCache, CacheETag, CacheIdentifier, CacheKey},
     cache_hash::StableHasher,
     code_generation_record::{
@@ -60,81 +59,10 @@ impl RuntimeRequirements {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct RuntimeSpec(BTreeSet<String>);
-
-impl RuntimeSpec {
-    fn for_chunk(chunk_graph: &ChunkGraph, chunk: &Chunk) -> Self {
-        let mut names = BTreeSet::new();
-        let mut visited = BTreeSet::new();
-        let mut pending = chunk.groups().to_vec();
-
-        while let Some(group_id) = pending.pop() {
-            if !visited.insert(group_id) {
-                continue;
-            }
-            let group = &chunk_graph.chunk_groups()[group_id.index()];
-            match group.kind() {
-                ChunkGroupKind::Entrypoint { name } => {
-                    names.insert(name.clone());
-                }
-                ChunkGroupKind::Async => pending.extend(group.parents().iter().copied()),
-            }
-        }
-
-        Self(names)
-    }
-
-    #[cfg(test)]
-    fn names(&self) -> impl Iterator<Item = &str> {
-        self.0.iter().map(String::as_str)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct CodeGenerationKey {
-    module: ModuleIdentity,
-    runtime: RuntimeSpec,
-}
-
-impl CodeGenerationKey {
-    fn new(module: ModuleIdentity, runtime: RuntimeSpec) -> Self {
-        Self { module, runtime }
-    }
-}
-
-impl CacheKey for CodeGenerationKey {
-    fn cache_identifier(&self) -> CacheIdentifier {
-        let module = self.module.cache_identifier();
-        let mut parts = vec![
-            b"code-generation-v1".to_vec(),
-            module.as_bytes().to_vec(),
-            (self.runtime.0.len() as u64).to_le_bytes().to_vec(),
-        ];
-        parts.extend(
-            self.runtime
-                .0
-                .iter()
-                .map(|runtime| runtime.as_bytes().to_vec()),
-        );
-        CacheIdentifier::from_parts(parts)
-    }
-}
-
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct CodeGenerationResults {
     module_render_ids: HashMap<ModuleId, RenderId>,
-    module_identities: HashMap<ModuleId, ModuleIdentity>,
-    results: HashMap<CodeGenerationKey, CodeGenerationResult>,
-}
-
-impl CodeGenerationResults {
-    fn key_for(&self, module: ModuleId, runtime: RuntimeSpec) -> Option<CodeGenerationKey> {
-        self.module_identities
-            .get(&module)
-            .cloned()
-            .map(|identity| CodeGenerationKey::new(identity, runtime))
-    }
+    results: HashMap<ModuleId, CodeGenerationResult>,
 }
 
 struct CodeGenerationInput<'a> {
@@ -171,8 +99,8 @@ enum AssetRenderManifest {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ModuleRenderManifest {
+    module: ModuleId,
     render_id: RenderId,
-    code_generation_key: CodeGenerationKey,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -214,10 +142,16 @@ enum InitFragmentStage {
 }
 
 pub(crate) fn generate_code(
-    options: &CompilerOptions,
-    build_cache: &BuildCache,
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
+) -> CodeGenerationResults {
+    generate_code_with(module_graph, chunk_graph, generate_module_code)
+}
+
+fn generate_code_with(
+    module_graph: &ModuleGraph,
+    chunk_graph: &ChunkGraph,
+    mut generate_module: impl FnMut(CodeGenerationInput<'_>) -> CodeGenerationResult,
 ) -> CodeGenerationResults {
     let module_render_ids = module_graph
         .modules()
@@ -236,136 +170,29 @@ pub(crate) fn generate_code(
             (module.id(), render_id)
         })
         .collect::<HashMap<_, _>>();
-    let module_identities = module_graph
+    let mut results = HashMap::new();
+    for module in module_graph
         .modules()
         .iter()
-        .map(|module| (module.id(), module.identity().clone()))
-        .collect::<HashMap<_, _>>();
-    let mut results = HashMap::new();
-    let cache = build_cache.code_generations::<CodeGenerationKey>();
-    let cache_enabled = options.cache.kind == crate::CacheKind::Filesystem;
-
-    for chunk in chunk_graph.chunks() {
-        let runtime = RuntimeSpec::for_chunk(chunk_graph, chunk);
-        for module_id in chunk_graph.chunk_modules(chunk.id()) {
-            let Some(module) = module_graph.module(*module_id) else {
-                continue;
-            };
-            let key = CodeGenerationKey::new(module.identity().clone(), runtime.clone());
-            if results.contains_key(&key) {
-                continue;
-            }
-            let input = CodeGenerationInput {
-                module,
-                module_graph,
-                chunk_graph,
-                module_render_ids: &module_render_ids,
-            };
-            let result = if cache_enabled {
-                let etag = code_generation_etag(&input);
-                if let Some(result) = cache.get(&key, Some(&etag)) {
-                    result.as_ref().clone()
-                } else {
-                    let result = generate_module_code(input);
-                    cache.store(key.clone(), Some(etag), result.clone());
-                    result
-                }
-            } else {
-                generate_module_code(input)
-            };
-            results.insert(key, result);
-        }
+        .filter(|module| !chunk_graph.module_chunks(module.id()).is_empty())
+    {
+        let input = CodeGenerationInput {
+            module,
+            module_graph,
+            chunk_graph,
+            module_render_ids: &module_render_ids,
+        };
+        let previous = results.insert(module.id(), generate_module(input));
+        assert!(
+            previous.is_none(),
+            "module {:?} must be generated exactly once per Compilation",
+            module.id()
+        );
     }
 
     CodeGenerationResults {
         module_render_ids,
-        module_identities,
         results,
-    }
-}
-
-fn code_generation_etag(input: &CodeGenerationInput<'_>) -> CacheETag {
-    let mut hasher = StableHasher::default();
-    hasher.write(b"unpack/code-generation/dependency-templates/1");
-    input.module.source_hash().hash(&mut hasher);
-    input
-        .module
-        .build_error()
-        .map(ToString::to_string)
-        .hash(&mut hasher);
-    input.module.presentational_dependencies().hash(&mut hasher);
-    input.module.dependencies().hash(&mut hasher);
-    input.module.blocks().hash(&mut hasher);
-    input
-        .module
-        .exports_info()
-        .provided_exports()
-        .collect::<Vec<_>>()
-        .hash(&mut hasher);
-    input.module_render_ids[&input.module.id()].hash(&mut hasher);
-
-    for (dependency_id, dependency) in input.module.dependencies().iter().enumerate() {
-        hash_dependency_template_connection(input, dependency, None, dependency_id, &mut hasher);
-    }
-    for (block_index, block) in input.module.blocks().iter().enumerate() {
-        for (dependency_id, dependency) in block.dependencies().iter().enumerate() {
-            hash_dependency_template_connection(
-                input,
-                dependency,
-                Some(block_index),
-                dependency_id,
-                &mut hasher,
-            );
-        }
-    }
-    CacheETag::new(hasher.finish().to_le_bytes())
-}
-
-fn hash_dependency_template_connection(
-    input: &CodeGenerationInput<'_>,
-    dependency: &Dependency,
-    block_index: Option<usize>,
-    dependency_id: usize,
-    hasher: &mut StableHasher,
-) {
-    let target =
-        input
-            .module_graph
-            .module_for_dependency(input.module.id(), block_index, dependency_id);
-    match dependency {
-        Dependency::HarmonyImportSideEffect(_) => target
-            .and_then(|target| input.module_render_ids.get(&target))
-            .hash(hasher),
-        Dependency::HarmonyImportSpecifier(_) | Dependency::HarmonyExportImportedSpecifier(_) => {
-            target.is_some().hash(hasher)
-        }
-        Dependency::Import(_) => {
-            target
-                .and_then(|target| input.module_render_ids.get(&target))
-                .hash(hasher);
-            let chunk_render_id = block_index
-                .and_then(|block_index| {
-                    input.chunk_graph.block_chunk_group(AsyncBlockOrigin {
-                        module: input.module.id(),
-                        block_index,
-                    })
-                })
-                .and_then(|group_id| {
-                    input.chunk_graph.chunk_groups()[group_id.index()]
-                        .chunks()
-                        .first()
-                        .copied()
-                })
-                .and_then(|chunk_id| input.chunk_graph.chunk(chunk_id))
-                .map(Chunk::render_id);
-            chunk_render_id.hash(hasher);
-        }
-        Dependency::Entry(_)
-        | Dependency::HarmonyExportHeader(_)
-        | Dependency::HarmonyExportSpecifier(_)
-        | Dependency::HarmonyExportExpression(_)
-        | Dependency::Null(_)
-        | Dependency::Const(_) => {}
     }
 }
 
@@ -378,22 +205,29 @@ pub(crate) fn create_render_manifest(
 
     for (entry_index, group_id) in chunk_graph.entrypoints().iter().copied().enumerate() {
         let group = &chunk_graph.chunk_groups()[group_id.index()];
-        let Some(chunk_id) = group.chunks().first().copied() else {
-            continue;
-        };
-        let Some(chunk) = chunk_graph.chunk(chunk_id) else {
-            continue;
-        };
-        let Some(entry_module) = entries.get(entry_index).copied() else {
-            continue;
-        };
+        let chunk_id = group
+            .chunks()
+            .first()
+            .copied()
+            .expect("Entrypoint must contain a Chunk before manifest creation");
+        let chunk = chunk_graph
+            .chunk(chunk_id)
+            .expect("Entrypoint Chunk must exist before manifest creation");
+        let entry_module = entries
+            .get(entry_index)
+            .copied()
+            .expect("Entrypoint must have an Entry Module before manifest creation");
         let modules = module_render_manifest(chunk_graph, chunk, code_generation_results);
         manifest_entries.push(RenderManifestEntry {
             filename: resolve_chunk_filename(chunk),
             render: AssetRenderManifest::InitialChunk {
                 modules,
                 chunk_filename_map: render_chunk_filename_map(chunk_graph),
-                entry_id: code_generation_results.module_render_ids[&entry_module].clone(),
+                entry_id: code_generation_results
+                    .module_render_ids
+                    .get(&entry_module)
+                    .expect("Entry Module must have a Render ID before manifest creation")
+                    .clone(),
                 chunk_id: chunk.render_id().clone(),
             },
         });
@@ -504,17 +338,18 @@ fn hash_module_render_inputs(
     modules.len().hash(hasher);
     for module in modules {
         module.render_id.hash(hasher);
-        module.code_generation_key.hash(hasher);
-        match code_generation_results
+        module.module.hash(hasher);
+        let result = code_generation_results
             .results
-            .get(&module.code_generation_key)
-        {
-            Some(result) => {
-                true.hash(hasher);
-                result.source().hash(hasher);
-            }
-            None => false.hash(hasher),
-        }
+            .get(&module.module)
+            .expect("manifest Module must have a Code Generation Result");
+        result.source().hash(hasher);
+        result
+            .runtime_requirements()
+            .iter()
+            .for_each(|requirement| {
+                requirement.hash(hasher);
+            });
     }
 }
 
@@ -523,20 +358,24 @@ fn module_render_manifest(
     chunk: &Chunk,
     code_generation_results: &CodeGenerationResults,
 ) -> Vec<ModuleRenderManifest> {
-    let runtime = RuntimeSpec::for_chunk(chunk_graph, chunk);
     let mut modules = chunk_graph
         .chunk_modules(chunk.id())
         .iter()
-        .filter_map(|module_id| {
-            let code_generation_key =
-                code_generation_results.key_for(*module_id, runtime.clone())?;
-            code_generation_results
-                .results
-                .contains_key(&code_generation_key)
-                .then(|| ModuleRenderManifest {
-                    render_id: code_generation_results.module_render_ids[module_id].clone(),
-                    code_generation_key,
-                })
+        .map(|module_id| {
+            assert!(
+                code_generation_results.results.contains_key(module_id),
+                "module {module_id:?} must have a Code Generation Result before rendering"
+            );
+            ModuleRenderManifest {
+                module: *module_id,
+                render_id: code_generation_results
+                    .module_render_ids
+                    .get(module_id)
+                    .unwrap_or_else(|| {
+                        panic!("module {module_id:?} must have a Render ID before rendering")
+                    })
+                    .clone(),
+            }
         })
         .collect::<Vec<_>>();
     modules.sort_by(|left, right| left.render_id.cmp(&right.render_id));
@@ -714,22 +553,34 @@ fn render_module_table(
     let mut source = ConcatSource::default();
     let mut first = true;
     for module in modules {
-        let Some(result) = code_generation_results
+        let result = code_generation_results
             .results
-            .get(&module.code_generation_key)
-        else {
-            continue;
-        };
+            .get(&module.module)
+            .unwrap_or_else(|| {
+                panic!(
+                    "module {:?} must have a Code Generation Result before rendering",
+                    module.module
+                )
+            });
         if first {
             first = false;
         } else {
             source.add(RawStringSource::from(",\n".to_string()));
         }
         source.add(RawStringSource::from(format!(
-            "{}: ",
-            json_render_id(&module.render_id)
+            "{}: ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {{\n\"use strict\";\n{}",
+            json_render_id(&module.render_id),
+            if result
+                .runtime_requirements()
+                .contains(RuntimeRequirement::MakeNamespaceObject)
+            {
+                "__webpack_require__.r(__webpack_exports__);\n"
+            } else {
+                ""
+            }
         )));
         source.add(result.source().clone());
+        source.add(RawStringSource::from("\n})".to_string()));
     }
     source
 }
@@ -743,7 +594,7 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
     } = input;
     if let Some(error) = module.build_error() {
         return CodeGenerationResult::new(CodeGenerationSource::Raw {
-            source: render_failed_module_factory(error),
+            source: render_failed_module_content(error),
         });
     }
 
@@ -755,6 +606,8 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
         module_render_name.as_str(),
     ));
     let mut init_fragments = Vec::new();
+    let mut runtime_requirements = RuntimeRequirements::default();
+    runtime_requirements.insert(RuntimeRequirement::MakeNamespaceObject);
 
     for dependency in module.presentational_dependencies() {
         apply_dependency_template(
@@ -766,6 +619,7 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
             chunk_graph,
             module.exports_info(),
             module_render_ids,
+            &mut runtime_requirements,
             &mut source,
             &mut init_fragments,
         );
@@ -780,6 +634,7 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
             chunk_graph,
             module.exports_info(),
             module_render_ids,
+            &mut runtime_requirements,
             &mut source,
             &mut init_fragments,
         );
@@ -795,6 +650,7 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
                 chunk_graph,
                 module.exports_info(),
                 module_render_ids,
+                &mut runtime_requirements,
                 &mut source,
                 &mut init_fragments,
             );
@@ -803,9 +659,7 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
 
     let init = render_init_fragments(init_fragments);
     CodeGenerationResult::new(CodeGenerationSource::OriginalWithReplacements {
-        prefix: format!(
-            "((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {{\n\"use strict\";\n__webpack_require__.r(__webpack_exports__);\n{init}"
-        ),
+        prefix: init,
         original_source: module.source().to_string(),
         original_name: module_render_name,
         replacements: source
@@ -813,15 +667,13 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
             .iter()
             .map(CodeGenerationReplacement::from)
             .collect(),
-        suffix: "\n})".to_string(),
+        suffix: String::new(),
     })
+    .with_runtime_requirements(runtime_requirements)
 }
 
-fn render_failed_module_factory(error: &Error) -> String {
-    format!(
-        "((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {{\n\"use strict\";\nthrow new Error({});\n}})",
-        json_string(&error.to_string())
-    )
+fn render_failed_module_content(error: &Error) -> String {
+    format!("throw new Error({});", json_string(&error.to_string()))
 }
 
 fn render_init_fragments(mut fragments: Vec<InitFragment>) -> String {
@@ -854,6 +706,7 @@ fn apply_dependency_template(
     chunk_graph: &ChunkGraph,
     exports_info: &ExportsInfo,
     module_render_ids: &HashMap<ModuleId, RenderId>,
+    runtime_requirements: &mut RuntimeRequirements,
     source: &mut ReplaceSource,
     init_fragments: &mut Vec<InitFragment>,
 ) {
@@ -861,14 +714,17 @@ fn apply_dependency_template(
         Dependency::Const(dep) => apply_const_dependency(dep, source),
         Dependency::Null(_) => {}
         Dependency::HarmonyExportHeader(dep) => apply_export_header_dependency(dep, source),
-        Dependency::HarmonyImportSideEffect(dep) => apply_harmony_import_side_effect_dependency(
-            dep,
-            module_id,
-            dependency_id,
-            module_graph,
-            module_render_ids,
-            init_fragments,
-        ),
+        Dependency::HarmonyImportSideEffect(dep) => {
+            runtime_requirements.insert(RuntimeRequirement::Require);
+            apply_harmony_import_side_effect_dependency(
+                dep,
+                module_id,
+                dependency_id,
+                module_graph,
+                module_render_ids,
+                init_fragments,
+            )
+        }
         Dependency::HarmonyImportSpecifier(dep) => apply_harmony_import_specifier_dependency(
             dep,
             module_id,
@@ -878,12 +734,15 @@ fn apply_dependency_template(
             source,
         ),
         Dependency::HarmonyExportSpecifier(dep) => {
+            runtime_requirements.insert(RuntimeRequirement::DefinePropertyGetters);
             apply_harmony_export_specifier_dependency(dep, exports_info, init_fragments)
         }
         Dependency::HarmonyExportExpression(dep) => {
+            runtime_requirements.insert(RuntimeRequirement::DefinePropertyGetters);
             apply_harmony_export_expression_dependency(dep, exports_info, source, init_fragments)
         }
         Dependency::HarmonyExportImportedSpecifier(dep) => {
+            runtime_requirements.insert(RuntimeRequirement::DefinePropertyGetters);
             apply_harmony_export_imported_specifier_dependency(
                 dep,
                 module_id,
@@ -894,16 +753,20 @@ fn apply_dependency_template(
                 init_fragments,
             )
         }
-        Dependency::Import(dep) => apply_import_dependency(
-            dep,
-            module_id,
-            origin_block,
-            dependency_id,
-            module_graph,
-            chunk_graph,
-            module_render_ids,
-            source,
-        ),
+        Dependency::Import(dep) => {
+            runtime_requirements.insert(RuntimeRequirement::EnsureChunk);
+            runtime_requirements.insert(RuntimeRequirement::Require);
+            apply_import_dependency(
+                dep,
+                module_id,
+                origin_block,
+                dependency_id,
+                module_graph,
+                chunk_graph,
+                module_render_ids,
+                source,
+            )
+        }
         Dependency::Entry(_) => {}
     }
 }
@@ -932,12 +795,10 @@ fn apply_harmony_import_side_effect_dependency(
     module_render_ids: &HashMap<ModuleId, RenderId>,
     init_fragments: &mut Vec<InitFragment>,
 ) {
-    let Some(dependency_id) = dependency_id else {
-        return;
-    };
-    let Some(target) = module_graph.module_for_dependency(module_id, None, dependency_id) else {
-        return;
-    };
+    let dependency_id = dependency_id.expect("Harmony import must have a Dependency ID");
+    let target = module_graph
+        .module_for_dependency(module_id, None, dependency_id)
+        .expect("Harmony import must have a Module Graph connection");
     let import_var = import_var(&dep.module.request, dep.module.source_order.unwrap_or(0));
     let target_id = json_render_id(&module_render_ids[&target]);
     push_init_fragment(
@@ -955,12 +816,10 @@ fn apply_harmony_import_specifier_dependency(
     module_render_ids: &HashMap<ModuleId, RenderId>,
     source: &mut ReplaceSource,
 ) {
-    let Some(dependency_id) = dependency_id else {
-        return;
-    };
-    let Some(_target) = module_graph.module_for_dependency(module_id, None, dependency_id) else {
-        return;
-    };
+    let dependency_id = dependency_id.expect("Harmony import specifier must have a Dependency ID");
+    module_graph
+        .module_for_dependency(module_id, None, dependency_id)
+        .expect("Harmony import specifier must have a Module Graph connection");
     let expression = import_expression(
         &dep.module.request,
         dep.module.source_order.unwrap_or(0),
@@ -1035,12 +894,10 @@ fn apply_harmony_export_imported_specifier_dependency(
     module_render_ids: &HashMap<ModuleId, RenderId>,
     init_fragments: &mut Vec<InitFragment>,
 ) {
-    let Some(dependency_id) = dependency_id else {
-        return;
-    };
-    let Some(_target) = module_graph.module_for_dependency(module_id, None, dependency_id) else {
-        return;
-    };
+    let dependency_id = dependency_id.expect("Harmony re-export must have a Dependency ID");
+    module_graph
+        .module_for_dependency(module_id, None, dependency_id)
+        .expect("Harmony re-export must have a Module Graph connection");
     let import_var = import_var(&dep.module.request, dep.module.source_order.unwrap_or(0));
     if dep.is_star {
         push_init_fragment(
@@ -1075,17 +932,11 @@ fn apply_import_dependency(
     module_render_ids: &HashMap<ModuleId, RenderId>,
     source: &mut ReplaceSource,
 ) {
-    let Some(block_index) = origin_block else {
-        return;
-    };
-    let Some(dependency_id) = dependency_id else {
-        return;
-    };
-    let Some(target) =
-        module_graph.module_for_dependency(module_id, Some(block_index), dependency_id)
-    else {
-        return;
-    };
+    let block_index = origin_block.expect("Dynamic import must belong to an Async Block");
+    let dependency_id = dependency_id.expect("Dynamic import must have a Dependency ID");
+    let target = module_graph
+        .module_for_dependency(module_id, Some(block_index), dependency_id)
+        .expect("Dynamic import must have a Module Graph connection");
     let target_id = json_render_id(&module_render_ids[&target]);
     let origin = AsyncBlockOrigin {
         module: module_id,
@@ -1096,9 +947,12 @@ fn apply_import_dependency(
         let chunk_id = group
             .chunks()
             .first()
-            .and_then(|chunk_id| chunk_graph.chunk(*chunk_id))
-            .map(|chunk| json_render_id(chunk.render_id()))
-            .unwrap_or_else(|| "\"\"".to_string());
+            .copied()
+            .expect("Async Chunk Group must contain a Chunk");
+        let chunk = chunk_graph
+            .chunk(chunk_id)
+            .expect("Async Chunk must exist before Dynamic Import generation");
+        let chunk_id = json_render_id(chunk.render_id());
         format!(
             "__webpack_require__.e({chunk_id}).then(__webpack_require__.bind(__webpack_require__, {target_id}))"
         )
@@ -1215,95 +1069,21 @@ fn json_render_id(render_id: &RenderId) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::{BTreeSet, HashMap},
-        fs,
-    };
+    use std::fs;
 
-    use rspack_sources::{ConcatSource, OriginalSource};
+    use rspack_sources::{ConcatSource, OriginalSource, Source};
 
     use crate::{
-        CacheOptions, ChunkGraph, ChunkGroupKind, Compiler, CompilerOptions, ConstDependency,
-        Dependency, Entry, ModuleGraph, ModuleIdentity, SnapshotOptions, SourceRange,
+        CacheOptions, Compiler, CompilerOptions, Entry, ModuleId, SnapshotOptions,
         build_cache::{BuildCache, CacheIdentifier, CacheKey, CacheNamespace},
         id_assignment::RenderId,
     };
 
     use super::{
-        AssetRenderKey, AssetRenderKind, AssetRenderManifest, CodeGenerationInput,
-        CodeGenerationKey, CodeGenerationResult, CodeGenerationResults, CodeGenerationSource,
-        ModuleRenderManifest, RenderedSource, RuntimeSpec, code_generation_etag, emit_asset,
+        AssetRenderKey, AssetRenderKind, AssetRenderManifest, CodeGenerationResult,
+        CodeGenerationResults, CodeGenerationSource, ModuleRenderManifest, RenderedSource,
+        RuntimeRequirement, emit_asset,
     };
-
-    #[test]
-    fn code_generation_facade_partitions_module_runtime_identity() {
-        let build_cache = BuildCache::new(CacheOptions::memory(), SnapshotOptions::default());
-        let facade = build_cache.code_generations::<CodeGenerationKey>();
-        assert_eq!(
-            facade.namespace(),
-            CacheNamespace::new("unpack/code-generation")
-        );
-
-        let module = ModuleIdentity::new("/project/src/shared.js");
-        let main = CodeGenerationKey::new(
-            module.clone(),
-            RuntimeSpec(BTreeSet::from(["main".to_string()])),
-        );
-        let same = CodeGenerationKey::new(
-            module.clone(),
-            RuntimeSpec(BTreeSet::from(["main".to_string()])),
-        );
-        let admin =
-            CodeGenerationKey::new(module, RuntimeSpec(BTreeSet::from(["admin".to_string()])));
-        let other_module = CodeGenerationKey::new(
-            ModuleIdentity::new("/project/src/other.js"),
-            RuntimeSpec(BTreeSet::from(["main".to_string()])),
-        );
-
-        assert_eq!(main.cache_identifier(), same.cache_identifier());
-        assert_ne!(main.cache_identifier(), admin.cache_identifier());
-        assert_ne!(main.cache_identifier(), other_module.cache_identifier());
-    }
-
-    #[test]
-    fn code_generation_etag_covers_module_hash_and_dependency_template_inputs() {
-        let baseline = code_generation_etag_fixture(41, "replacement");
-        assert_eq!(baseline, code_generation_etag_fixture(41, "replacement"));
-        assert_ne!(baseline, code_generation_etag_fixture(42, "replacement"));
-        assert_ne!(baseline, code_generation_etag_fixture(41, "other"));
-    }
-
-    fn code_generation_etag_fixture(
-        source_hash: u64,
-        expression: &str,
-    ) -> crate::build_cache::CacheETag {
-        let identity = ModuleIdentity::new("/project/src/index.js");
-        let mut module_graph = ModuleGraph::default();
-        let module_id = module_graph.add_module(identity);
-        module_graph
-            .module_mut(module_id)
-            .expect("fixture module should exist")
-            .finish_build(
-                Vec::new(),
-                Vec::new(),
-                vec![Dependency::Const(ConstDependency::new(
-                    expression,
-                    SourceRange::new(0, 5),
-                ))],
-                "value".to_string(),
-                source_hash,
-            );
-        let module_render_ids =
-            HashMap::from([(module_id, RenderId::String("./src/index.js".to_string()))]);
-        code_generation_etag(&CodeGenerationInput {
-            module: module_graph
-                .module(module_id)
-                .expect("fixture module should exist"),
-            module_graph: &module_graph,
-            chunk_graph: &ChunkGraph::default(),
-            module_render_ids: &module_render_ids,
-        })
-    }
 
     #[test]
     fn asset_render_facade_uses_stable_namespace_and_manifest_identity() {
@@ -1331,13 +1111,10 @@ mod tests {
 
     #[test]
     fn exact_render_hash_covers_generated_source_and_manifest_inputs() {
-        let code_generation_key = CodeGenerationKey::new(
-            ModuleIdentity::new("/project/src/feature.js"),
-            RuntimeSpec(BTreeSet::from(["main".to_string()])),
-        );
+        let module_id = ModuleId::new(0);
         let module = ModuleRenderManifest {
+            module: module_id,
             render_id: RenderId::String("./src/feature.js".to_string()),
-            code_generation_key: code_generation_key.clone(),
         };
         let render = AssetRenderManifest::AsyncChunk {
             modules: vec![module],
@@ -1345,16 +1122,29 @@ mod tests {
         };
         let mut results = CodeGenerationResults::default();
         results.results.insert(
-            code_generation_key.clone(),
+            module_id,
             code_generation_result("export const value = 'before';"),
         );
         let before = render.cache_etag(&results);
 
         results.results.insert(
-            code_generation_key,
+            module_id,
             code_generation_result("export const value = 'after';"),
         );
         assert_ne!(before, render.cache_etag(&results));
+
+        let without_requirement = render.cache_etag(&results);
+        results.results.insert(
+            module_id,
+            code_generation_result("export const value = 'after';").with_runtime_requirements(
+                super::RuntimeRequirements {
+                    requirements: std::collections::BTreeSet::from([
+                        RuntimeRequirement::MakeNamespaceObject,
+                    ]),
+                },
+            ),
+        );
+        assert_ne!(without_requirement, render.cache_etag(&results));
 
         let initial = AssetRenderManifest::InitialChunk {
             modules: Vec::new(),
@@ -1381,41 +1171,61 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn shared_async_chunk_runtime_spec_contains_each_parent_entrypoint()
+    async fn code_generation_is_module_only_and_leaves_factory_wrapping_to_renderer()
     -> Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
         fs::write(
             temp.path().join("a.js"),
-            "export const load = () => import('./feature');",
+            "import { shared } from './shared'; export const a = shared;",
         )?;
         fs::write(
             temp.path().join("b.js"),
-            "export const load = () => import('./feature');",
+            "import { shared } from './shared'; export const b = shared;",
         )?;
-        fs::write(temp.path().join("feature.js"), "export const value = 42;")?;
+        fs::write(temp.path().join("shared.js"), "export const shared = 42;")?;
         let compilation = Compiler::new(CompilerOptions::new(
             temp.path(),
             vec![Entry::new("a", "./a"), Entry::new("b", "./b")],
         ))
         .run()
         .await?;
-        let chunk = compilation
-            .chunk_graph()
-            .chunks()
-            .iter()
-            .find(|chunk| {
-                chunk.groups().iter().any(|group| {
-                    matches!(
-                        compilation.chunk_graph().chunk_groups()[group.index()].kind(),
-                        ChunkGroupKind::Async
-                    )
-                })
-            })
-            .expect("shared async chunk should exist");
+        let mut generation_count = 0;
+        let results = super::generate_code_with(
+            compilation.module_graph(),
+            compilation.chunk_graph(),
+            |input| {
+                generation_count += 1;
+                super::generate_module_code(input)
+            },
+        );
 
-        let runtime = RuntimeSpec::for_chunk(compilation.chunk_graph(), chunk);
-
-        assert_eq!(runtime.names().collect::<Vec<_>>(), ["a", "b"]);
+        assert_eq!(generation_count, compilation.module_graph().modules().len());
+        assert_eq!(
+            results.results.len(),
+            compilation.module_graph().modules().len()
+        );
+        assert!(results.results.values().all(|result| {
+            !result
+                .source()
+                .source()
+                .into_string_lossy()
+                .contains("__unused_webpack_module")
+        }));
+        assert!(results.results.values().all(|result| {
+            result
+                .runtime_requirements()
+                .contains(RuntimeRequirement::MakeNamespaceObject)
+        }));
+        assert!(results.results.values().all(|result| {
+            result
+                .runtime_requirements()
+                .contains(RuntimeRequirement::DefinePropertyGetters)
+        }));
+        assert!(results.results.values().any(|result| {
+            result
+                .runtime_requirements()
+                .contains(RuntimeRequirement::Require)
+        }));
 
         Ok(())
     }

--- a/crates/unpack_core/src/code_generation_record.rs
+++ b/crates/unpack_core/src/code_generation_record.rs
@@ -2,30 +2,36 @@ use rspack_sources::{
     ConcatSource, OriginalSource, RawStringSource, ReplaceSource, Replacement, ReplacementEnforce,
 };
 
+use crate::code_generation::RuntimeRequirements;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CodeGenerationResult {
     source: ConcatSource,
-    record_source: CodeGenerationSource,
+    runtime_requirements: RuntimeRequirements,
 }
 
 impl CodeGenerationResult {
     pub(crate) fn new(record_source: CodeGenerationSource) -> Self {
         Self {
             source: record_source.render(),
-            record_source,
+            runtime_requirements: RuntimeRequirements::default(),
         }
-    }
-
-    pub(crate) fn record_source(&self) -> &CodeGenerationSource {
-        &self.record_source
     }
 
     pub(crate) fn source(&self) -> &ConcatSource {
         &self.source
     }
 
-    pub(crate) fn from_record_source(record_source: CodeGenerationSource) -> Self {
-        Self::new(record_source)
+    pub(crate) fn runtime_requirements(&self) -> &RuntimeRequirements {
+        &self.runtime_requirements
+    }
+
+    pub(crate) fn with_runtime_requirements(
+        mut self,
+        runtime_requirements: RuntimeRequirements,
+    ) -> Self {
+        self.runtime_requirements = runtime_requirements;
+        self
     }
 }
 

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -165,6 +165,13 @@ impl Compilation {
         self.render_ids_assigned = true;
     }
 
+    pub fn seal(&mut self) {
+        self.build_chunk_graph();
+        self.assign_render_ids();
+        self.code_generation();
+        self.create_assets();
+    }
+
     fn assign_module_ids(&mut self) {
         assign_module_render_ids(&self.options, &self.module_graph, &mut self.chunk_graph);
     }
@@ -191,9 +198,6 @@ impl Compilation {
     }
 
     pub fn create_asset_render_manifest(&mut self) {
-        if self.code_generation_results.is_none() {
-            self.code_generation();
-        }
         self.asset_render_manifest = Some(code_generation::create_render_manifest(
             &self.chunk_graph,
             &self.entries,
@@ -204,9 +208,6 @@ impl Compilation {
     }
 
     pub fn render_assets(&mut self) {
-        if self.asset_render_manifest.is_none() {
-            self.create_asset_render_manifest();
-        }
         self.assets = code_generation::render_assets(
             &self.options,
             &self.build_cache,
@@ -222,12 +223,11 @@ impl Compilation {
     pub fn code_generation(&mut self) {
         let span = tracing::trace_span!("Compilation::code_generation");
         let _enter = span.enter();
-        if !self.render_ids_assigned {
-            self.assign_render_ids();
-        }
+        assert!(
+            self.render_ids_assigned,
+            "Render IDs must be assigned before code generation"
+        );
         self.code_generation_results = Some(code_generation::generate_code(
-            &self.options,
-            &self.build_cache,
             &self.module_graph,
             &self.chunk_graph,
         ));

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -1142,6 +1142,7 @@ mod tests {
 
         assert_eq!(settling.await?.diagnostic(), None);
         assert_eq!(running.await??.errors(), []);
+        assert_eq!(compiler.settle_cache().await.diagnostic(), None);
         let registry = CodecRegistry::new()
             .with_resolve_record(ResolveRecordCodec::current())
             .with_module_build_record(ModuleBuildRecordCodec::current());

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -675,10 +675,7 @@ impl Compiler {
         let result = async {
             let mut compilation = self.create_compilation();
             compilation.make().await?;
-            compilation.build_chunk_graph();
-            compilation.assign_render_ids();
-            compilation.code_generation();
-            compilation.create_assets();
+            compilation.seal();
             Ok(compilation)
         }
         .instrument(tracing::trace_span!("Compiler::run"))

--- a/crates/unpack_core/src/id_assignment.rs
+++ b/crates/unpack_core/src/id_assignment.rs
@@ -364,7 +364,7 @@ mod tests {
         assign_chunk_render_ids(&options, &module_graph, &mut chunk_graph);
 
         let build_cache = BuildCache::new(CacheOptions::memory(), SnapshotOptions::default());
-        let results = generate_code(&options, &build_cache, &module_graph, &chunk_graph);
+        let results = generate_code(&module_graph, &chunk_graph);
         let manifest = create_render_manifest(&chunk_graph, &[module], &results);
         let assets = render_assets(&options, &build_cache, &manifest, &results);
         let main = assets
@@ -405,7 +405,7 @@ mod tests {
         assign_chunk_render_ids(&options, &module_graph, &mut chunk_graph);
 
         let build_cache = BuildCache::new(CacheOptions::memory(), SnapshotOptions::default());
-        let results = generate_code(&options, &build_cache, &module_graph, &chunk_graph);
+        let results = generate_code(&module_graph, &chunk_graph);
         let manifest = create_render_manifest(&chunk_graph, &entries, &results);
         render_assets(&options, &build_cache, &manifest, &results)
     }

--- a/crates/unpack_core/src/pack_file.rs
+++ b/crates/unpack_core/src/pack_file.rs
@@ -1234,25 +1234,23 @@ mod tests {
         let module_record = ModuleBuildRecord::try_from(module_dto.clone())?;
         assert_eq!(ModuleBuildRecordDto::try_from(&module_record)?, module_dto);
 
-        let code_generation_record = CodeGenerationResult::from_record_source(
-            CodeGenerationSource::OriginalWithReplacements {
-                prefix: "prefix".to_string(),
-                original_source: "before".to_string(),
-                original_name: "./fixture.js".to_string(),
-                replacements: vec![CodeGenerationReplacement {
-                    start: 0,
-                    end: 6,
-                    content: "after".to_string(),
-                    name: None,
-                    enforce: ReplacementEnforce::Normal,
-                }],
-                suffix: "suffix".to_string(),
-            },
-        );
-        let code_generation_dto = CodeGenerationRecordDto::from(&code_generation_record);
+        let code_generation_source = CodeGenerationSource::OriginalWithReplacements {
+            prefix: "prefix".to_string(),
+            original_source: "before".to_string(),
+            original_name: "./fixture.js".to_string(),
+            replacements: vec![CodeGenerationReplacement {
+                start: 0,
+                end: 6,
+                content: "after".to_string(),
+                name: None,
+                enforce: ReplacementEnforce::Normal,
+            }],
+            suffix: "suffix".to_string(),
+        };
+        let code_generation_dto = CodeGenerationRecordDto::from(&code_generation_source);
         assert_eq!(
-            CodeGenerationResult::try_from(code_generation_dto)?,
-            code_generation_record
+            CodeGenerationSource::try_from(code_generation_dto)?,
+            code_generation_source
         );
         Ok(())
     }
@@ -1742,9 +1740,13 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use rspack_sources::ReplacementEnforce;
 use brotli::{CompressorWriter, Decompressor};
 use flate2::{Compression as GzipLevel, read::GzDecoder, write::GzEncoder};
+#[cfg(test)]
+use rspack_sources::ReplacementEnforce;
+
+#[cfg(test)]
+use crate::code_generation_record::{CodeGenerationReplacement, CodeGenerationSource};
 
 use crate::{
     AsyncDependenciesBlock, ConstDependency, Dependency, EntryDependency,
@@ -1754,9 +1756,6 @@ use crate::{
     ModuleDependency, ModuleIdentity, ModuleType, NullDependency, SourceRange,
     build_cache::{ModuleBuildRecord, ResolveRecord},
     cache_hash::stable_hash,
-    code_generation_record::{
-        CodeGenerationReplacement, CodeGenerationResult, CodeGenerationSource,
-    },
     parser::ParsedModule,
     rendered_source::RenderedSource,
     snapshot::{PersistentManagedItemState, PersistentSnapshotEntry, Snapshot},
@@ -1790,11 +1789,13 @@ const BROTLI_WINDOW_BITS: u32 = 22;
 const GZIP_LEVEL: u32 = 6;
 const RESOLVE_RECORD_CODEC_ID: StableCodecId = StableCodecId::new(*b"unpack.rslv.c001");
 const MODULE_BUILD_RECORD_CODEC_ID: StableCodecId = StableCodecId::new(*b"unpack.modb.c001");
+#[cfg(test)]
 const CODE_GENERATION_RECORD_CODEC_ID: StableCodecId = StableCodecId::new(*b"unpack.cgen.c001");
 const ASSET_RENDER_RECORD_CODEC_ID: StableCodecId = StableCodecId::new(*b"unpack.astr.c001");
 pub(crate) const RESOLVE_RECORD_TYPE_ID: StableTypeId = StableTypeId::new(*b"unpack.resolve.1");
 pub(crate) const MODULE_BUILD_RECORD_TYPE_ID: StableTypeId =
     StableTypeId::new(*b"unpack.moduleb.1");
+#[cfg(test)]
 pub(crate) const CODE_GENERATION_RECORD_TYPE_ID: StableTypeId =
     StableTypeId::new(*b"unpack.codegen.1");
 pub(crate) const ASSET_RENDER_RECORD_TYPE_ID: StableTypeId =
@@ -2073,11 +2074,13 @@ pub(crate) struct AssetRenderRecordDto {
     pub(crate) source_map: Option<String>,
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CodeGenerationRecordDto {
     pub(crate) source: CodeGenerationSourceDto,
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CodeGenerationSourceDto {
     Raw {
@@ -2092,6 +2095,7 @@ pub(crate) enum CodeGenerationSourceDto {
     },
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CodeGenerationReplacementDto {
     pub(crate) start: u32,
@@ -2101,6 +2105,7 @@ pub(crate) struct CodeGenerationReplacementDto {
     pub(crate) enforce: ReplacementEnforceDto,
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ReplacementEnforceDto {
     Pre,
@@ -2491,9 +2496,10 @@ impl TryFrom<ModuleBuildRecordDto> for ModuleBuildRecord {
     }
 }
 
-impl From<&CodeGenerationResult> for CodeGenerationRecordDto {
-    fn from(record: &CodeGenerationResult) -> Self {
-        let source = match record.record_source() {
+#[cfg(test)]
+impl From<&CodeGenerationSource> for CodeGenerationRecordDto {
+    fn from(record: &CodeGenerationSource) -> Self {
+        let source = match record {
             CodeGenerationSource::Raw { source } => CodeGenerationSourceDto::Raw {
                 source: source.clone(),
             },
@@ -2528,7 +2534,8 @@ impl From<&CodeGenerationResult> for CodeGenerationRecordDto {
     }
 }
 
-impl TryFrom<CodeGenerationRecordDto> for CodeGenerationResult {
+#[cfg(test)]
+impl TryFrom<CodeGenerationRecordDto> for CodeGenerationSource {
     type Error = io::Error;
 
     fn try_from(record: CodeGenerationRecordDto) -> io::Result<Self> {
@@ -2562,7 +2569,7 @@ impl TryFrom<CodeGenerationRecordDto> for CodeGenerationResult {
                 suffix,
             },
         };
-        Ok(CodeGenerationResult::from_record_source(source))
+        Ok(source)
     }
 }
 
@@ -2955,6 +2962,7 @@ impl PackFileItem for ModuleBuildRecordDto {
     const TYPE_ID: StableTypeId = MODULE_BUILD_RECORD_TYPE_ID;
 }
 
+#[cfg(test)]
 impl PackFileItem for CodeGenerationRecordDto {
     const TYPE_ID: StableTypeId = CODE_GENERATION_RECORD_TYPE_ID;
 }
@@ -3032,6 +3040,7 @@ impl CodecRegistry {
         self
     }
 
+    #[cfg(test)]
     pub(crate) fn with_code_generation_record(mut self, codec: CodeGenerationRecordCodec) -> Self {
         self.register::<CodeGenerationRecordDto, _>(codec);
         self
@@ -3159,11 +3168,13 @@ impl ItemCodec<ModuleBuildRecordDto> for ModuleBuildRecordCodec {
     }
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct CodeGenerationRecordCodec {
     codec_id: StableCodecId,
 }
 
+#[cfg(test)]
 impl CodeGenerationRecordCodec {
     pub(crate) const fn current() -> Self {
         Self {
@@ -3172,6 +3183,7 @@ impl CodeGenerationRecordCodec {
     }
 }
 
+#[cfg(test)]
 impl ItemCodec<CodeGenerationRecordDto> for CodeGenerationRecordCodec {
     fn codec_id(&self) -> StableCodecId {
         self.codec_id
@@ -3257,6 +3269,7 @@ impl ItemCodec<CodeGenerationRecordDto> for CodeGenerationRecordCodec {
     }
 }
 
+#[cfg(test)]
 fn validate_code_generation_record(record: &CodeGenerationRecordDto) -> io::Result<()> {
     let CodeGenerationSourceDto::OriginalWithReplacements {
         original_source,

--- a/crates/unpack_core/tests/codegen.rs
+++ b/crates/unpack_core/tests/codegen.rs
@@ -7,16 +7,9 @@ use std::{
 use unpack_core::{ChunkGroupKind, Compiler, CompilerOptions, Entry};
 
 #[tokio::test]
-async fn separates_module_code_generation_from_asset_rendering()
--> Result<(), Box<dyn std::error::Error>> {
+async fn seal_orchestrates_post_make_phases() -> Result<(), Box<dyn std::error::Error>> {
     let temp = tempfile::tempdir()?;
-    write(
-        temp.path().join("src/index.js"),
-        r#"
-            export const value = 42;
-        "#,
-    )?;
-
+    write(temp.path().join("src/index.js"), "export const value = 42;")?;
     let compiler = Compiler::new(CompilerOptions::new(
         temp.path(),
         vec![Entry::new("main", "./src/index")],
@@ -24,74 +17,36 @@ async fn separates_module_code_generation_from_asset_rendering()
     let mut compilation = compiler.create_compilation();
 
     compilation.make().await?;
-    compilation.build_chunk_graph();
-    compilation.code_generation();
+    assert!(compilation.assets().is_empty());
 
-    assert_eq!(compilation.assets(), []);
-
-    compilation.create_assets();
+    compilation.seal();
 
     assert_eq!(compilation.errors(), []);
-    assert_eq!(
+    assert!(
         compilation
             .assets()
             .iter()
-            .map(|asset| asset.filename.as_str())
-            .collect::<Vec<_>>(),
-        ["main.js", "main.js.map"]
+            .any(|asset| asset.filename == "main.js")
     );
 
     Ok(())
 }
 
 #[tokio::test]
-async fn builds_a_render_manifest_before_creating_asset_bookkeeping()
--> Result<(), Box<dyn std::error::Error>> {
-    let temp = tempfile::tempdir()?;
-    write(
-        temp.path().join("src/index.js"),
-        r#"
-            export async function load() {
-                return import("./feature");
-            }
-        "#,
-    )?;
-    write(
-        temp.path().join("src/feature.js"),
-        "export const value = 42;",
-    )?;
-
+#[should_panic(expected = "Render IDs must be assigned before code generation")]
+async fn code_generation_rejects_an_unsealed_compilation() {
+    let temp = tempfile::tempdir().expect("temp directory should be created");
+    write(temp.path().join("src/index.js"), "export const value = 42;")
+        .expect("fixture should be written");
     let compiler = Compiler::new(CompilerOptions::new(
         temp.path(),
         vec![Entry::new("main", "./src/index")],
     ));
     let mut compilation = compiler.create_compilation();
 
-    compilation.make().await?;
+    compilation.make().await.expect("make should complete");
     compilation.build_chunk_graph();
     compilation.code_generation();
-    compilation.create_asset_render_manifest();
-
-    assert_eq!(compilation.assets(), []);
-
-    compilation.render_assets();
-
-    assert_eq!(compilation.errors(), []);
-    assert_eq!(
-        compilation
-            .assets()
-            .iter()
-            .map(|asset| asset.filename.as_str())
-            .collect::<Vec<_>>(),
-        [
-            "main.js",
-            "main.js.map",
-            "src_feature_js.js",
-            "src_feature_js.js.map"
-        ]
-    );
-
-    Ok(())
 }
 
 // Ported from webpack 5.108.1:

--- a/docs/implementation/code-splitting-and-codegen.md
+++ b/docs/implementation/code-splitting-and-codegen.md
@@ -4,12 +4,14 @@ This plan implements dynamic-import code splitting and webpack-shaped code gener
 
 ## Target Shape
 
-The compilation pipeline should be explicit:
+The compilation pipeline is explicit and keeps webpack's post-Make sealing boundary:
 
 1. `make`
-2. `build_chunk_graph`
-3. `code_generation`
-4. `create_assets`
+2. `seal`
+   1. `build_chunk_graph`
+   2. assign module and chunk render IDs
+   3. `code_generation`
+   4. `create_assets`
 
 `Compiler::run()` should return a `Compilation` with a module graph, chunk graph, code generation results, and in-memory assets. Disk output, CLI, config files, and target selection are out of scope for the first implementation.
 
@@ -129,6 +131,12 @@ Add `Chunk::split(new_chunk)` as the common rewiring operation for future split 
 ## Slice 6: Code Generation Core
 
 Add code generation based on `rspack_sources`.
+
+Code generation is keyed only by module identity inside one `Compilation`. Each
+renderable module produces exactly one source-preserving result plus its direct
+runtime requirements. Results are not persisted or reused by later
+compilations. Chunk asset rendering consumes those results and owns the module
+factory wrapper.
 
 Core pieces:
 

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -14,11 +14,14 @@ That means differences should be classified as staged scope decisions, deliberat
 
 ## Compiler and compilation lifecycle
 
-Unpack currently runs a direct Rust pipeline:
+Unpack currently runs a compact Rust pipeline with a webpack-shaped sealing boundary:
 
 1. `Compilation::make`
-2. `Compilation::build_chunk_graph`
-3. `Compilation::create_assets`
+2. `Compilation::seal`
+   1. build the chunk graph
+   2. assign render IDs
+   3. generate one result per module
+   4. create assets
 
 Webpack's lifecycle is much larger: `Compiler.run` guards concurrent runs, calls run hooks, reads records, compiles, emits assets, emits records, stores build dependencies, and returns `Stats`. `Compiler.compile` creates normal and context module factories, runs make hooks, finishes the compilation, seals it, and then runs after-compile hooks.
 
@@ -26,7 +29,9 @@ Necessity:
 
 - Keeping Unpack's lifecycle small is a staged implementation choice while the public API grows toward webpack.
 - Matching webpack's hook graph, records, cache idle state, and plugin lifecycle becomes necessary when the corresponding public plugin and lifecycle surfaces are supported.
-- The phase names are still useful because they provide good implementation boundaries and future cache boundaries.
+- The phase names remain useful implementation boundaries. Code generation
+  results deliberately belong to one `Compilation`; they are not a persistent
+  cache boundary.
 
 ## Normal module factory
 

--- a/packages/unpack/test/persistent-cache-contract.test.ts
+++ b/packages/unpack/test/persistent-cache-contract.test.ts
@@ -419,13 +419,13 @@ test("unchanged Resolve and Module Build work restores in an independent process
     assert.deepEqual(cold.cacheWork, {
       resolve: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
       moduleBuild: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
-      codeGeneration: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
+      codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
       assetRender: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 }
     });
     assert.deepEqual(warm.cacheWork, {
       resolve: { hits: 2, misses: 0, stores: 0, restores: 2, evictions: 0 },
       moduleBuild: { hits: 2, misses: 0, stores: 0, restores: 2, evictions: 0 },
-      codeGeneration: { hits: 2, misses: 0, stores: 0, restores: 2, evictions: 0 },
+      codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
       assetRender: { hits: 1, misses: 0, stores: 0, restores: 1, evictions: 0 }
     });
   } finally {
@@ -433,7 +433,7 @@ test("unchanged Resolve and Module Build work restores in an independent process
   }
 });
 
-test("Code Generation records restore module-runtime work without restoring Compilation graphs", async () => {
+test("Code Generation runs once per module in each independent Compilation", async () => {
   const fixture = await createFixture({
     "src/index.js": [
       "export async function load() {",
@@ -465,26 +465,14 @@ test("Code Generation records restore module-runtime work without restoring Comp
   try {
     const cold = await runCacheProcess(request(coldOutput));
     assert.equal(cold.error, null);
-    assert.deepEqual(cold.cacheWork?.codeGeneration, {
-      hits: 0,
-      misses: 2,
-      stores: 2,
-      restores: 0,
-      evictions: 0
-    });
+    assertNoCodeGenerationCacheWork(cold);
     const coldFiles = await readAssetRenderFixture(coldOutput);
 
     const warm = await runCacheProcess(request(warmOutput));
     assert.equal(warm.error, null);
     assert.notEqual(cold.pid, warm.pid);
     assert.notEqual(cold.instanceId, warm.instanceId);
-    assert.deepEqual(warm.cacheWork?.codeGeneration, {
-      hits: 2,
-      misses: 0,
-      stores: 0,
-      restores: 2,
-      evictions: 0
-    });
+    assertNoCodeGenerationCacheWork(warm);
     assert.deepEqual(await readAssetRenderFixture(warmOutput), coldFiles);
     assert.deepEqual(warm.assetDetails, cold.assetDetails);
 
@@ -495,13 +483,7 @@ test("Code Generation records restore module-runtime work without restoring Comp
     );
     const changed = await runCacheProcess(request(changedOutput));
     assert.equal(changed.error, null);
-    assert.deepEqual(changed.cacheWork?.codeGeneration, {
-      hits: 1,
-      misses: 1,
-      stores: 1,
-      restores: 1,
-      evictions: 0
-    });
+    assertNoCodeGenerationCacheWork(changed);
     assert.match(
       await readFile(join(changedOutput, "src_feature_js.js"), "utf8"),
       /after/
@@ -524,13 +506,7 @@ test("Code Generation records restore module-runtime work without restoring Comp
     );
     const graphChanged = await runCacheProcess(request(graphOutput));
     assert.equal(graphChanged.error, null);
-    assert.deepEqual(graphChanged.cacheWork?.codeGeneration, {
-      hits: 1,
-      misses: 2,
-      stores: 2,
-      restores: 1,
-      evictions: 0
-    });
+    assertNoCodeGenerationCacheWork(graphChanged);
     assert.deepEqual(graphChanged.assets, [
       "main.js",
       "main.js.map",
@@ -681,13 +657,13 @@ test("resolved Build Dependency requests guard PackFile entries across processes
     assert.deepEqual(cold.cacheWork, {
       resolve: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 },
       moduleBuild: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 },
-      codeGeneration: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 },
+      codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
       assetRender: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 }
     });
     assert.deepEqual(relabeledWarm.cacheWork, {
       resolve: { hits: 1, misses: 0, stores: 0, restores: 1, evictions: 0 },
       moduleBuild: { hits: 1, misses: 0, stores: 0, restores: 1, evictions: 0 },
-      codeGeneration: { hits: 1, misses: 0, stores: 0, restores: 1, evictions: 0 },
+      codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
       assetRender: { hits: 1, misses: 0, stores: 0, restores: 1, evictions: 0 }
     });
     assert.deepEqual(changed.cacheWork, cold.cacheWork);
@@ -829,7 +805,7 @@ test("a source mutation rebuilds only the affected Module Build record", async (
     assert.deepEqual(cold.cacheWork, {
       resolve: { hits: 0, misses: 3, stores: 3, restores: 0, evictions: 0 },
       moduleBuild: { hits: 0, misses: 3, stores: 3, restores: 0, evictions: 0 },
-      codeGeneration: { hits: 0, misses: 3, stores: 3, restores: 0, evictions: 0 },
+      codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
       assetRender: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 }
     });
 
@@ -844,7 +820,7 @@ test("a source mutation rebuilds only the affected Module Build record", async (
     assert.deepEqual(changed.cacheWork, {
       resolve: { hits: 3, misses: 0, stores: 0, restores: 3, evictions: 0 },
       moduleBuild: { hits: 3, misses: 0, stores: 1, restores: 3, evictions: 0 },
-      codeGeneration: { hits: 2, misses: 1, stores: 1, restores: 2, evictions: 0 },
+      codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
       assetRender: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 }
     });
     assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /after/);
@@ -881,14 +857,14 @@ test("cache version is an exact container guard at the same location", async () 
       assert.deepEqual(cold.cacheWork, {
         resolve: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
         moduleBuild: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
-        codeGeneration: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
+        codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
         assetRender: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 }
       });
     }
     assert.deepEqual(warmV2.cacheWork, {
       resolve: { hits: 2, misses: 0, stores: 0, restores: 2, evictions: 0 },
       moduleBuild: { hits: 2, misses: 0, stores: 0, restores: 2, evictions: 0 },
-      codeGeneration: { hits: 2, misses: 0, stores: 0, restores: 2, evictions: 0 },
+      codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
       assetRender: { hits: 1, misses: 0, stores: 0, restores: 1, evictions: 0 }
     });
   } finally {
@@ -948,7 +924,7 @@ test("legacy JSON and CBOR cache files remain untouched and are treated as cold"
     assert.deepEqual(observation.cacheWork, {
       resolve: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
       moduleBuild: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
-      codeGeneration: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
+      codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
       assetRender: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 }
     });
     assert.deepEqual(await readFile(manifestPath), manifest);
@@ -1102,9 +1078,19 @@ function singleModuleCacheWork(kind: "cold" | "warm") {
   return {
     resolve: { ...item },
     moduleBuild: { ...item },
-    codeGeneration: { ...item },
+    codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
     assetRender: { ...item }
   };
+}
+
+function assertNoCodeGenerationCacheWork(observation: CacheProcessObservation) {
+  assert.deepEqual(observation.cacheWork?.codeGeneration, {
+    hits: 0,
+    misses: 0,
+    stores: 0,
+    restores: 0,
+    evictions: 0
+  });
 }
 
 async function readAssetRenderFixture(outputPath: string) {


### PR DESCRIPTION
Closes #166.

- add a webpack-shaped post-Make sealing boundary
- generate one source-preserving result per renderable module and retain direct runtime requirements
- move module-factory wrapping to asset rendering and fail impossible phase inputs explicitly
- remove Code Generation Result reuse from the persistent cache path while preserving existing asset-render caching
- document the lifecycle and update cross-process cache contracts