### PR TITLE
Generate static runtime capabilities from requirements

### DIFF
--- a/crates/unpack_core/src/chunk_graph.rs
+++ b/crates/unpack_core/src/chunk_graph.rs
@@ -1,6 +1,13 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use crate::{CompilerOptions, ModuleGraph, ModuleId, id_assignment::RenderId};
+use crate::{
+    CompilerOptions, ModuleGraph, ModuleId,
+    id_assignment::RenderId,
+    runtime::{
+        RuntimeModule, RuntimeRequirements, entry_startup_runtime_requirements,
+        resolve_runtime_modules,
+    },
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ChunkId(usize);
@@ -180,6 +187,10 @@ pub struct ChunkGraph {
     module_chunks: Vec<Vec<ChunkId>>,
     module_render_ids: Vec<Option<RenderId>>,
     block_chunk_groups: HashMap<AsyncBlockOrigin, ChunkGroupId>,
+    module_runtime_requirements: Vec<RuntimeRequirements>,
+    chunk_runtime_requirements: Vec<RuntimeRequirements>,
+    runtime_tree_requirements: HashMap<ChunkGroupId, RuntimeRequirements>,
+    chunk_runtime_modules: Vec<Vec<RuntimeModule>>,
 }
 
 impl ChunkGraph {
@@ -273,6 +284,9 @@ impl ChunkGraph {
         let id = ChunkId::new(self.chunks.len());
         self.chunks.push(Chunk::new(id, name, root_modules));
         self.chunk_modules.push(Vec::new());
+        self.chunk_runtime_requirements
+            .push(RuntimeRequirements::default());
+        self.chunk_runtime_modules.push(Vec::new());
         id
     }
 
@@ -316,6 +330,8 @@ impl ChunkGraph {
             self.module_chunks.resize_with(module.index() + 1, Vec::new);
             self.module_render_ids
                 .resize_with(module.index() + 1, || None);
+            self.module_runtime_requirements
+                .resize_with(module.index() + 1, RuntimeRequirements::default);
         }
         if !self.chunk_modules[chunk.index()].contains(&module) {
             self.chunk_modules[chunk.index()].push(module);
@@ -372,6 +388,90 @@ impl ChunkGraph {
 
     pub fn chunk(&self, id: ChunkId) -> Option<&Chunk> {
         self.chunks.get(id.index())
+    }
+
+    pub(crate) fn process_runtime_requirements(
+        &mut self,
+        module_requirements: impl IntoIterator<Item = (ModuleId, RuntimeRequirements)>,
+    ) {
+        self.module_runtime_requirements
+            .resize_with(self.module_chunks.len(), RuntimeRequirements::default);
+        for requirements in &mut self.module_runtime_requirements {
+            *requirements = RuntimeRequirements::default();
+        }
+        for (module, direct) in module_requirements {
+            assert!(
+                module.index() < self.module_runtime_requirements.len(),
+                "Runtime Requirements must reference a Module in the Chunk Graph"
+            );
+            let (processed, _) = resolve_runtime_modules(&direct);
+            self.module_runtime_requirements[module.index()] = processed;
+        }
+
+        for chunk_index in 0..self.chunks.len() {
+            let mut requirements = RuntimeRequirements::default();
+            for module in &self.chunk_modules[chunk_index] {
+                requirements.extend(&self.module_runtime_requirements[module.index()]);
+            }
+            self.chunk_runtime_requirements[chunk_index] = requirements;
+            self.chunk_runtime_modules[chunk_index].clear();
+        }
+
+        self.runtime_tree_requirements.clear();
+        for entrypoint in self.entrypoints.iter().copied() {
+            let mut requirements = RuntimeRequirements::default();
+            let mut visited = HashSet::new();
+            let mut pending = vec![entrypoint];
+            while let Some(group_id) = pending.pop() {
+                if !visited.insert(group_id) {
+                    continue;
+                }
+                let group = &self.chunk_groups[group_id.index()];
+                for chunk in group.chunks() {
+                    requirements.extend(&self.chunk_runtime_requirements[chunk.index()]);
+                }
+                pending.extend(group.children().iter().copied());
+            }
+            requirements.extend(&entry_startup_runtime_requirements());
+            let (processed, modules) = resolve_runtime_modules(&requirements);
+            let runtime_chunk = self.chunk_groups[entrypoint.index()]
+                .chunks()
+                .first()
+                .copied()
+                .expect("Entrypoint must contain a runtime Chunk");
+            self.chunk_runtime_modules[runtime_chunk.index()] = modules;
+            self.runtime_tree_requirements.insert(entrypoint, processed);
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn module_runtime_requirements(
+        &self,
+        module: ModuleId,
+    ) -> Option<&RuntimeRequirements> {
+        self.module_runtime_requirements.get(module.index())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn chunk_runtime_requirements(
+        &self,
+        chunk: ChunkId,
+    ) -> Option<&RuntimeRequirements> {
+        self.chunk_runtime_requirements.get(chunk.index())
+    }
+
+    pub(crate) fn runtime_tree_requirements(
+        &self,
+        entrypoint: ChunkGroupId,
+    ) -> Option<&RuntimeRequirements> {
+        self.runtime_tree_requirements.get(&entrypoint)
+    }
+
+    pub(crate) fn runtime_modules(&self, chunk: ChunkId) -> &[RuntimeModule] {
+        self.chunk_runtime_modules
+            .get(chunk.index())
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
     }
 }
 

--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, HashMap},
     hash::{Hash, Hasher},
 };
 
@@ -19,6 +19,7 @@ use crate::{
     },
     id_assignment::RenderId,
     rendered_source::RenderedSource,
+    runtime::{RuntimeModule, RuntimeModuleContext, RuntimeRequirement, RuntimeRequirements},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -27,42 +28,20 @@ pub struct Asset {
     pub source: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum RuntimeRequirement {
-    ModuleFactories,
-    ModuleCache,
-    Require,
-    DefinePropertyGetters,
-    HasOwnProperty,
-    MakeNamespaceObject,
-    EnsureChunk,
-    GetChunkFilename,
-    RequireChunkLoading,
-}
-
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct RuntimeRequirements {
-    requirements: BTreeSet<RuntimeRequirement>,
-}
-
-impl RuntimeRequirements {
-    pub fn insert(&mut self, requirement: RuntimeRequirement) {
-        self.requirements.insert(requirement);
-    }
-
-    pub fn contains(&self, requirement: RuntimeRequirement) -> bool {
-        self.requirements.contains(&requirement)
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = RuntimeRequirement> + '_ {
-        self.requirements.iter().copied()
-    }
-}
-
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct CodeGenerationResults {
     module_render_ids: HashMap<ModuleId, RenderId>,
     results: HashMap<ModuleId, CodeGenerationResult>,
+}
+
+impl CodeGenerationResults {
+    pub(crate) fn runtime_requirements(
+        &self,
+    ) -> impl Iterator<Item = (ModuleId, &RuntimeRequirements)> {
+        self.results
+            .iter()
+            .map(|(module, result)| (*module, result.runtime_requirements()))
+    }
 }
 
 struct CodeGenerationInput<'a> {
@@ -87,6 +66,8 @@ struct RenderManifestEntry {
 enum AssetRenderManifest {
     InitialChunk {
         modules: Vec<ModuleRenderManifest>,
+        runtime_modules: Vec<RenderedRuntimeModule>,
+        use_legacy_async_runtime: bool,
         chunk_filename_map: String,
         entry_id: RenderId,
         chunk_id: RenderId,
@@ -101,6 +82,12 @@ enum AssetRenderManifest {
 struct ModuleRenderManifest {
     module: ModuleId,
     render_id: RenderId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RenderedRuntimeModule {
+    module: RuntimeModule,
+    source: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -136,6 +123,7 @@ struct InitFragment {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum InitFragmentStage {
+    HarmonyCompatibility,
     HarmonyImport,
     HarmonyExport,
     HarmonyStarReexport,
@@ -218,10 +206,28 @@ pub(crate) fn create_render_manifest(
             .copied()
             .expect("Entrypoint must have an Entry Module before manifest creation");
         let modules = module_render_manifest(chunk_graph, chunk, code_generation_results);
+        let runtime_tree_requirements = chunk_graph
+            .runtime_tree_requirements(group_id)
+            .expect("Runtime Requirements must be processed before manifest creation");
+        let runtime_context = RuntimeModuleContext {
+            chunk_graph,
+            runtime_chunk: chunk_id,
+        };
+        let runtime_modules = chunk_graph
+            .runtime_modules(chunk_id)
+            .iter()
+            .map(|module| RenderedRuntimeModule {
+                module: *module,
+                source: module.generate(&runtime_context),
+            })
+            .collect();
         manifest_entries.push(RenderManifestEntry {
             filename: resolve_chunk_filename(chunk),
             render: AssetRenderManifest::InitialChunk {
                 modules,
+                runtime_modules,
+                use_legacy_async_runtime: runtime_tree_requirements
+                    .contains(RuntimeRequirement::EnsureChunk),
                 chunk_filename_map: render_chunk_filename_map(chunk_graph),
                 entry_id: code_generation_results
                     .module_render_ids
@@ -310,12 +316,16 @@ impl AssetRenderManifest {
         match self {
             Self::InitialChunk {
                 modules,
+                runtime_modules,
+                use_legacy_async_runtime,
                 chunk_filename_map,
                 entry_id,
                 chunk_id,
             } => {
                 hasher.write_u8(0);
                 hash_module_render_inputs(modules, code_generation_results, &mut hasher);
+                runtime_modules.hash(&mut hasher);
+                use_legacy_async_runtime.hash(&mut hasher);
                 chunk_filename_map.hash(&mut hasher);
                 entry_id.hash(&mut hasher);
                 chunk_id.hash(&mut hasher);
@@ -389,11 +399,15 @@ fn render_asset(
     let source = match manifest {
         AssetRenderManifest::InitialChunk {
             modules,
+            runtime_modules,
+            use_legacy_async_runtime,
             chunk_filename_map,
             entry_id,
             chunk_id,
         } => render_initial_asset(
             modules,
+            runtime_modules,
+            *use_legacy_async_runtime,
             chunk_filename_map,
             entry_id,
             chunk_id,
@@ -439,6 +453,8 @@ fn emit_asset(filename: String, rendered: &RenderedSource, sourcemap: bool) -> V
 
 fn render_initial_asset(
     modules: &[ModuleRenderManifest],
+    runtime_modules: &[RenderedRuntimeModule],
+    use_legacy_async_runtime: bool,
     chunk_filename_map: &str,
     entry_id: &RenderId,
     chunk_id: &RenderId,
@@ -446,7 +462,6 @@ fn render_initial_asset(
 ) -> ConcatSource {
     let modules = render_module_table(modules, code_generation_results);
     let entry_id = json_render_id(entry_id);
-    let chunk_id = json_render_id(chunk_id);
 
     let mut source = ConcatSource::default();
     source.add(RawStringSource::from(
@@ -456,23 +471,29 @@ var __webpack_modules__ = ({
         .to_string(),
     ));
     source.add(modules);
-    source.add(RawStringSource::from(format!(
+    source.add(RawStringSource::from(
         r#"
-}});
+});
 
-var __webpack_module_cache__ = {{}};
-function __webpack_require__(moduleId) {{
+var __webpack_module_cache__ = {};
+function __webpack_require__(moduleId) {
   var cachedModule = __webpack_module_cache__[moduleId];
-  if (cachedModule !== undefined) {{
+  if (cachedModule !== undefined) {
     return cachedModule.exports;
-  }}
-  var module = __webpack_module_cache__[moduleId] = {{
-    exports: {{}}
-  }};
+  }
+  var module = __webpack_module_cache__[moduleId] = {
+    exports: {}
+  };
   __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
   return module.exports;
-}}
-__webpack_require__.m = __webpack_modules__;
+}
+"#
+        .to_string(),
+    ));
+    if use_legacy_async_runtime {
+        let chunk_id = json_render_id(chunk_id);
+        source.add(RawStringSource::from(format!(
+            r#"__webpack_require__.m = __webpack_modules__;
 __webpack_require__.d = function(exports, definition) {{
   for(var key in definition) {{
     if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {{
@@ -522,7 +543,15 @@ __webpack_require__.f.require = function(chunkId, promises) {{
 }};
 module.exports = __webpack_require__({entry_id});
 "#,
-    )));
+        )));
+    } else {
+        for runtime_module in runtime_modules {
+            source.add(RawStringSource::from(runtime_module.source.clone()));
+        }
+        source.add(RawStringSource::from(format!(
+            "module.exports = __webpack_require__({entry_id});\n"
+        )));
+    }
     source
 }
 
@@ -568,16 +597,8 @@ fn render_module_table(
             source.add(RawStringSource::from(",\n".to_string()));
         }
         source.add(RawStringSource::from(format!(
-            "{}: ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {{\n\"use strict\";\n{}",
+            "{}: ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {{\n\"use strict\";\n",
             json_render_id(&module.render_id),
-            if result
-                .runtime_requirements()
-                .contains(RuntimeRequirement::MakeNamespaceObject)
-            {
-                "__webpack_require__.r(__webpack_exports__);\n"
-            } else {
-                ""
-            }
         )));
         source.add(result.source().clone());
         source.add(RawStringSource::from("\n})".to_string()));
@@ -607,7 +628,9 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
     ));
     let mut init_fragments = Vec::new();
     let mut runtime_requirements = RuntimeRequirements::default();
-    runtime_requirements.insert(RuntimeRequirement::MakeNamespaceObject);
+    if module.is_harmony() {
+        apply_harmony_compatibility_template(&mut runtime_requirements, &mut init_fragments);
+    }
 
     for dependency in module.presentational_dependencies() {
         apply_dependency_template(
@@ -674,6 +697,18 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
 
 fn render_failed_module_content(error: &Error) -> String {
     format!("throw new Error({});", json_string(&error.to_string()))
+}
+
+fn apply_harmony_compatibility_template(
+    runtime_requirements: &mut RuntimeRequirements,
+    init_fragments: &mut Vec<InitFragment>,
+) {
+    runtime_requirements.insert(RuntimeRequirement::MakeNamespaceObject);
+    push_init_fragment(
+        init_fragments,
+        InitFragmentStage::HarmonyCompatibility,
+        "__webpack_require__.r(__webpack_exports__);\n".to_string(),
+    );
 }
 
 fn render_init_fragments(mut fragments: Vec<InitFragment>) -> String {
@@ -754,7 +789,6 @@ fn apply_dependency_template(
             )
         }
         Dependency::Import(dep) => {
-            runtime_requirements.insert(RuntimeRequirement::EnsureChunk);
             runtime_requirements.insert(RuntimeRequirement::Require);
             apply_import_dependency(
                 dep,
@@ -764,6 +798,7 @@ fn apply_dependency_template(
                 module_graph,
                 chunk_graph,
                 module_render_ids,
+                runtime_requirements,
                 source,
             )
         }
@@ -930,6 +965,7 @@ fn apply_import_dependency(
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
     module_render_ids: &HashMap<ModuleId, RenderId>,
+    runtime_requirements: &mut RuntimeRequirements,
     source: &mut ReplaceSource,
 ) {
     let block_index = origin_block.expect("Dynamic import must belong to an Async Block");
@@ -943,6 +979,10 @@ fn apply_import_dependency(
         block_index,
     };
     let expression = if let Some(group_id) = chunk_graph.block_chunk_group(origin) {
+        runtime_requirements.insert(RuntimeRequirement::EnsureChunk);
+        runtime_requirements.insert(RuntimeRequirement::GetChunkFilename);
+        runtime_requirements.insert(RuntimeRequirement::ModuleFactories);
+        runtime_requirements.insert(RuntimeRequirement::HasOwnProperty);
         let group = &chunk_graph.chunk_groups()[group_id.index()];
         let chunk_id = group
             .chunks()
@@ -1077,6 +1117,7 @@ mod tests {
         CacheOptions, Compiler, CompilerOptions, Entry, ModuleId, SnapshotOptions,
         build_cache::{BuildCache, CacheIdentifier, CacheKey, CacheNamespace},
         id_assignment::RenderId,
+        runtime::RuntimeModule,
     };
 
     use super::{
@@ -1134,26 +1175,27 @@ mod tests {
         assert_ne!(before, render.cache_etag(&results));
 
         let without_requirement = render.cache_etag(&results);
+        let mut requirements = super::RuntimeRequirements::default();
+        requirements.insert(RuntimeRequirement::MakeNamespaceObject);
         results.results.insert(
             module_id,
-            code_generation_result("export const value = 'after';").with_runtime_requirements(
-                super::RuntimeRequirements {
-                    requirements: std::collections::BTreeSet::from([
-                        RuntimeRequirement::MakeNamespaceObject,
-                    ]),
-                },
-            ),
+            code_generation_result("export const value = 'after';")
+                .with_runtime_requirements(requirements),
         );
         assert_ne!(without_requirement, render.cache_etag(&results));
 
         let initial = AssetRenderManifest::InitialChunk {
             modules: Vec::new(),
+            runtime_modules: Vec::new(),
+            use_legacy_async_runtime: false,
             chunk_filename_map: "{\"feature\":\"feature.js\"}".to_string(),
             entry_id: RenderId::String("./src/index.js".to_string()),
             chunk_id: RenderId::String("main".to_string()),
         };
         let changed_filename_map = AssetRenderManifest::InitialChunk {
             modules: Vec::new(),
+            runtime_modules: Vec::new(),
+            use_legacy_async_runtime: false,
             chunk_filename_map: "{\"feature\":\"renamed.js\"}".to_string(),
             entry_id: RenderId::String("./src/index.js".to_string()),
             chunk_id: RenderId::String("main".to_string()),
@@ -1189,6 +1231,42 @@ mod tests {
         ))
         .run()
         .await?;
+        for module in compilation.module_graph().modules() {
+            let requirements = compilation
+                .chunk_graph()
+                .module_runtime_requirements(module.id())
+                .expect("renderable Module must have processed Runtime Requirements");
+            assert!(requirements.contains(RuntimeRequirement::MakeNamespaceObject));
+            assert!(requirements.contains(RuntimeRequirement::DefinePropertyGetters));
+            assert!(requirements.contains(RuntimeRequirement::HasOwnProperty));
+        }
+        for chunk in compilation.chunk_graph().chunks() {
+            let requirements = compilation
+                .chunk_graph()
+                .chunk_runtime_requirements(chunk.id())
+                .expect("Chunk must have processed Runtime Requirements");
+            assert!(requirements.contains(RuntimeRequirement::MakeNamespaceObject));
+            assert!(requirements.contains(RuntimeRequirement::DefinePropertyGetters));
+            assert!(requirements.contains(RuntimeRequirement::HasOwnProperty));
+            assert_eq!(
+                compilation.chunk_graph().runtime_modules(chunk.id()),
+                [
+                    RuntimeModule::DefinePropertyGetters,
+                    RuntimeModule::HasOwnProperty,
+                    RuntimeModule::MakeNamespaceObject,
+                ]
+            );
+        }
+        for entrypoint in compilation.chunk_graph().entrypoints() {
+            let requirements = compilation
+                .chunk_graph()
+                .runtime_tree_requirements(*entrypoint)
+                .expect("Entrypoint must have processed runtime-tree requirements");
+            assert!(requirements.contains(RuntimeRequirement::ModuleFactories));
+            assert!(requirements.contains(RuntimeRequirement::ModuleCache));
+            assert!(requirements.contains(RuntimeRequirement::Require));
+            assert!(requirements.contains(RuntimeRequirement::ReturnExportsFromRuntime));
+        }
         let mut generation_count = 0;
         let results = super::generate_code_with(
             compilation.module_graph(),

--- a/crates/unpack_core/src/code_generation_record.rs
+++ b/crates/unpack_core/src/code_generation_record.rs
@@ -2,7 +2,7 @@ use rspack_sources::{
     ConcatSource, OriginalSource, RawStringSource, ReplaceSource, Replacement, ReplacementEnforce,
 };
 
-use crate::code_generation::RuntimeRequirements;
+use crate::runtime::RuntimeRequirements;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CodeGenerationResult {

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -169,6 +169,7 @@ impl Compilation {
         self.build_chunk_graph();
         self.assign_render_ids();
         self.code_generation();
+        self.process_runtime_requirements();
         self.create_assets();
     }
 
@@ -232,6 +233,17 @@ impl Compilation {
             &self.chunk_graph,
         ));
         self.asset_render_manifest = None;
+    }
+
+    pub(crate) fn process_runtime_requirements(&mut self) {
+        let requirements = self
+            .code_generation_results
+            .as_ref()
+            .expect("code generation results should exist before Runtime Requirements processing")
+            .runtime_requirements()
+            .map(|(module, requirements)| (module, requirements.clone()))
+            .collect::<Vec<_>>();
+        self.chunk_graph.process_runtime_requirements(requirements);
     }
 
     fn log_infrastructure(

--- a/crates/unpack_core/src/dependency.rs
+++ b/crates/unpack_core/src/dependency.rs
@@ -161,6 +161,18 @@ impl Dependency {
     pub fn is_import_dependency(&self) -> bool {
         matches!(self, Self::Import(_))
     }
+
+    pub(crate) fn is_harmony_dependency(&self) -> bool {
+        matches!(
+            self,
+            Self::HarmonyImportSideEffect(_)
+                | Self::HarmonyImportSpecifier(_)
+                | Self::HarmonyExportHeader(_)
+                | Self::HarmonyExportSpecifier(_)
+                | Self::HarmonyExportExpression(_)
+                | Self::HarmonyExportImportedSpecifier(_)
+        )
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/unpack_core/src/id_assignment.rs
+++ b/crates/unpack_core/src/id_assignment.rs
@@ -365,6 +365,11 @@ mod tests {
 
         let build_cache = BuildCache::new(CacheOptions::memory(), SnapshotOptions::default());
         let results = generate_code(&module_graph, &chunk_graph);
+        chunk_graph.process_runtime_requirements(
+            results
+                .runtime_requirements()
+                .map(|(module, requirements)| (module, requirements.clone())),
+        );
         let manifest = create_render_manifest(&chunk_graph, &[module], &results);
         let assets = render_assets(&options, &build_cache, &manifest, &results);
         let main = assets
@@ -406,6 +411,11 @@ mod tests {
 
         let build_cache = BuildCache::new(CacheOptions::memory(), SnapshotOptions::default());
         let results = generate_code(&module_graph, &chunk_graph);
+        chunk_graph.process_runtime_requirements(
+            results
+                .runtime_requirements()
+                .map(|(module, requirements)| (module, requirements.clone())),
+        );
         let manifest = create_render_manifest(&chunk_graph, &entries, &results);
         render_assets(&options, &build_cache, &manifest, &results)
     }

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -18,13 +18,14 @@ mod pack_file;
 mod parser;
 mod rendered_source;
 mod resolver;
+mod runtime;
 mod snapshot;
 
 pub use build_cache::{BuildDependency, CacheCompression, CacheKind, CacheOptions};
 pub use chunk_graph::{
     AsyncBlockOrigin, Chunk, ChunkGraph, ChunkGroup, ChunkGroupId, ChunkGroupKind, ChunkId,
 };
-pub use code_generation::{Asset, RuntimeRequirement, RuntimeRequirements};
+pub use code_generation::Asset;
 pub use compilation::{Compilation, WatchDependencies};
 pub use compiler::{
     CacheIdleReason, CacheLifecycleOutcome, Compiler, CompilerOptions, DEFAULT_EXTENSIONS, Entry,

--- a/crates/unpack_core/src/module.rs
+++ b/crates/unpack_core/src/module.rs
@@ -29,6 +29,7 @@ pub struct Module {
     source_len: usize,
     source_hash: u64,
     build_error: Option<Error>,
+    harmony: bool,
 }
 
 impl Module {
@@ -44,6 +45,7 @@ impl Module {
             source_len: 0,
             source_hash: stable_hash(""),
             build_error: None,
+            harmony: false,
         }
     }
 
@@ -87,6 +89,10 @@ impl Module {
         self.build_error.as_ref()
     }
 
+    pub(crate) fn is_harmony(&self) -> bool {
+        self.harmony
+    }
+
     pub(crate) fn finish_build(
         &mut self,
         dependencies: Vec<Dependency>,
@@ -96,6 +102,10 @@ impl Module {
         source_hash: u64,
     ) {
         self.exports_info = ExportsInfo::from_dependencies(&dependencies);
+        self.harmony = dependencies
+            .iter()
+            .chain(&presentational_dependencies)
+            .any(Dependency::is_harmony_dependency);
         self.source_len = source.len();
         self.source_hash = source_hash;
         self.source = source;
@@ -114,6 +124,7 @@ impl Module {
         self.blocks.clear();
         self.presentational_dependencies.clear();
         self.build_error = Some(error);
+        self.harmony = false;
     }
 }
 

--- a/crates/unpack_core/src/runtime.rs
+++ b/crates/unpack_core/src/runtime.rs
@@ -1,0 +1,222 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::{ChunkGraph, ChunkId};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) enum RuntimeRequirement {
+    ModuleFactories,
+    ModuleCache,
+    Require,
+    DefinePropertyGetters,
+    HasOwnProperty,
+    MakeNamespaceObject,
+    EnsureChunk,
+    GetChunkFilename,
+    ReturnExportsFromRuntime,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct RuntimeRequirements {
+    requirements: BTreeSet<RuntimeRequirement>,
+}
+
+impl RuntimeRequirements {
+    pub(crate) fn insert(&mut self, requirement: RuntimeRequirement) -> bool {
+        self.requirements.insert(requirement)
+    }
+
+    pub(crate) fn contains(&self, requirement: RuntimeRequirement) -> bool {
+        self.requirements.contains(&requirement)
+    }
+
+    pub(crate) fn extend(&mut self, other: &Self) {
+        self.requirements.extend(other.iter());
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = RuntimeRequirement> + '_ {
+        self.requirements.iter().copied()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) enum RuntimeModuleStage {
+    Normal,
+    Basic,
+    Attach,
+    Trigger,
+}
+
+const RUNTIME_MODULE_STAGE_ORDER: [RuntimeModuleStage; 4] = [
+    RuntimeModuleStage::Normal,
+    RuntimeModuleStage::Basic,
+    RuntimeModuleStage::Attach,
+    RuntimeModuleStage::Trigger,
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum RuntimeModule {
+    DefinePropertyGetters,
+    HasOwnProperty,
+    MakeNamespaceObject,
+}
+
+pub(crate) struct RuntimeModuleContext<'a> {
+    pub(crate) chunk_graph: &'a ChunkGraph,
+    pub(crate) runtime_chunk: ChunkId,
+}
+
+impl RuntimeModule {
+    pub(crate) fn identifier(self) -> &'static str {
+        match self {
+            Self::DefinePropertyGetters => "webpack/runtime/define property getters",
+            Self::HasOwnProperty => "webpack/runtime/hasOwnProperty shorthand",
+            Self::MakeNamespaceObject => "webpack/runtime/make namespace object",
+        }
+    }
+
+    pub(crate) fn stage(self) -> RuntimeModuleStage {
+        match self {
+            Self::HasOwnProperty | Self::DefinePropertyGetters | Self::MakeNamespaceObject => {
+                RuntimeModuleStage::Normal
+            }
+        }
+    }
+
+    fn prerequisites(self) -> &'static [RuntimeRequirement] {
+        match self {
+            Self::DefinePropertyGetters => &[RuntimeRequirement::HasOwnProperty],
+            Self::HasOwnProperty | Self::MakeNamespaceObject => &[],
+        }
+    }
+
+    pub(crate) fn generate(self, context: &RuntimeModuleContext<'_>) -> String {
+        let _ = context
+            .chunk_graph
+            .chunk(context.runtime_chunk)
+            .expect("Runtime Module context must reference an existing runtime Chunk");
+        match self {
+            Self::DefinePropertyGetters => r#"__webpack_require__.d = function(exports, definition) {
+  for(var key in definition) {
+    if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+      Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+    }
+  }
+};
+"#
+            .to_string(),
+            Self::HasOwnProperty => {
+                "__webpack_require__.o = function(obj, prop) { return Object.prototype.hasOwnProperty.call(obj, prop); };\n".to_string()
+            }
+            Self::MakeNamespaceObject => r#"__webpack_require__.r = function(exports) {
+  if(typeof Symbol !== "undefined" && Symbol.toStringTag) {
+    Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+  }
+  Object.defineProperty(exports, "__esModule", { value: true });
+};
+"#
+            .to_string(),
+        }
+    }
+}
+
+pub(crate) fn resolve_runtime_modules(
+    direct: &RuntimeRequirements,
+) -> (RuntimeRequirements, Vec<RuntimeModule>) {
+    let mut requirements = direct.clone();
+    let mut modules = BTreeMap::new();
+    let mut pending = requirements.iter().collect::<Vec<_>>();
+
+    while let Some(requirement) = pending.pop() {
+        let module = match requirement {
+            RuntimeRequirement::DefinePropertyGetters => Some(RuntimeModule::DefinePropertyGetters),
+            RuntimeRequirement::HasOwnProperty => Some(RuntimeModule::HasOwnProperty),
+            RuntimeRequirement::MakeNamespaceObject => Some(RuntimeModule::MakeNamespaceObject),
+            RuntimeRequirement::ModuleFactories
+            | RuntimeRequirement::ModuleCache
+            | RuntimeRequirement::Require
+            | RuntimeRequirement::EnsureChunk
+            | RuntimeRequirement::GetChunkFilename
+            | RuntimeRequirement::ReturnExportsFromRuntime => None,
+        };
+        let Some(module) = module else {
+            continue;
+        };
+        insert_runtime_module(&mut modules, module);
+        for prerequisite in module.prerequisites() {
+            if requirements.insert(*prerequisite) {
+                pending.push(*prerequisite);
+            }
+        }
+    }
+
+    let mut modules = modules.into_values().collect::<Vec<_>>();
+    modules.sort_by_key(|module| {
+        let stage = RUNTIME_MODULE_STAGE_ORDER
+            .iter()
+            .position(|stage| *stage == module.stage())
+            .expect("Runtime Module must use a known stage");
+        (stage, module.identifier())
+    });
+    (requirements, modules)
+}
+
+fn insert_runtime_module(
+    modules: &mut BTreeMap<&'static str, RuntimeModule>,
+    module: RuntimeModule,
+) {
+    if let Some(existing) = modules.insert(module.identifier(), module) {
+        assert_eq!(
+            existing, module,
+            "conflicting Runtime Modules must not share an identifier"
+        );
+    }
+}
+
+pub(crate) fn entry_startup_runtime_requirements() -> RuntimeRequirements {
+    let mut requirements = RuntimeRequirements::default();
+    requirements.insert(RuntimeRequirement::ModuleFactories);
+    requirements.insert(RuntimeRequirement::ModuleCache);
+    requirements.insert(RuntimeRequirement::Require);
+    requirements.insert(RuntimeRequirement::ReturnExportsFromRuntime);
+    requirements
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolver_closes_transitive_requirements_and_orders_modules() {
+        let mut direct = RuntimeRequirements::default();
+        direct.insert(RuntimeRequirement::MakeNamespaceObject);
+        direct.insert(RuntimeRequirement::DefinePropertyGetters);
+
+        let (closed, modules) = resolve_runtime_modules(&direct);
+
+        assert!(closed.contains(RuntimeRequirement::HasOwnProperty));
+        assert_eq!(
+            modules,
+            [
+                RuntimeModule::DefinePropertyGetters,
+                RuntimeModule::HasOwnProperty,
+                RuntimeModule::MakeNamespaceObject,
+            ]
+        );
+        assert!(
+            modules
+                .iter()
+                .all(|module| module.stage() == RuntimeModuleStage::Normal)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "conflicting Runtime Modules")]
+    fn resolver_rejects_conflicting_module_identifiers() {
+        let mut modules = BTreeMap::from([(
+            RuntimeModule::DefinePropertyGetters.identifier(),
+            RuntimeModule::HasOwnProperty,
+        )]);
+
+        insert_runtime_module(&mut modules, RuntimeModule::DefinePropertyGetters);
+    }
+}

--- a/docs/adr/0021-use-runtime-requirements.md
+++ b/docs/adr/0021-use-runtime-requirements.md
@@ -1,3 +1,15 @@
 # Use runtime requirements
 
-Unpack will model runtime helpers with webpack-like runtime requirements instead of always injecting an undifferentiated runtime block. Dependency templates and init fragments can declare required helpers such as `__webpack_require__`, export getter definition, namespace object marking via `__webpack_require__.r`, module cache, and async chunk loading, while asset creation remains free to conservatively include helpers in the first implementation.
+Unpack models runtime helpers with webpack-like Runtime Requirements instead of
+always injecting an undifferentiated runtime block. Dependency Templates, Init
+Fragments, and startup declare their direct requirements. The Chunk Graph stores
+processed module, chunk, and Entrypoint runtime-tree requirements.
+
+A crate-internal fixed-point resolver adds transitive requirements, selects and
+deduplicates Runtime Modules, and orders them by the Normal, Basic, Attach, and
+Trigger stages followed by stable identifier. Asset creation renders only the
+selected modules. Runtime Requirements and Runtime Modules are closed enums, so
+unknown capabilities fail exhaustive compilation and conflicting stable module
+identifiers fail explicitly during resolution. The remaining legacy asynchronous Node runtime is retained
+only for Entrypoint runtime trees that require chunk ensuring until its dedicated
+migration.

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -96,14 +96,23 @@ Necessity:
 
 ## Runtime and asset generation
 
-Unpack emits webpack-shaped Node/CommonJS output with a module table, module cache, `__webpack_require__`, export getters, namespace marking, `__webpack_require__.e`, `__webpack_require__.f.require`, `__webpack_require__.u`, and require-based async chunk installation. It also emits source maps for generated assets.
+Unpack emits webpack-shaped Node/CommonJS output with a fixed module table,
+module cache, core `__webpack_require__`, and CommonJS entry startup. Generated
+code declares Runtime Requirements; a fixed-point resolver selects ordered
+Runtime Modules for export getters, own-property checks, and namespace marking.
+Static-only Bundles therefore omit chunk ensure, filename lookup, handler, and
+Node loading code. Entrypoints with dynamic imports temporarily retain the
+legacy `__webpack_require__.e`, `__webpack_require__.f.require`,
+`__webpack_require__.u`, and require-based async chunk installation path. Source
+maps remain available for generated assets.
 
 Webpack renders runtime behavior through runtime modules and runtime requirements. Its Node require chunk loading module computes output paths, conditions loading on chunk type, handles installed chunk state, supports optional on-chunk-load hooks, external install hooks, HMR, base URI, and generated filename templates.
 
 Necessity:
 
 - Starting with fixed Node require chunk loading is intentional and covered by ADR `0032`.
-- Hard-coded runtime helpers are acceptable while only one target exists, but the current `RuntimeRequirements` calculation is mostly aspirational because helper inclusion is not yet driven by it.
+- Runtime Requirements now drive the implemented static Runtime Modules. The
+  legacy asynchronous runtime remains a staged migration gap.
 - Browser JSONP, ESM chunk loading, HMR, public path, chunk filename templates, and external chunk installation are future target features, not current requirements.
 
 ## ESM code generation

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -34,6 +34,114 @@ test("emits assets through the ESM default API", async () => {
   }
 });
 
+// Ported from webpack 5.108.1's DefinePropertyGettersRuntimeModule,
+// HasOwnPropertyRuntimeModule, and MakeNamespaceObjectRuntimeModule behavior.
+test("static ESM emits only the runtime capabilities used by generated code", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "import { value } from './dep'; export const result = value;",
+    "src/dep.js": "export const value = 42;"
+  });
+  const outputPath = join(fixture, "dist");
+
+  try {
+    const { err, stats } = await runCompiler({
+      context: fixture,
+      entry: "./src/index.js",
+      output: { path: outputPath },
+      sourcemap: false
+    });
+
+    assert.equal(err, null);
+    assert.equal(stats?.hasErrors(), false);
+    const source = await readFile(join(outputPath, "main.js"), "utf8");
+    assert.match(source, /__webpack_require__\.d =/);
+    assert.match(source, /__webpack_require__\.o =/);
+    assert.match(source, /__webpack_require__\.r =/);
+    assert.doesNotMatch(source, /__webpack_require__\.e =/);
+    assert.doesNotMatch(source, /__webpack_require__\.f =/);
+    assert.doesNotMatch(source, /__webpack_require__\.u =/);
+    assert.doesNotMatch(source, /installedChunks/);
+    assert.doesNotMatch(source, /installChunk/);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+// Ported from webpack 5.108.1's HarmonyCompatibilityDependency behavior.
+test("namespace compatibility marks static ESM but not scripts or dynamic-import-only modules", async () => {
+  const scriptFixture = await createFixture({
+    "src/index.js": "globalThis.__unpack_script__ = 1;"
+  });
+  const dynamicFixture = await createFixture({
+    "src/index.js": "globalThis.__unpack_load__ = () => import('./feature');",
+    "src/feature.js": "export const value = 42;"
+  });
+
+  try {
+    const script = await runCompiler({
+      context: scriptFixture,
+      entry: "./src/index.js",
+      sourcemap: false
+    });
+    assert.equal(script.err, null);
+    assert.equal(script.stats?.hasErrors(), false);
+    const scriptSource = await readFile(join(scriptFixture, "dist/main.js"), "utf8");
+    assert.doesNotMatch(scriptSource, /__webpack_require__\.r\(__webpack_exports__\)/);
+    assert.doesNotMatch(scriptSource, /__webpack_require__\.r =/);
+
+    const dynamic = await runCompiler({
+      context: dynamicFixture,
+      entry: "./src/index.js",
+      sourcemap: false
+    });
+    assert.equal(dynamic.err, null);
+    assert.equal(dynamic.stats?.hasErrors(), false);
+    const dynamicAssets = dynamic.stats?.toJson().assets.map((asset) => asset.name) ?? [];
+    const asyncAsset = dynamicAssets.find((asset) => asset !== "main.js");
+    assert.ok(asyncAsset);
+    const mainSource = await readFile(join(dynamicFixture, "dist/main.js"), "utf8");
+    const asyncSource = await readFile(join(dynamicFixture, "dist", asyncAsset), "utf8");
+    assert.doesNotMatch(mainSource, /__webpack_require__\.r\(__webpack_exports__\)/);
+    assert.match(asyncSource, /__webpack_require__\.r\(__webpack_exports__\)/);
+  } finally {
+    await rm(scriptFixture, { recursive: true, force: true });
+    await rm(dynamicFixture, { recursive: true, force: true });
+  }
+});
+
+// Ported from webpack 5.108.1's collapsed import() behavior when a target is
+// already available in the initial chunk.
+test("collapsed dynamic imports do not provision asynchronous runtime capabilities", async () => {
+  const fixture = await createFixture({
+    "src/index.js": [
+      "import { value } from './dep';",
+      "export const initial = value;",
+      "export const load = () => import('./dep');"
+    ].join("\n"),
+    "src/dep.js": "export const value = 42;"
+  });
+
+  try {
+    const { err, stats } = await runCompiler({
+      context: fixture,
+      entry: "./src/index.js",
+      sourcemap: false
+    });
+
+    assert.equal(err, null);
+    assert.equal(stats?.hasErrors(), false);
+    assert.deepEqual(stats?.toJson().assets.map((asset) => asset.name), ["main.js"]);
+    const source = await readFile(join(fixture, "dist/main.js"), "utf8");
+    assert.match(source, /Promise\.resolve\(\)\.then/);
+    assert.doesNotMatch(source, /__webpack_require__\.e =/);
+    assert.doesNotMatch(source, /__webpack_require__\.f =/);
+    assert.doesNotMatch(source, /__webpack_require__\.u =/);
+    assert.doesNotMatch(source, /installedChunks/);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 test("supports object entries", async () => {
   const fixture = await createFixture({
     "src/a.js": "export const a = 'a';",

--- a/packages/unpack/test/e2e-cases/static-reexports/README.md
+++ b/packages/unpack/test/e2e-cases/static-reexports/README.md
@@ -1,0 +1,4 @@
+# Static re-exports
+
+Ported from webpack 5.108.1 `test/cases/parsing/harmony-reexport` and reduced to
+the named and star re-export behavior supported by Unpack.

--- a/packages/unpack/test/e2e-cases/static-reexports/case.json
+++ b/packages/unpack/test/e2e-cases/static-reexports/case.json
@@ -1,0 +1,4 @@
+{
+  "runtimeExpression": "[entry.renamed, entry.star]",
+  "expected": [42, "ok"]
+}

--- a/packages/unpack/test/e2e-cases/static-reexports/src/dep.js
+++ b/packages/unpack/test/e2e-cases/static-reexports/src/dep.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/packages/unpack/test/e2e-cases/static-reexports/src/index.js
+++ b/packages/unpack/test/e2e-cases/static-reexports/src/index.js
@@ -1,0 +1,2 @@
+export { value as renamed } from "./dep";
+export * from "./star";

--- a/packages/unpack/test/e2e-cases/static-reexports/src/star.js
+++ b/packages/unpack/test/e2e-cases/static-reexports/src/star.js
@@ -1,0 +1,1 @@
+export const star = "ok";


### PR DESCRIPTION
Closes #167.

- store processed module, chunk, and Entrypoint runtime-tree requirements in the Chunk Graph
- resolve transitive requirements into deduplicated Runtime Modules with webpack-relative stage and identifier ordering
- render only the getter, own-property, and namespace helpers used by static ESM bundles
- keep namespace compatibility scoped to Harmony modules and preserve the legacy dynamic-import runtime path
- add webpack-derived public bundle tests for static re-exports, Harmony detection, and collapsed dynamic imports