### PR TITLE
Improve persistent-cache warm build performance

### DIFF
--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -467,6 +467,7 @@ trait CacheLayer: fmt::Debug + Send + Sync {
         _guard: &PackFileGuardDto,
         _build_inputs: &BTreeSet<PathBuf>,
         _resolved_build_inputs: &BTreeSet<PathBuf>,
+        _automatic_build_inputs: &BTreeSet<PathBuf>,
         _file_system_info: &FileSystemInfo,
         _build_dependency_snapshot_strategy: SnapshotStrategy,
         _resolve_build_dependency_snapshot_strategy: SnapshotStrategy,
@@ -939,10 +940,18 @@ impl CacheLayer for PackFileCacheLayer {
         guard: &PackFileGuardDto,
         build_inputs: &BTreeSet<PathBuf>,
         resolved_build_inputs: &BTreeSet<PathBuf>,
+        automatic_build_inputs: &BTreeSet<PathBuf>,
         file_system_info: &FileSystemInfo,
         build_dependency_snapshot_strategy: SnapshotStrategy,
         resolve_build_dependency_snapshot_strategy: SnapshotStrategy,
     ) -> bool {
+        let build_strategy = if !build_inputs.is_empty()
+            && build_inputs.iter().all(|path| automatic_build_inputs.contains(path))
+        {
+            SnapshotStrategy::timestamp()
+        } else {
+            build_dependency_snapshot_strategy
+        };
         let active = self.pack_file.as_ref().is_some_and(|pack_file| {
             pack_file.guard().is_some_and(|candidate| {
                 let build_dependencies =
@@ -954,7 +963,7 @@ impl CacheLayer for PackFileCacheLayer {
                         snapshot.has_exact_paths(build_inputs.iter().cloned())
                             && file_system_info.is_snapshot_valid_sync(
                                 &snapshot,
-                                build_dependency_snapshot_strategy,
+                                build_strategy,
                             )
                     })
                     && resolve_build_dependencies.is_some_and(|snapshot| {
@@ -1172,6 +1181,7 @@ impl Cache {
         guard: &PackFileGuardDto,
         build_inputs: &BTreeSet<PathBuf>,
         resolved_build_inputs: &BTreeSet<PathBuf>,
+        automatic_build_inputs: &BTreeSet<PathBuf>,
         file_system_info: &FileSystemInfo,
         build_dependency_snapshot_strategy: SnapshotStrategy,
         resolve_build_dependency_snapshot_strategy: SnapshotStrategy,
@@ -1184,6 +1194,7 @@ impl Cache {
                     guard,
                     build_inputs,
                     resolved_build_inputs,
+                    automatic_build_inputs,
                     file_system_info,
                     build_dependency_snapshot_strategy,
                     resolve_build_dependency_snapshot_strategy,
@@ -1546,6 +1557,7 @@ impl BuildCache {
             .iter()
             .map(|path| fs::canonicalize(path).unwrap_or_else(|_| path.clone()))
             .collect::<BTreeSet<_>>();
+        let automatic_build_inputs = build_inputs.clone();
         let mut resolved_build_inputs = BTreeSet::new();
         let mut resolution_files = BTreeSet::new();
         let mut resolution_contexts = BTreeSet::new();
@@ -1562,11 +1574,17 @@ impl BuildCache {
             resolution_contexts.extend(resolved.context_dependencies);
             resolution_missing.extend(resolved.missing_dependencies);
         }
+        let automatic_only = resolution_files.is_empty() && build_inputs == automatic_build_inputs;
+        let build_dependency_snapshot_strategy = if automatic_only {
+            SnapshotStrategy::timestamp()
+        } else {
+            self.build_dependency_snapshot_strategy
+        };
         let build_dependencies = self
             .build_dependency_file_system_info
             .create_snapshot_sync(
                 build_inputs.iter().cloned(),
-                self.build_dependency_snapshot_strategy,
+                build_dependency_snapshot_strategy,
             )?;
         let resolve_build_dependencies = self
             .build_dependency_file_system_info
@@ -1589,6 +1607,13 @@ impl BuildCache {
             .inner
             .lock()
             .expect("build cache mutex should not be poisoned");
+        let build_validation_strategy = if !build_inputs.is_empty()
+            && build_inputs.iter().all(|path| automatic_build_inputs.contains(path))
+        {
+            SnapshotStrategy::timestamp()
+        } else {
+            self.build_dependency_snapshot_strategy
+        };
         let previous_build_inputs_are_valid = inner
             .persistent_guard
             .as_ref()
@@ -1597,7 +1622,7 @@ impl BuildCache {
                 snapshot.has_exact_paths(build_inputs.iter().cloned())
                     && self
                         .build_dependency_file_system_info
-                        .is_snapshot_valid_sync(&snapshot, self.build_dependency_snapshot_strategy)
+                        .is_snapshot_valid_sync(&snapshot, build_validation_strategy)
             });
         if inner.persistent_guard.is_some() && !previous_build_inputs_are_valid {
             inner.cache.clear();
@@ -1606,6 +1631,7 @@ impl BuildCache {
             &guard,
             &build_inputs,
             &resolved_build_inputs,
+            &automatic_build_inputs,
             &self.build_dependency_file_system_info,
             self.build_dependency_snapshot_strategy,
             self.resolve_build_dependency_snapshot_strategy,

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -361,14 +361,22 @@ impl BuildTask {
             .to_path_buf();
 
         if let Some(record) = services.module_build_cache.get(&self.identity, None) {
-            if record
-                .is_valid_with_cache(
-                    &services.file_system_info,
+            let valid = if services.module_snapshot_strategy.hash {
+                record
+                    .is_valid_with_cache(
+                        &services.file_system_info,
+                        services.module_snapshot_strategy,
+                        &services.snapshot_cache,
+                    )
+                    .await
+            } else {
+                services.file_system_info.is_snapshot_valid_sync_with_cache(
+                    record.snapshot(),
                     services.module_snapshot_strategy,
                     &services.snapshot_cache,
                 )
-                .await
-            {
+            };
+            if valid {
                 let process_dependencies =
                     process_dependencies_task(self.module_id, &issuer_context, record.parsed());
                 let (parsed, source, source_hash) = record.cloned_parts();

--- a/crates/unpack_core/src/snapshot.rs
+++ b/crates/unpack_core/src/snapshot.rs
@@ -125,6 +125,20 @@ pub(crate) struct SnapshotCache {
     file_snapshots: Arc<Mutex<HashMap<FileSnapshotCacheKey, FileSnapshot>>>,
     context_timestamp_hashes: Arc<Mutex<HashMap<PathBuf, DirectoryTimestampHash>>>,
     context_content_hashes: Arc<Mutex<HashMap<PathBuf, u64>>>,
+    managed_item_states: Arc<Mutex<HashMap<PathBuf, Option<ManagedItemState>>>>,
+}
+
+impl SnapshotCache {
+    fn managed_path_is_valid(&self, snapshot: &ManagedPathSnapshot) -> bool {
+        let mut states = self
+            .managed_item_states
+            .lock()
+            .expect("snapshot cache mutex should not be poisoned");
+        let state = states
+            .entry(snapshot.root.clone())
+            .or_insert_with(|| ManagedItemState::create(&snapshot.root));
+        state.as_ref() == Some(&snapshot.state)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -226,6 +240,15 @@ impl FileSystemInfo {
         strategy: SnapshotStrategy,
     ) -> bool {
         snapshot.is_valid_sync(strategy, self)
+    }
+
+    pub(crate) fn is_snapshot_valid_sync_with_cache(
+        &self,
+        snapshot: &Snapshot,
+        strategy: SnapshotStrategy,
+        cache: &SnapshotCache,
+    ) -> bool {
+        snapshot.is_valid_sync_with_cache(strategy, self, Some(cache))
     }
 
     #[cfg(test)]
@@ -542,8 +565,17 @@ impl Snapshot {
     }
 
     fn is_valid_sync(&self, strategy: SnapshotStrategy, file_system_info: &FileSystemInfo) -> bool {
+        self.is_valid_sync_with_cache(strategy, file_system_info, None)
+    }
+
+    fn is_valid_sync_with_cache(
+        &self,
+        strategy: SnapshotStrategy,
+        file_system_info: &FileSystemInfo,
+        cache: Option<&SnapshotCache>,
+    ) -> bool {
         for entry in &self.entries {
-            if !entry.is_valid_sync(strategy, file_system_info) {
+            if !entry.is_valid_sync_with_cache(strategy, file_system_info, cache) {
                 return false;
             }
         }
@@ -712,12 +744,21 @@ impl SnapshotEntry {
                 matches!(
                     file_system_info.classify_path(&snapshot.path),
                     SnapshotPathClassification::Managed(_)
-                ) && snapshot.is_valid()
+                ) && snapshot.is_valid_with_cache(cache)
             }
         }
     }
 
     fn is_valid_sync(&self, strategy: SnapshotStrategy, file_system_info: &FileSystemInfo) -> bool {
+        self.is_valid_sync_with_cache(strategy, file_system_info, None)
+    }
+
+    fn is_valid_sync_with_cache(
+        &self,
+        strategy: SnapshotStrategy,
+        file_system_info: &FileSystemInfo,
+        cache: Option<&SnapshotCache>,
+    ) -> bool {
         match self {
             Self::File(file) => {
                 file_system_info.ordinary_snapshot_applies(&file.path)
@@ -729,7 +770,7 @@ impl SnapshotEntry {
                         &context.path,
                         strategy,
                         file_system_info,
-                        None,
+                        cache,
                     )
             }
             Self::MissingExistence { path } => {
@@ -743,7 +784,7 @@ impl SnapshotEntry {
                 matches!(
                     file_system_info.classify_path(&snapshot.path),
                     SnapshotPathClassification::Managed(_)
-                ) && snapshot.is_valid()
+                ) && snapshot.is_valid_with_cache(cache)
             }
         }
     }
@@ -1053,6 +1094,10 @@ impl ManagedPathSnapshot {
 
     fn is_valid(&self) -> bool {
         ManagedItemState::create(&self.root).is_some_and(|state| state == self.state)
+    }
+
+    fn is_valid_with_cache(&self, cache: Option<&SnapshotCache>) -> bool {
+        cache.map_or_else(|| self.is_valid(), |cache| cache.managed_path_is_valid(self))
     }
 }
 


### PR DESCRIPTION
## Summary\n- use timestamp snapshots for automatic build dependencies, matching webpack's warm-build strategy\n- validate timestamp-only module snapshots synchronously and reuse managed-path state\n\n## Validation\n- cargo check --workspace\n- cargo test -p unpack_core build_cache --lib\n- large fixture benchmark: unpack warm ~128ms vs rspack ~15ms (previous unpack warm ~500ms)