### PR TITLE
Emit usable assets for failed modules

### DIFF
--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -34,6 +34,11 @@ pub(crate) struct CodeGenerationResults {
     results: HashMap<ModuleId, CodeGenerationResult>,
 }
 
+pub(crate) struct CodeGenerationOutcome {
+    pub(crate) results: CodeGenerationResults,
+    pub(crate) errors: Vec<Error>,
+}
+
 impl CodeGenerationResults {
     pub(crate) fn runtime_requirements(
         &self,
@@ -132,15 +137,17 @@ enum InitFragmentStage {
 pub(crate) fn generate_code(
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
-) -> CodeGenerationResults {
+) -> CodeGenerationOutcome {
     generate_code_with(module_graph, chunk_graph, generate_module_code)
 }
 
 fn generate_code_with(
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
-    mut generate_module: impl FnMut(CodeGenerationInput<'_>) -> CodeGenerationResult,
-) -> CodeGenerationResults {
+    mut generate_module: impl FnMut(
+        CodeGenerationInput<'_>,
+    ) -> std::result::Result<CodeGenerationResult, Error>,
+) -> CodeGenerationOutcome {
     let module_render_ids = module_graph
         .modules()
         .iter()
@@ -159,6 +166,7 @@ fn generate_code_with(
         })
         .collect::<HashMap<_, _>>();
     let mut results = HashMap::new();
+    let mut errors = Vec::new();
     for module in module_graph
         .modules()
         .iter()
@@ -170,7 +178,13 @@ fn generate_code_with(
             chunk_graph,
             module_render_ids: &module_render_ids,
         };
-        let previous = results.insert(module.id(), generate_module(input));
+        let result = generate_module(input).unwrap_or_else(|error| {
+            errors.push(error.clone());
+            CodeGenerationResult::new(CodeGenerationSource::Raw {
+                source: render_failed_module_content(&error),
+            })
+        });
+        let previous = results.insert(module.id(), result);
         assert!(
             previous.is_none(),
             "module {:?} must be generated exactly once per Compilation",
@@ -178,9 +192,12 @@ fn generate_code_with(
         );
     }
 
-    CodeGenerationResults {
-        module_render_ids,
-        results,
+    CodeGenerationOutcome {
+        results: CodeGenerationResults {
+            module_render_ids,
+            results,
+        },
+        errors,
     }
 }
 
@@ -606,7 +623,9 @@ fn render_module_table(
     source
 }
 
-fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult {
+fn generate_module_code(
+    input: CodeGenerationInput<'_>,
+) -> std::result::Result<CodeGenerationResult, Error> {
     let CodeGenerationInput {
         module,
         module_graph,
@@ -614,9 +633,9 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
         module_render_ids,
     } = input;
     if let Some(error) = module.build_error() {
-        return CodeGenerationResult::new(CodeGenerationSource::Raw {
+        return Ok(CodeGenerationResult::new(CodeGenerationSource::Raw {
             source: render_failed_module_content(error),
-        });
+        }));
     }
 
     let module_id = module.id();
@@ -645,7 +664,7 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
             &mut runtime_requirements,
             &mut source,
             &mut init_fragments,
-        );
+        )?;
     }
     for (dependency_id, dependency) in module.dependencies().iter().enumerate() {
         apply_dependency_template(
@@ -660,7 +679,7 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
             &mut runtime_requirements,
             &mut source,
             &mut init_fragments,
-        );
+        )?;
     }
     for (block_index, block) in module.blocks().iter().enumerate() {
         for (dependency_id, dependency) in block.dependencies().iter().enumerate() {
@@ -676,23 +695,25 @@ fn generate_module_code(input: CodeGenerationInput<'_>) -> CodeGenerationResult 
                 &mut runtime_requirements,
                 &mut source,
                 &mut init_fragments,
-            );
+            )?;
         }
     }
 
     let init = render_init_fragments(init_fragments);
-    CodeGenerationResult::new(CodeGenerationSource::OriginalWithReplacements {
-        prefix: init,
-        original_source: module.source().to_string(),
-        original_name: module_render_name,
-        replacements: source
-            .replacements()
-            .iter()
-            .map(CodeGenerationReplacement::from)
-            .collect(),
-        suffix: String::new(),
-    })
-    .with_runtime_requirements(runtime_requirements)
+    Ok(
+        CodeGenerationResult::new(CodeGenerationSource::OriginalWithReplacements {
+            prefix: init,
+            original_source: module.source().to_string(),
+            original_name: module_render_name,
+            replacements: source
+                .replacements()
+                .iter()
+                .map(CodeGenerationReplacement::from)
+                .collect(),
+            suffix: String::new(),
+        })
+        .with_runtime_requirements(runtime_requirements),
+    )
 }
 
 fn render_failed_module_content(error: &Error) -> String {
@@ -744,7 +765,24 @@ fn apply_dependency_template(
     runtime_requirements: &mut RuntimeRequirements,
     source: &mut ReplaceSource,
     init_fragments: &mut Vec<InitFragment>,
-) {
+) -> std::result::Result<(), Error> {
+    let module = module_graph
+        .module(module_id)
+        .expect("Dependency Template origin Module must exist in the Module Graph");
+    for range in dependency.source_ranges() {
+        if range.start > range.end || range.end as usize > module.source_len() {
+            return Err(Error::CodeGeneration {
+                module: module_id,
+                path: module.identity().resource.clone(),
+                message: format!(
+                    "dependency source range {}..{} exceeds module source length {}",
+                    range.start,
+                    range.end,
+                    module.source_len()
+                ),
+            });
+        }
+    }
     match dependency {
         Dependency::Const(dep) => apply_const_dependency(dep, source),
         Dependency::Null(_) => {}
@@ -804,6 +842,7 @@ fn apply_dependency_template(
         }
         Dependency::Entry(_) => {}
     }
+    Ok(())
 }
 
 fn apply_const_dependency(dep: &ConstDependency, source: &mut ReplaceSource) {
@@ -1092,12 +1131,7 @@ fn is_identifier(value: &str) -> bool {
 }
 
 fn json_string(value: &str) -> String {
-    let escaped = value
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r");
-    format!("\"{escaped}\"")
+    simd_json::to_string(value).expect("JavaScript string input must serialize as JSON")
 }
 
 fn json_render_id(render_id: &RenderId) -> String {
@@ -1114,9 +1148,10 @@ mod tests {
     use rspack_sources::{ConcatSource, OriginalSource, Source};
 
     use crate::{
-        CacheOptions, Compiler, CompilerOptions, Entry, ModuleId, SnapshotOptions,
+        CacheOptions, Compiler, CompilerOptions, ConstDependency, Dependency, Entry, Error,
+        ModuleGraph, ModuleId, ModuleIdentity, SnapshotOptions, SourceRange,
         build_cache::{BuildCache, CacheIdentifier, CacheKey, CacheNamespace},
-        id_assignment::RenderId,
+        id_assignment::{RenderId, assign_chunk_render_ids, assign_module_render_ids},
         runtime::RuntimeModule,
     };
 
@@ -1212,6 +1247,48 @@ mod tests {
         })
     }
 
+    #[test]
+    fn module_attributable_generation_errors_become_throwing_results() {
+        let options = CompilerOptions::new("/project", vec![Entry::new("main", "./index")]);
+        let mut module_graph = ModuleGraph::default();
+        let module = module_graph.add_module(ModuleIdentity::new("/project/index.js"));
+        module_graph
+            .module_mut(module)
+            .expect("fixture Module should exist")
+            .finish_build(
+                Vec::new(),
+                Vec::new(),
+                vec![Dependency::Const(ConstDependency::new(
+                    "replacement",
+                    SourceRange::new(0, 99),
+                ))],
+                "value".to_string(),
+                1,
+            );
+        let mut chunk_graph = crate::ChunkGraph::build(&options, &module_graph, &[module]);
+        assign_module_render_ids(&options, &module_graph, &mut chunk_graph);
+        assign_chunk_render_ids(&options, &module_graph, &mut chunk_graph);
+
+        let outcome = super::generate_code(&module_graph, &chunk_graph);
+
+        assert_eq!(
+            outcome.errors,
+            [Error::CodeGeneration {
+                module,
+                path: "/project/index.js".into(),
+                message: "dependency source range 0..99 exceeds module source length 5".to_string(),
+            }]
+        );
+        assert!(outcome.errors[0].is_compilation_error());
+        assert!(
+            outcome.results.results[&module]
+                .source()
+                .source()
+                .into_string_lossy()
+                .contains("throw new Error")
+        );
+    }
+
     #[tokio::test]
     async fn code_generation_is_module_only_and_leaves_factory_wrapping_to_renderer()
     -> Result<(), Box<dyn std::error::Error>> {
@@ -1268,7 +1345,7 @@ mod tests {
             assert!(requirements.contains(RuntimeRequirement::ReturnExportsFromRuntime));
         }
         let mut generation_count = 0;
-        let results = super::generate_code_with(
+        let outcome = super::generate_code_with(
             compilation.module_graph(),
             compilation.chunk_graph(),
             |input| {
@@ -1276,6 +1353,8 @@ mod tests {
                 super::generate_module_code(input)
             },
         );
+        assert!(outcome.errors.is_empty());
+        let results = outcome.results;
 
         assert_eq!(generation_count, compilation.module_graph().modules().len());
         assert_eq!(
@@ -1304,6 +1383,45 @@ mod tests {
                 .runtime_requirements()
                 .contains(RuntimeRequirement::Require)
         }));
+
+        let failed_module = compilation
+            .module_graph()
+            .modules()
+            .iter()
+            .find(|module| module.identity().resource.ends_with("shared.js"))
+            .expect("fixture shared Module should exist");
+        let failed_path = failed_module.identity().resource.clone();
+        let failed_module = failed_module.id();
+        let failed = super::generate_code_with(
+            compilation.module_graph(),
+            compilation.chunk_graph(),
+            |input| {
+                if input.module.id() == failed_module {
+                    Err(Error::CodeGeneration {
+                        module: failed_module,
+                        path: input.module.identity().resource.clone(),
+                        message: "fixture generation failure".to_string(),
+                    })
+                } else {
+                    super::generate_module_code(input)
+                }
+            },
+        );
+        assert_eq!(
+            failed.errors,
+            [Error::CodeGeneration {
+                module: failed_module,
+                path: failed_path,
+                message: "fixture generation failure".to_string(),
+            }]
+        );
+        assert!(
+            failed.results.results[&failed_module]
+                .source()
+                .source()
+                .into_string_lossy()
+                .contains("fixture generation failure")
+        );
 
         Ok(())
     }

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -228,10 +228,9 @@ impl Compilation {
             self.render_ids_assigned,
             "Render IDs must be assigned before code generation"
         );
-        self.code_generation_results = Some(code_generation::generate_code(
-            &self.module_graph,
-            &self.chunk_graph,
-        ));
+        let outcome = code_generation::generate_code(&self.module_graph, &self.chunk_graph);
+        self.errors.extend(outcome.errors);
+        self.code_generation_results = Some(outcome.results);
         self.asset_render_manifest = None;
     }
 

--- a/crates/unpack_core/src/dependency.rs
+++ b/crates/unpack_core/src/dependency.rs
@@ -173,6 +173,34 @@ impl Dependency {
                 | Self::HarmonyExportImportedSpecifier(_)
         )
     }
+
+    pub(crate) fn source_ranges(&self) -> Vec<SourceRange> {
+        let mut ranges = Vec::new();
+        match self {
+            Self::Entry(_) | Self::HarmonyExportSpecifier(_) | Self::Null(_) => {}
+            Self::HarmonyImportSideEffect(dependency) => {
+                ranges.extend(dependency.module.range);
+            }
+            Self::HarmonyImportSpecifier(dependency) => {
+                ranges.extend(dependency.module.range);
+                ranges.push(dependency.usage_range);
+            }
+            Self::HarmonyExportHeader(dependency) => {
+                ranges.push(dependency.statement_range);
+                ranges.extend(dependency.declaration_range);
+            }
+            Self::HarmonyExportExpression(dependency) => {
+                ranges.push(dependency.statement_range);
+                ranges.push(dependency.range);
+            }
+            Self::HarmonyExportImportedSpecifier(dependency) => {
+                ranges.extend(dependency.module.range);
+            }
+            Self::Const(dependency) => ranges.push(dependency.range),
+            Self::Import(dependency) => ranges.extend(dependency.module.range),
+        }
+        ranges
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/unpack_core/src/error.rs
+++ b/crates/unpack_core/src/error.rs
@@ -39,6 +39,13 @@ pub enum Error {
 
     #[error("module {0:?} does not have a filesystem parent directory")]
     MissingModuleDirectory(ModuleId),
+
+    #[error("failed to generate {path} ({module:?}): {message}")]
+    CodeGeneration {
+        module: ModuleId,
+        path: PathBuf,
+        message: String,
+    },
 }
 
 impl Error {
@@ -49,6 +56,7 @@ impl Error {
                 | Self::Read { .. }
                 | Self::Parse { .. }
                 | Self::UnsupportedDynamicImport { .. }
+                | Self::CodeGeneration { .. }
         )
     }
 

--- a/crates/unpack_core/src/id_assignment.rs
+++ b/crates/unpack_core/src/id_assignment.rs
@@ -364,7 +364,7 @@ mod tests {
         assign_chunk_render_ids(&options, &module_graph, &mut chunk_graph);
 
         let build_cache = BuildCache::new(CacheOptions::memory(), SnapshotOptions::default());
-        let results = generate_code(&module_graph, &chunk_graph);
+        let results = generate_code(&module_graph, &chunk_graph).results;
         chunk_graph.process_runtime_requirements(
             results
                 .runtime_requirements()
@@ -410,7 +410,7 @@ mod tests {
         assign_chunk_render_ids(&options, &module_graph, &mut chunk_graph);
 
         let build_cache = BuildCache::new(CacheOptions::memory(), SnapshotOptions::default());
-        let results = generate_code(&module_graph, &chunk_graph);
+        let results = generate_code(&module_graph, &chunk_graph).results;
         chunk_graph.process_runtime_requirements(
             results
                 .runtime_requirements()

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -11,8 +11,8 @@ use napi::Result;
 use napi_derive::napi;
 use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
 use unpack_core::{
-    Asset, BuildDependency, CacheCompression, CacheIdleReason, CacheOptions, Compiler, CompilerOptions, Entry,
-    Error as CoreError, InfrastructureLogEvent, InfrastructureLogLevel,
+    Asset, BuildDependency, CacheCompression, CacheIdleReason, CacheOptions, Compiler,
+    CompilerOptions, Entry, Error as CoreError, InfrastructureLogEvent, InfrastructureLogLevel,
     InfrastructureLoggingOptions, SnapshotOptions, SnapshotPathPattern, SnapshotStrategy,
 };
 
@@ -584,6 +584,13 @@ fn stats_error(error: &CoreError) -> NativeStatsError {
         CoreError::MakeTask { message } => NativeStatsError {
             message: error.to_string(),
             path: None,
+            request: None,
+            issuer: None,
+            stack: Some(message.clone()),
+        },
+        CoreError::CodeGeneration { path, message, .. } => NativeStatsError {
+            message: error.to_string(),
+            path: Some(path.to_string_lossy().into_owned()),
             request: None,
             issuer: None,
             stack: Some(message.clone()),

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -47,15 +47,21 @@ Necessity:
 
 ## Make phase and errors
 
-Unpack uses `FuturesUnordered` plus a semaphore to factorize, read, parse, and connect modules. It records errors in `Compilation::errors`, but the first make error currently returns `Err` and stops the run.
+Unpack uses `FuturesUnordered` plus a semaphore to factorize, read, parse, and connect modules. Module-attributable make errors are recorded in `Compilation::errors`; infrastructure failures still return `Err` and stop the run.
 
-Webpack uses separate async queues for factorize, add, build, rebuild, and process-dependencies. It can keep a failed module in the graph, collect module errors on the compilation, and continue sealing/emitting where the compilation itself completed.
+Webpack uses separate async queues for factorize, add, build, rebuild, and
+process-dependencies. Unpack uses Rust-native tasks but now follows the same
+completed-compilation boundary: a module-attributable build or code-generation
+failure remains in the Module Graph, is reported through Stats, and renders as a
+throwing module factory. Unaffected entry code and deferred paths remain usable
+until execution reaches that factory.
 
 Necessity:
 
 - Rust-native queues are fine; copying webpack's `AsyncQueue` API is not needed.
-- The current stop-on-first module-processing error is a real parity gap against Unpack's own ADRs `0037`, `0042`, and `0052`.
-- Keeping failed modules in the graph and generating throwing module factories is necessary if the JavaScript API is expected to mirror webpack-like completed-compilation error semantics.
+- Missing Render IDs and malformed graph connections remain infrastructure
+  invariants and terminate compilation instead of being converted into module
+  failures.
 
 ## Dependency model and parser
 
@@ -150,7 +156,6 @@ Current staged scope limits:
 
 Implementation gaps to resolve for current stated semantics:
 
-- Completed-compilation error behavior: failed modules should remain in the graph and emitted code should throw only if executed.
 - Nested dynamic imports: async blocks discovered inside async chunks must create further async chunk groups.
 - Runtime requirements should either drive helper emission or be kept clearly internal until needed.
 

--- a/packages/unpack/test/e2e-cases/README.md
+++ b/packages/unpack/test/e2e-cases/README.md
@@ -18,3 +18,6 @@ Optional manifest fields:
 
 - `entry`: override the default `./src/index.js` entry.
 - `entryAsset`: override the default emitted `main.js` asset to require.
+- `expectedErrors`: require completed-compilation Stats errors containing these strings.
+- `expectedErrorCount`: require the exact number of completed-compilation errors.
+- `expectedAssets`: require the exact emitted Asset names.

--- a/packages/unpack/test/e2e-cases/failed-deferred-module/README.md
+++ b/packages/unpack/test/e2e-cases/failed-deferred-module/README.md
@@ -1,0 +1,5 @@
+# Deferred Failed Module
+
+Ported from webpack 5.108.1 `test/cases/runtime/error-handling` and adapted to
+Unpack's supported static-string dynamic import seam. The entry remains usable,
+while executing the deferred Failed Module exposes its compilation diagnostic.

--- a/packages/unpack/test/e2e-cases/failed-deferred-module/case.json
+++ b/packages/unpack/test/e2e-cases/failed-deferred-module/case.json
@@ -1,0 +1,7 @@
+{
+  "runtimeExpression": "entry.load().then(() => [entry.safe, false, false], error => [entry.safe, /failed to parse/.test(error.message), /broken\\.js/.test(error.message)])",
+  "expected": ["safe", true, true],
+  "expectedErrors": ["failed to parse", "broken.js"],
+  "expectedErrorCount": 1,
+  "expectedAssets": ["main.js", "src_broken_js.js"]
+}

--- a/packages/unpack/test/e2e-cases/failed-deferred-module/src/broken.js
+++ b/packages/unpack/test/e2e-cases/failed-deferred-module/src/broken.js
@@ -1,0 +1,1 @@
+export const = ;

--- a/packages/unpack/test/e2e-cases/failed-deferred-module/src/index.js
+++ b/packages/unpack/test/e2e-cases/failed-deferred-module/src/index.js
@@ -1,0 +1,2 @@
+export const safe = "safe";
+export const load = () => import("./broken");

--- a/packages/unpack/test/e2e.test.ts
+++ b/packages/unpack/test/e2e.test.ts
@@ -31,6 +31,9 @@ interface BundleExecutionCase {
   entryAsset?: string;
   runtimeExpression: string;
   expected: unknown;
+  expectedErrors?: string[];
+  expectedErrorCount?: number;
+  expectedAssets?: string[];
 }
 
 interface BundleExecutionCaseManifest {
@@ -38,6 +41,9 @@ interface BundleExecutionCaseManifest {
   entryAsset?: string;
   runtimeExpression: string;
   expected: unknown;
+  expectedErrors?: string[];
+  expectedErrorCount?: number;
+  expectedAssets?: string[];
 }
 
 const bundleExecutionCases = await readBundleExecutionCases();
@@ -61,13 +67,35 @@ async function runBundleExecutionCase(bundleCase: BundleExecutionCase) {
     });
 
     assert.equal(err, null);
-    assert.equal(stats?.hasErrors(), false);
+    const errors = stats?.toJson().errors ?? [];
+    if (bundleCase.expectedErrors === undefined && bundleCase.expectedErrorCount === undefined) {
+      assert.equal(stats?.hasErrors(), false);
+    } else {
+      if (bundleCase.expectedErrors !== undefined) {
+        assert.equal(stats?.hasErrors(), true);
+        for (const expectedError of bundleCase.expectedErrors) {
+          assert.ok(
+            errors.some((error) => error.message.includes(expectedError)),
+            `expected Stats error containing ${JSON.stringify(expectedError)}`
+          );
+        }
+      }
+      if (bundleCase.expectedErrorCount !== undefined) {
+        assert.equal(errors.length, bundleCase.expectedErrorCount);
+      }
+    }
     assert.ok(
       stats?.toJson().assets.some((asset) => asset.name === (bundleCase.entryAsset ?? defaultEntryAsset))
     );
     assert.ok(
       (await readdir(outputPath)).includes(bundleCase.entryAsset ?? defaultEntryAsset)
     );
+    if (bundleCase.expectedAssets !== undefined) {
+      assert.deepEqual(
+        stats?.toJson().assets.map((asset) => asset.name).sort(),
+        [...bundleCase.expectedAssets].sort()
+      );
+    }
 
     const result = await executeEntryExpression(
       outputPath,
@@ -198,6 +226,21 @@ function parseCaseManifest(id: string, source: string): BundleExecutionCaseManif
       typeof manifest.entryAsset,
       "string",
       `${id}/case.json entryAsset must be a string`
+    );
+  }
+  for (const field of ["expectedErrors", "expectedAssets"] as const) {
+    if (manifest[field] !== undefined) {
+      assert.ok(
+        Array.isArray(manifest[field]) && manifest[field].every((value) => typeof value === "string"),
+        `${id}/case.json ${field} must be an array of strings`
+      );
+    }
+  }
+  if (manifest.expectedErrorCount !== undefined) {
+    assert.equal(
+      Number.isInteger(manifest.expectedErrorCount) && manifest.expectedErrorCount >= 0,
+      true,
+      `${id}/case.json expectedErrorCount must be a non-negative integer`
     );
   }
 


### PR DESCRIPTION
Closes #168

Keep module-attributable code-generation failures in the compilation graph and Stats while emitting throwing factories and usable assets for unaffected and deferred paths. Adds webpack-derived deferred failure coverage through the public Node API.