### PR TITLE
Drive Node chunk loading from runtime requirements

### DIFF
--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     hash::{Hash, Hasher},
 };
 
@@ -18,6 +18,7 @@ use crate::{
         CodeGenerationReplacement, CodeGenerationResult, CodeGenerationSource,
     },
     id_assignment::RenderId,
+    output_filename::resolve_chunk_filename,
     rendered_source::RenderedSource,
     runtime::{RuntimeModule, RuntimeModuleContext, RuntimeRequirement, RuntimeRequirements},
 };
@@ -72,8 +73,6 @@ enum AssetRenderManifest {
     InitialChunk {
         modules: Vec<ModuleRenderManifest>,
         runtime_modules: Vec<RenderedRuntimeModule>,
-        use_legacy_async_runtime: bool,
-        chunk_filename_map: String,
         entry_id: RenderId,
         chunk_id: RenderId,
     },
@@ -223,7 +222,7 @@ pub(crate) fn create_render_manifest(
             .copied()
             .expect("Entrypoint must have an Entry Module before manifest creation");
         let modules = module_render_manifest(chunk_graph, chunk, code_generation_results);
-        let runtime_tree_requirements = chunk_graph
+        chunk_graph
             .runtime_tree_requirements(group_id)
             .expect("Runtime Requirements must be processed before manifest creation");
         let runtime_context = RuntimeModuleContext {
@@ -243,9 +242,6 @@ pub(crate) fn create_render_manifest(
             render: AssetRenderManifest::InitialChunk {
                 modules,
                 runtime_modules,
-                use_legacy_async_runtime: runtime_tree_requirements
-                    .contains(RuntimeRequirement::EnsureChunk),
-                chunk_filename_map: render_chunk_filename_map(chunk_graph),
                 entry_id: code_generation_results
                     .module_render_ids
                     .get(&entry_module)
@@ -334,16 +330,12 @@ impl AssetRenderManifest {
             Self::InitialChunk {
                 modules,
                 runtime_modules,
-                use_legacy_async_runtime,
-                chunk_filename_map,
                 entry_id,
                 chunk_id,
             } => {
                 hasher.write_u8(0);
                 hash_module_render_inputs(modules, code_generation_results, &mut hasher);
                 runtime_modules.hash(&mut hasher);
-                use_legacy_async_runtime.hash(&mut hasher);
-                chunk_filename_map.hash(&mut hasher);
                 entry_id.hash(&mut hasher);
                 chunk_id.hash(&mut hasher);
             }
@@ -417,19 +409,9 @@ fn render_asset(
         AssetRenderManifest::InitialChunk {
             modules,
             runtime_modules,
-            use_legacy_async_runtime,
-            chunk_filename_map,
             entry_id,
-            chunk_id,
-        } => render_initial_asset(
-            modules,
-            runtime_modules,
-            *use_legacy_async_runtime,
-            chunk_filename_map,
-            entry_id,
-            chunk_id,
-            code_generation_results,
-        ),
+            chunk_id: _,
+        } => render_initial_asset(modules, runtime_modules, entry_id, code_generation_results),
         AssetRenderManifest::AsyncChunk { modules, chunk_id } => {
             render_async_chunk_asset(modules, chunk_id, code_generation_results)
         }
@@ -471,10 +453,7 @@ fn emit_asset(filename: String, rendered: &RenderedSource, sourcemap: bool) -> V
 fn render_initial_asset(
     modules: &[ModuleRenderManifest],
     runtime_modules: &[RenderedRuntimeModule],
-    use_legacy_async_runtime: bool,
-    chunk_filename_map: &str,
     entry_id: &RenderId,
-    chunk_id: &RenderId,
     code_generation_results: &CodeGenerationResults,
 ) -> ConcatSource {
     let modules = render_module_table(modules, code_generation_results);
@@ -507,68 +486,12 @@ function __webpack_require__(moduleId) {
 "#
         .to_string(),
     ));
-    if use_legacy_async_runtime {
-        let chunk_id = json_render_id(chunk_id);
-        source.add(RawStringSource::from(format!(
-            r#"__webpack_require__.m = __webpack_modules__;
-__webpack_require__.d = function(exports, definition) {{
-  for(var key in definition) {{
-    if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {{
-      Object.defineProperty(exports, key, {{ enumerable: true, get: definition[key] }});
-    }}
-  }}
-}};
-__webpack_require__.o = function(obj, prop) {{ return Object.prototype.hasOwnProperty.call(obj, prop); }};
-__webpack_require__.r = function(exports) {{
-  if(typeof Symbol !== "undefined" && Symbol.toStringTag) {{
-    Object.defineProperty(exports, Symbol.toStringTag, {{ value: "Module" }});
-  }}
-  Object.defineProperty(exports, "__esModule", {{ value: true }});
-}};
-__webpack_require__.u = function(chunkId) {{
-  return ({{{chunk_filename_map}}})[chunkId];
-}};
-__webpack_require__.f = {{}};
-__webpack_require__.e = function(chunkId) {{
-  return Promise.all(Object.keys(__webpack_require__.f).reduce(function(promises, key) {{
-    __webpack_require__.f[key](chunkId, promises);
-    return promises;
-  }}, []));
-}};
-var installedChunks = {{
-  {chunk_id}: 1
-}};
-var installChunk = function(chunk) {{
-  var moreModules = chunk.modules, chunkIds = chunk.ids, runtime = chunk.runtime;
-  for(var moduleId in moreModules) {{
-    if(__webpack_require__.o(moreModules, moduleId)) {{
-      __webpack_require__.m[moduleId] = moreModules[moduleId];
-    }}
-  }}
-  if(runtime) runtime(__webpack_require__);
-  for(var i = 0; i < chunkIds.length; i++) {{
-    installedChunks[chunkIds[i]] = 1;
-  }}
-}};
-__webpack_require__.f.require = function(chunkId, promises) {{
-  if(!installedChunks[chunkId]) {{
-    var installedChunk = require("./" + __webpack_require__.u(chunkId));
-    if(!installedChunks[chunkId]) {{
-      installChunk(installedChunk);
-    }}
-  }}
-}};
-module.exports = __webpack_require__({entry_id});
-"#,
-        )));
-    } else {
-        for runtime_module in runtime_modules {
-            source.add(RawStringSource::from(runtime_module.source.clone()));
-        }
-        source.add(RawStringSource::from(format!(
-            "module.exports = __webpack_require__({entry_id});\n"
-        )));
+    for runtime_module in runtime_modules {
+        source.add(RawStringSource::from(runtime_module.source.clone()));
     }
+    source.add(RawStringSource::from(format!(
+        "module.exports = __webpack_require__({entry_id});\n"
+    )));
     source
 }
 
@@ -1019,9 +942,6 @@ fn apply_import_dependency(
     };
     let expression = if let Some(group_id) = chunk_graph.block_chunk_group(origin) {
         runtime_requirements.insert(RuntimeRequirement::EnsureChunk);
-        runtime_requirements.insert(RuntimeRequirement::GetChunkFilename);
-        runtime_requirements.insert(RuntimeRequirement::ModuleFactories);
-        runtime_requirements.insert(RuntimeRequirement::HasOwnProperty);
         let group = &chunk_graph.chunk_groups()[group_id.index()];
         let chunk_id = group
             .chunks()
@@ -1045,30 +965,6 @@ fn apply_import_dependency(
 
 fn replace(source: &mut ReplaceSource, range: SourceRange, content: String) {
     source.replace(range.start, range.end, content, None);
-}
-
-fn render_chunk_filename_map(chunk_graph: &ChunkGraph) -> String {
-    let mut entries = BTreeMap::new();
-    for chunk in chunk_graph.chunks() {
-        entries.insert(chunk.render_id().clone(), resolve_chunk_filename(chunk));
-    }
-    entries
-        .into_iter()
-        .map(|(chunk_id, filename)| {
-            format!("{}: {}", json_render_id(&chunk_id), json_string(&filename))
-        })
-        .collect::<Vec<_>>()
-        .join(", ")
-}
-
-fn resolve_chunk_filename(chunk: &Chunk) -> String {
-    if let Some(filename) = chunk.filename_override() {
-        return filename.to_string();
-    }
-    match chunk.name() {
-        Some(name) => format!("{name}.js"),
-        None => format!("{}.js", chunk.render_id()),
-    }
 }
 
 fn import_var(request: &str, source_order: usize) -> String {
@@ -1157,8 +1053,8 @@ mod tests {
 
     use super::{
         AssetRenderKey, AssetRenderKind, AssetRenderManifest, CodeGenerationResult,
-        CodeGenerationResults, CodeGenerationSource, ModuleRenderManifest, RenderedSource,
-        RuntimeRequirement, emit_asset,
+        CodeGenerationResults, CodeGenerationSource, ModuleRenderManifest, RenderedRuntimeModule,
+        RenderedSource, RuntimeRequirement, emit_asset,
     };
 
     #[test]
@@ -1221,17 +1117,19 @@ mod tests {
 
         let initial = AssetRenderManifest::InitialChunk {
             modules: Vec::new(),
-            runtime_modules: Vec::new(),
-            use_legacy_async_runtime: false,
-            chunk_filename_map: "{\"feature\":\"feature.js\"}".to_string(),
+            runtime_modules: vec![RenderedRuntimeModule {
+                module: RuntimeModule::GetChunkFilename,
+                source: "return feature.js".to_string(),
+            }],
             entry_id: RenderId::String("./src/index.js".to_string()),
             chunk_id: RenderId::String("main".to_string()),
         };
         let changed_filename_map = AssetRenderManifest::InitialChunk {
             modules: Vec::new(),
-            runtime_modules: Vec::new(),
-            use_legacy_async_runtime: false,
-            chunk_filename_map: "{\"feature\":\"renamed.js\"}".to_string(),
+            runtime_modules: vec![RenderedRuntimeModule {
+                module: RuntimeModule::GetChunkFilename,
+                source: "return renamed.js".to_string(),
+            }],
             entry_id: RenderId::String("./src/index.js".to_string()),
             chunk_id: RenderId::String("main".to_string()),
         };

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -14,6 +14,7 @@ mod make;
 mod module;
 mod module_graph;
 mod normal_module_factory;
+mod output_filename;
 mod pack_file;
 mod parser;
 mod rendered_source;

--- a/crates/unpack_core/src/output_filename.rs
+++ b/crates/unpack_core/src/output_filename.rs
@@ -1,0 +1,11 @@
+use crate::Chunk;
+
+pub(crate) fn resolve_chunk_filename(chunk: &Chunk) -> String {
+    if let Some(filename) = chunk.filename_override() {
+        return filename.to_string();
+    }
+    match chunk.name() {
+        Some(name) => format!("{name}.js"),
+        None => format!("{}.js", chunk.render_id()),
+    }
+}

--- a/crates/unpack_core/src/runtime.rs
+++ b/crates/unpack_core/src/runtime.rs
@@ -1,6 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::{ChunkGraph, ChunkId};
+use crate::{
+    ChunkGraph, ChunkId, id_assignment::RenderId, output_filename::resolve_chunk_filename,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) enum RuntimeRequirement {
@@ -11,7 +13,9 @@ pub(crate) enum RuntimeRequirement {
     HasOwnProperty,
     MakeNamespaceObject,
     EnsureChunk,
+    EnsureChunkHandlers,
     GetChunkFilename,
+    ModuleFactoriesAddOnly,
     ReturnExportsFromRuntime,
 }
 
@@ -25,6 +29,7 @@ impl RuntimeRequirements {
         self.requirements.insert(requirement)
     }
 
+    #[cfg(test)]
     pub(crate) fn contains(&self, requirement: RuntimeRequirement) -> bool {
         self.requirements.contains(&requirement)
     }
@@ -56,8 +61,12 @@ const RUNTIME_MODULE_STAGE_ORDER: [RuntimeModuleStage; 4] = [
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum RuntimeModule {
     DefinePropertyGetters,
+    EnsureChunk,
+    GetChunkFilename,
     HasOwnProperty,
     MakeNamespaceObject,
+    ModuleFactoriesAddOnly,
+    RequireChunkLoading,
 }
 
 pub(crate) struct RuntimeModuleContext<'a> {
@@ -69,23 +78,40 @@ impl RuntimeModule {
     pub(crate) fn identifier(self) -> &'static str {
         match self {
             Self::DefinePropertyGetters => "webpack/runtime/define property getters",
+            Self::EnsureChunk => "webpack/runtime/ensure chunk",
+            Self::GetChunkFilename => "webpack/runtime/get javascript chunk filename",
             Self::HasOwnProperty => "webpack/runtime/hasOwnProperty shorthand",
             Self::MakeNamespaceObject => "webpack/runtime/make namespace object",
+            Self::ModuleFactoriesAddOnly => "webpack/runtime/module factories add only",
+            Self::RequireChunkLoading => "webpack/runtime/require chunk loading",
         }
     }
 
     pub(crate) fn stage(self) -> RuntimeModuleStage {
         match self {
-            Self::HasOwnProperty | Self::DefinePropertyGetters | Self::MakeNamespaceObject => {
-                RuntimeModuleStage::Normal
-            }
+            Self::DefinePropertyGetters
+            | Self::GetChunkFilename
+            | Self::HasOwnProperty
+            | Self::MakeNamespaceObject
+            | Self::ModuleFactoriesAddOnly => RuntimeModuleStage::Normal,
+            Self::EnsureChunk => RuntimeModuleStage::Basic,
+            Self::RequireChunkLoading => RuntimeModuleStage::Attach,
         }
     }
 
     fn prerequisites(self) -> &'static [RuntimeRequirement] {
         match self {
             Self::DefinePropertyGetters => &[RuntimeRequirement::HasOwnProperty],
-            Self::HasOwnProperty | Self::MakeNamespaceObject => &[],
+            Self::EnsureChunk => &[RuntimeRequirement::EnsureChunkHandlers],
+            Self::RequireChunkLoading => &[
+                RuntimeRequirement::GetChunkFilename,
+                RuntimeRequirement::ModuleFactoriesAddOnly,
+                RuntimeRequirement::HasOwnProperty,
+            ],
+            Self::GetChunkFilename
+            | Self::HasOwnProperty
+            | Self::MakeNamespaceObject
+            | Self::ModuleFactoriesAddOnly => &[],
         }
     }
 
@@ -115,6 +141,57 @@ impl RuntimeModule {
 };
 "#
             .to_string(),
+            Self::EnsureChunk => r#"__webpack_require__.f = {};
+__webpack_require__.e = function(chunkId) {
+  return Promise.all(Object.keys(__webpack_require__.f).reduce(function(promises, key) {
+    __webpack_require__.f[key](chunkId, promises);
+    return promises;
+  }, []));
+};
+"#
+            .to_string(),
+            Self::GetChunkFilename => {
+                let filename_map = render_chunk_filename_map(context.chunk_graph);
+                format!(
+                    "__webpack_require__.u = function(chunkId) {{\n  return ({{{filename_map}}})[chunkId];\n}};\n"
+                )
+            }
+            Self::ModuleFactoriesAddOnly => {
+                "__webpack_require__.m = __webpack_modules__;\n".to_string()
+            }
+            Self::RequireChunkLoading => {
+                let runtime_chunk = context
+                    .chunk_graph
+                    .chunk(context.runtime_chunk)
+                    .expect("Require Chunk Loading must reference an existing runtime Chunk");
+                let chunk_id = json_render_id(runtime_chunk.render_id());
+                format!(
+                    r#"var installedChunks = {{
+  {chunk_id}: 1
+}};
+var installChunk = function(chunk) {{
+  var moreModules = chunk.modules, chunkIds = chunk.ids, runtime = chunk.runtime;
+  for(var moduleId in moreModules) {{
+    if(__webpack_require__.o(moreModules, moduleId)) {{
+      __webpack_require__.m[moduleId] = moreModules[moduleId];
+    }}
+  }}
+  if(runtime) runtime(__webpack_require__);
+  for(var i = 0; i < chunkIds.length; i++) {{
+    installedChunks[chunkIds[i]] = 1;
+  }}
+}};
+__webpack_require__.f.require = function(chunkId, promises) {{
+  if(!installedChunks[chunkId]) {{
+    var installedChunk = require("./" + __webpack_require__.u(chunkId));
+    if(!installedChunks[chunkId]) {{
+      installChunk(installedChunk);
+    }}
+  }}
+}};
+"#
+                )
+            }
         }
     }
 }
@@ -131,11 +208,15 @@ pub(crate) fn resolve_runtime_modules(
             RuntimeRequirement::DefinePropertyGetters => Some(RuntimeModule::DefinePropertyGetters),
             RuntimeRequirement::HasOwnProperty => Some(RuntimeModule::HasOwnProperty),
             RuntimeRequirement::MakeNamespaceObject => Some(RuntimeModule::MakeNamespaceObject),
+            RuntimeRequirement::EnsureChunk => Some(RuntimeModule::EnsureChunk),
+            RuntimeRequirement::EnsureChunkHandlers => Some(RuntimeModule::RequireChunkLoading),
+            RuntimeRequirement::GetChunkFilename => Some(RuntimeModule::GetChunkFilename),
+            RuntimeRequirement::ModuleFactoriesAddOnly => {
+                Some(RuntimeModule::ModuleFactoriesAddOnly)
+            }
             RuntimeRequirement::ModuleFactories
             | RuntimeRequirement::ModuleCache
             | RuntimeRequirement::Require
-            | RuntimeRequirement::EnsureChunk
-            | RuntimeRequirement::GetChunkFilename
             | RuntimeRequirement::ReturnExportsFromRuntime => None,
         };
         let Some(module) = module else {
@@ -158,6 +239,33 @@ pub(crate) fn resolve_runtime_modules(
         (stage, module.identifier())
     });
     (requirements, modules)
+}
+
+fn render_chunk_filename_map(chunk_graph: &ChunkGraph) -> String {
+    let mut entries = BTreeMap::new();
+    for chunk in chunk_graph.chunks() {
+        entries.insert(chunk.render_id().clone(), resolve_chunk_filename(chunk));
+    }
+    entries
+        .into_iter()
+        .map(|(chunk_id, filename)| {
+            format!(
+                "{}: {}",
+                json_render_id(&chunk_id),
+                simd_json::to_string(&filename)
+                    .expect("Chunk filename must serialize as a JavaScript string")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn json_render_id(render_id: &RenderId) -> String {
+    match render_id {
+        RenderId::String(value) => simd_json::to_string(value)
+            .expect("Chunk Render ID must serialize as a JavaScript string"),
+        RenderId::Number(value) => value.to_string(),
+    }
 }
 
 fn insert_runtime_module(
@@ -207,6 +315,31 @@ mod tests {
                 .iter()
                 .all(|module| module.stage() == RuntimeModuleStage::Normal)
         );
+    }
+
+    #[test]
+    fn chunk_ensure_selects_the_complete_node_require_runtime_in_stage_order() {
+        let mut direct = RuntimeRequirements::default();
+        direct.insert(RuntimeRequirement::EnsureChunk);
+
+        let (closed, modules) = resolve_runtime_modules(&direct);
+
+        assert!(closed.contains(RuntimeRequirement::EnsureChunkHandlers));
+        assert!(closed.contains(RuntimeRequirement::GetChunkFilename));
+        assert!(closed.contains(RuntimeRequirement::ModuleFactoriesAddOnly));
+        assert!(closed.contains(RuntimeRequirement::HasOwnProperty));
+        assert_eq!(
+            modules,
+            [
+                RuntimeModule::GetChunkFilename,
+                RuntimeModule::HasOwnProperty,
+                RuntimeModule::ModuleFactoriesAddOnly,
+                RuntimeModule::EnsureChunk,
+                RuntimeModule::RequireChunkLoading,
+            ]
+        );
+        assert_eq!(modules[3].stage(), RuntimeModuleStage::Basic);
+        assert_eq!(modules[4].stage(), RuntimeModuleStage::Attach);
     }
 
     #[test]

--- a/crates/unpack_core/tests/codegen.rs
+++ b/crates/unpack_core/tests/codegen.rs
@@ -274,7 +274,7 @@ async fn produces_stable_static_async_and_sourcemap_outputs()
     assert_eq!(
         fingerprints,
         [
-            ("main.js", 3166, 13406043872577102803),
+            ("main.js", 3166, 6672719859425331571),
             ("main.js.map", 480, 5745374754696300241),
             ("src_feature_js.js", 398, 7014656015713497901),
             ("src_feature_js.js.map", 164, 2414748877879059404)
@@ -371,8 +371,34 @@ async fn emits_node_require_chunks_for_dynamic_import() -> Result<(), Box<dyn st
     assert!(main.source.contains("__webpack_require__.e"));
     assert!(main.source.contains("__webpack_require__.f.require"));
     assert!(main.source.contains("__webpack_require__.u"));
+    assert!(
+        main.source
+            .contains("__webpack_require__.m = __webpack_modules__")
+    );
+    assert!(main.source.contains("__webpack_require__.o"));
     assert!(main.source.contains("__webpack_require__.d"));
     assert!(main.source.contains("__webpack_require__.r"));
+    assert!(
+        main.source
+            .contains(r#"__webpack_require__.e("src_feature_js").then(__webpack_require__.bind"#)
+    );
+    assert!(
+        main.source
+            .contains(r#"require("./" + __webpack_require__.u(chunkId))"#)
+    );
+    let register_factory = main
+        .source
+        .find("__webpack_require__.m[moduleId] = moreModules[moduleId]")
+        .expect("Require Chunk Loading must register payload factories");
+    let execute_runtime = main
+        .source
+        .find("if(runtime) runtime(__webpack_require__)")
+        .expect("Require Chunk Loading must execute an optional payload runtime");
+    let mark_loaded = main
+        .source
+        .find("installedChunks[chunkIds[i]] = 1")
+        .expect("Require Chunk Loading must mark payload chunk IDs loaded");
+    assert!(register_factory < execute_runtime && execute_runtime < mark_loaded);
     assert!(main.source.contains("./src/index.js"));
     assert!(main.source.contains("//# sourceMappingURL=main.js.map"));
 

--- a/docs/adr/0021-use-runtime-requirements.md
+++ b/docs/adr/0021-use-runtime-requirements.md
@@ -10,6 +10,9 @@ deduplicates Runtime Modules, and orders them by the Normal, Basic, Attach, and
 Trigger stages followed by stable identifier. Asset creation renders only the
 selected modules. Runtime Requirements and Runtime Modules are closed enums, so
 unknown capabilities fail exhaustive compilation and conflicting stable module
-identifiers fail explicitly during resolution. The remaining legacy asynchronous Node runtime is retained
-only for Entrypoint runtime trees that require chunk ensuring until its dedicated
-migration.
+identifiers fail explicitly during resolution. Entrypoint runtime trees with
+loadable Async Chunks now select Ensure Chunk at the Basic stage and the
+cohesive Require Chunk Loading module at the Attach stage. Transitive
+requirements provide the handler collection, filename lookup, add-only module
+factory exposure, and own-property support. The former monolithic asynchronous
+Node runtime path has been removed.

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -105,20 +105,22 @@ Necessity:
 Unpack emits webpack-shaped Node/CommonJS output with a fixed module table,
 module cache, core `__webpack_require__`, and CommonJS entry startup. Generated
 code declares Runtime Requirements; a fixed-point resolver selects ordered
-Runtime Modules for export getters, own-property checks, and namespace marking.
-Static-only Bundles therefore omit chunk ensure, filename lookup, handler, and
-Node loading code. Entrypoints with dynamic imports temporarily retain the
-legacy `__webpack_require__.e`, `__webpack_require__.f.require`,
-`__webpack_require__.u`, and require-based async chunk installation path. Source
-maps remain available for generated assets.
+Runtime Modules for export getters, own-property checks, namespace marking,
+chunk ensuring, filename lookup, add-only module-factory exposure, and cohesive
+Node require chunk loading. Static-only Bundles omit all asynchronous helpers.
+For runtime trees with loadable Async Chunks, the Node loader registers payload
+factories, executes optional payload runtime, then marks every payload chunk ID
+loaded; load and runtime failures leave installation retryable. Asset emission
+and filename lookup share one fixed id-based JavaScript filename resolver.
+Source maps remain available for generated assets.
 
 Webpack renders runtime behavior through runtime modules and runtime requirements. Its Node require chunk loading module computes output paths, conditions loading on chunk type, handles installed chunk state, supports optional on-chunk-load hooks, external install hooks, HMR, base URI, and generated filename templates.
 
 Necessity:
 
 - Starting with fixed Node require chunk loading is intentional and covered by ADR `0032`.
-- Runtime Requirements now drive the implemented static Runtime Modules. The
-  legacy asynchronous runtime remains a staged migration gap.
+- Runtime Requirements drive both static helpers and the implemented Node
+  require Chunk Loading Runtime; the legacy monolithic async path is removed.
 - Browser JSONP, ESM chunk loading, HMR, public path, chunk filename templates, and external chunk installation are future target features, not current requirements.
 
 ## ESM code generation

--- a/packages/unpack/test/e2e-cases/async-chunk-retry/README.md
+++ b/packages/unpack/test/e2e-cases/async-chunk-retry/README.md
@@ -1,0 +1,10 @@
+# Async chunk retry and install ordering case
+
+Ported from webpack 5.108.1 `test/configCases/web/retry-failed-import` for the
+retry contract and `lib/node/RequireChunkLoadingRuntimeModule.js` for Node
+payload installation order. The fixture adapts the web retry case to Unpack's
+fixed Node target and static-string import, removes the emitted payload for the
+first attempt, and adds a transient payload runtime for the second. It proves
+through the public JavaScript API and an isolated Node process that load failures
+and payload-runtime failures remain retryable, factories exist before payload
+runtime execution, and chunk IDs are marked loaded only after runtime success.

--- a/packages/unpack/test/e2e-cases/async-chunk-retry/case.json
+++ b/packages/unpack/test/e2e-cases/async-chunk-retry/case.json
@@ -1,5 +1,5 @@
 {
   "runtimeExpression": "require('../runner.cjs')(entry)",
-  "expected": ["entry:async:feature-ok", "entry:async:feature-ok", 1],
+  "expected": [true, "transient payload runtime", "feature", 2, "feature"],
   "expectedAssets": ["main.js", "src_feature_js.js"]
 }

--- a/packages/unpack/test/e2e-cases/async-chunk-retry/runner.cjs
+++ b/packages/unpack/test/e2e-cases/async-chunk-retry/runner.cjs
@@ -1,0 +1,49 @@
+const fs = require("fs");
+const path = require("path");
+
+const payloadRuntime = `
+exports.runtime = function(__webpack_require__) {
+  global.__runtimeAttempts = (global.__runtimeAttempts || 0) + 1;
+  global.__runtimeSawFactory = __webpack_require__("./src/feature.js").value;
+  if(global.__runtimeAttempts === 1) throw new Error("transient payload runtime");
+};
+`;
+
+module.exports = async function run(entry) {
+  const attempt = () => Promise.resolve().then(() => entry.load());
+  const chunk = path.join(process.cwd(), "src_feature_js.js");
+  const backup = `${chunk}.backup`;
+  fs.renameSync(chunk, backup);
+
+  let loadError;
+  try {
+    await attempt();
+  } catch (error) {
+    loadError = error;
+  }
+  if (loadError === undefined) {
+    throw new Error("missing chunk load unexpectedly succeeded");
+  }
+
+  fs.renameSync(backup, chunk);
+  fs.appendFileSync(chunk, payloadRuntime);
+
+  let runtimeError;
+  try {
+    await attempt();
+  } catch (error) {
+    runtimeError = error;
+  }
+  if (runtimeError === undefined) {
+    throw new Error("failing payload runtime unexpectedly succeeded");
+  }
+
+  const module = await attempt();
+  return [
+    loadError.code === "MODULE_NOT_FOUND",
+    runtimeError.message,
+    module.value,
+    global.__runtimeAttempts,
+    global.__runtimeSawFactory
+  ];
+};

--- a/packages/unpack/test/e2e-cases/async-chunk-retry/src/feature.js
+++ b/packages/unpack/test/e2e-cases/async-chunk-retry/src/feature.js
@@ -1,0 +1,1 @@
+export const value = "feature";

--- a/packages/unpack/test/e2e-cases/async-chunk-retry/src/index.js
+++ b/packages/unpack/test/e2e-cases/async-chunk-retry/src/index.js
@@ -1,0 +1,3 @@
+export function load() {
+  return import("./feature");
+}

--- a/packages/unpack/test/e2e-cases/async-chunk/README.md
+++ b/packages/unpack/test/e2e-cases/async-chunk/README.md
@@ -1,0 +1,7 @@
+# Async chunk load-once case
+
+Ported from webpack 5.108.1
+`test/configCases/target/node-dynamic-import`. The fixture is adapted to
+Unpack's supported static-string dynamic imports and verifies Promise exports,
+emitted assets, and one successful CommonJS payload load through the public
+JavaScript API and an isolated Node process.

--- a/packages/unpack/test/e2e-cases/async-chunk/runner.cjs
+++ b/packages/unpack/test/e2e-cases/async-chunk/runner.cjs
@@ -1,0 +1,18 @@
+const Module = require("module");
+
+module.exports = async function run(entry) {
+  const originalLoad = Module._load;
+  let chunkLoads = 0;
+  Module._load = function countAsyncPayloadLoads(request, parent, isMain) {
+    if (request.endsWith("src_feature_js.js")) chunkLoads += 1;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    const first = await entry.run();
+    const second = await entry.run();
+    return [first, second, chunkLoads];
+  } finally {
+    Module._load = originalLoad;
+  }
+};


### PR DESCRIPTION
Closes #169

Replace the legacy async runtime branch with staged Runtime Modules for chunk ensuring, filename lookup, add-only factory exposure, and cohesive Node require loading. Successful payloads install once; require and payload-runtime failures remain retryable, with factories registered before runtime and chunk IDs marked loaded afterward.

Adds webpack 5.108.1-derived public API cases for Promise results, Asset names, load-once behavior, installation order, and retry.