### PR TITLE
Make shared async chunks safe across entries

### DIFF
--- a/crates/unpack_core/src/chunk_graph.rs
+++ b/crates/unpack_core/src/chunk_graph.rs
@@ -178,6 +178,18 @@ pub struct AsyncBlockOrigin {
     pub block_index: usize,
 }
 
+struct EntrypointAsyncPlan {
+    group: ChunkGroupId,
+    available_modules: HashSet<ModuleId>,
+    origins: Vec<(AsyncBlockOrigin, ModuleId)>,
+}
+
+struct SharedAsyncPlan {
+    target: ModuleId,
+    available_modules: HashSet<ModuleId>,
+    parents: Vec<(ChunkGroupId, AsyncBlockOrigin)>,
+}
+
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct ChunkGraph {
     chunks: Vec<Chunk>,
@@ -200,7 +212,7 @@ impl ChunkGraph {
         entries: &[ModuleId],
     ) -> Self {
         let mut graph = Self::default();
-        let mut async_groups_by_target = HashMap::new();
+        let mut entrypoint_plans = Vec::new();
         for (entry_index, entry_module) in entries.iter().copied().enumerate() {
             let entry_name = options
                 .entries
@@ -222,8 +234,8 @@ impl ChunkGraph {
                 graph.connect_chunk_and_module(entry_chunk, *module);
             }
 
-            let initial_set = initial_modules.iter().copied().collect::<HashSet<_>>();
-            let mut async_origins = Vec::new();
+            let available_modules = initial_modules.iter().copied().collect::<HashSet<_>>();
+            let mut origins = Vec::new();
             for module in &initial_modules {
                 if let Some(module_ref) = module_graph.module(*module) {
                     for (block_index, block) in module_ref.blocks().iter().enumerate() {
@@ -232,48 +244,77 @@ impl ChunkGraph {
                             .iter()
                             .any(|dep| dep.is_import_dependency())
                         {
-                            async_origins.push(AsyncBlockOrigin {
+                            let origin = AsyncBlockOrigin {
                                 module: *module,
                                 block_index,
-                            });
+                            };
+                            if let Some(target) = import_block_target(module_graph, origin) {
+                                origins.push((origin, target));
+                            }
                         }
                     }
                 }
             }
 
-            for origin in async_origins {
-                let Some(target) = import_block_target(module_graph, origin) else {
-                    continue;
-                };
-                let async_modules =
-                    collect_static_reachable(module_graph, target, Some(&initial_set));
-                if async_modules.is_empty() {
-                    continue;
-                }
+            entrypoint_plans.push(EntrypointAsyncPlan {
+                group: entry_group,
+                available_modules,
+                origins,
+            });
+        }
 
-                let async_group = if let Some(group) = async_groups_by_target.get(&target).copied()
-                {
-                    group
+        let mut shared_plans = HashMap::<ModuleId, SharedAsyncPlan>::new();
+        for entrypoint in entrypoint_plans {
+            for (origin, target) in entrypoint.origins {
+                if let Some(plan) = shared_plans.get_mut(&target) {
+                    plan.available_modules
+                        .retain(|module| entrypoint.available_modules.contains(module));
+                    plan.parents.push((entrypoint.group, origin));
                 } else {
-                    let chunk = graph.add_chunk(None, vec![target]);
-                    let group = graph.add_chunk_group(ChunkGroupKind::Async, Some(origin));
-                    graph.connect_chunk_and_group(chunk, group);
-                    async_groups_by_target.insert(target, group);
-                    group
-                };
-
-                if let Some(chunk) = graph.chunk_groups()[async_group.index()]
-                    .chunks()
-                    .first()
-                    .copied()
-                {
-                    for module in async_modules {
-                        graph.connect_chunk_and_module(chunk, module);
-                    }
+                    shared_plans.insert(
+                        target,
+                        SharedAsyncPlan {
+                            target,
+                            available_modules: entrypoint.available_modules.clone(),
+                            parents: vec![(entrypoint.group, origin)],
+                        },
+                    );
                 }
+            }
+        }
 
+        let mut shared_plans = shared_plans.into_values().collect::<Vec<_>>();
+        shared_plans.sort_by(|left, right| {
+            let left_identity = module_graph
+                .module(left.target)
+                .expect("Shared Async target must exist in the Module Graph")
+                .identity();
+            let right_identity = module_graph
+                .module(right.target)
+                .expect("Shared Async target must exist in the Module Graph")
+                .identity();
+            left_identity.cmp(right_identity)
+        });
+        for plan in shared_plans {
+            let async_modules =
+                collect_static_reachable(module_graph, plan.target, Some(&plan.available_modules));
+            if async_modules.is_empty() {
+                continue;
+            }
+            let origin = plan
+                .parents
+                .first()
+                .map(|(_, origin)| *origin)
+                .expect("Shared Async Plan must have at least one parent origin");
+            let chunk = graph.add_chunk(None, vec![plan.target]);
+            let async_group = graph.add_chunk_group(ChunkGroupKind::Async, Some(origin));
+            graph.connect_chunk_and_group(chunk, async_group);
+            for module in async_modules {
+                graph.connect_chunk_and_module(chunk, module);
+            }
+            for (parent, origin) in plan.parents {
                 graph.block_chunk_groups.insert(origin, async_group);
-                graph.connect_chunk_groups(entry_group, async_group);
+                graph.connect_chunk_groups(parent, async_group);
             }
         }
 

--- a/crates/unpack_core/src/module.rs
+++ b/crates/unpack_core/src/module.rs
@@ -128,7 +128,7 @@ impl Module {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ModuleIdentity {
     pub module_type: ModuleType,
     pub resource: PathBuf,
@@ -151,7 +151,7 @@ impl ModuleIdentity {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum ModuleType {
     JavaScriptAuto,
 }

--- a/crates/unpack_core/tests/codegen.rs
+++ b/crates/unpack_core/tests/codegen.rs
@@ -591,6 +591,10 @@ async fn reused_async_chunk_contains_modules_needed_by_each_entry()
                 const mod = await import("./feature");
                 return [shared, mod.feature, mod.shared];
             }
+
+            export async function loadExtra() {
+                return (await import("./extra")).extra;
+            }
         "#,
     )?;
     write(
@@ -599,6 +603,10 @@ async fn reused_async_chunk_contains_modules_needed_by_each_entry()
             export async function load() {
                 const mod = await import("./feature");
                 return [mod.feature, mod.shared];
+            }
+
+            export async function loadExtra() {
+                return (await import("./extra")).extra;
             }
         "#,
     )?;
@@ -614,12 +622,72 @@ async fn reused_async_chunk_contains_modules_needed_by_each_entry()
         temp.path().join("src/shared.js"),
         r#"export const shared = "shared";"#,
     )?;
+    write(
+        temp.path().join("src/extra.js"),
+        r#"export const extra = "extra";"#,
+    )?;
 
     let compiler = Compiler::new(CompilerOptions::new(
         temp.path(),
         vec![Entry::new("a", "./src/a"), Entry::new("b", "./src/b")],
     ));
     let compilation = compiler.run().await?;
+    let async_asset = compilation
+        .assets()
+        .iter()
+        .find(|asset| asset.filename == "src_feature_js.js")
+        .expect("shared Async Chunk asset should exist");
+    assert!(async_asset.source.contains(r#""./src/feature.js": "#));
+    assert!(
+        async_asset.source.contains(r#""./src/shared.js": "#),
+        "a module available on only one parent path must remain in the shared Async Chunk"
+    );
+
+    let one_parent = Compiler::new(CompilerOptions::new(
+        temp.path(),
+        vec![Entry::new("a", "./src/a")],
+    ))
+    .run()
+    .await?;
+    let one_parent_async_asset = one_parent
+        .assets()
+        .iter()
+        .find(|asset| asset.filename == "src_feature_js.js")
+        .expect("one parent should emit its Async Chunk");
+    assert!(
+        !one_parent_async_asset
+            .source
+            .contains(r#""./src/shared.js": "#),
+        "a module available on the only parent path should be excluded"
+    );
+
+    let reversed = Compiler::new(CompilerOptions::new(
+        temp.path(),
+        vec![Entry::new("b", "./src/b"), Entry::new("a", "./src/a")],
+    ))
+    .run()
+    .await?;
+    let async_assets = compilation
+        .assets()
+        .iter()
+        .filter(|asset| {
+            asset.filename != "a.js" && asset.filename != "b.js" && asset.filename.ends_with(".js")
+        })
+        .map(|asset| (asset.filename.as_str(), asset.source.as_str()))
+        .collect::<Vec<_>>();
+    let reversed_async_assets = reversed
+        .assets()
+        .iter()
+        .filter(|asset| {
+            asset.filename != "a.js" && asset.filename != "b.js" && asset.filename.ends_with(".js")
+        })
+        .map(|asset| (asset.filename.as_str(), asset.source.as_str()))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        async_assets, reversed_async_assets,
+        "multiple shared Async targets must be stable across parent discovery order"
+    );
+
     let out_dir = temp.path().join("dist");
     fs::create_dir_all(&out_dir)?;
     write_assets(&out_dir, compilation.assets())?;

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -89,14 +89,22 @@ Necessity:
 
 ## Chunk graph
 
-Unpack creates one entrypoint chunk group per entry, assigns statically reachable modules to the initial chunk, creates or reuses async chunk groups for dynamic import targets, excludes modules already present in the parent initial chunk, and stores many-to-many module/chunk membership.
+Unpack creates one entrypoint chunk group per entry, assigns statically reachable
+modules to the initial chunk, and creates or reuses async chunk groups by dynamic
+import target. Shared Async Chunk planning is two-phase: it intersects the modules
+available on every parent Entrypoint path, then emits the target's static closure
+minus that intersection. Modules available on only some parents therefore remain
+in the shared payload. Each Entrypoint keeps its own Runtime Modules and installed
+chunk state while requirements from the shared child group propagate to every
+reachable runtime tree.
 
 Webpack's `buildChunkGraph` is much broader. It tracks runtime per chunk group, chunk loading and async chunk flags, named async chunk reuse, async entrypoints, available-module masks, skipped modules, conditional connections, nested blocks, pre/post order indices, child/parent updates, and block-to-chunk-group links.
 
 Necessity:
 
 - Unpack's chunk group and many-to-many membership model is necessary because it preserves the shape needed for later split chunks and runtime chunks.
-- Excluding parent initial modules is necessary for basic async chunk correctness.
+- Intersecting parent available-module sets is necessary: excluding a module
+  seen on only one path would make the shared payload unusable from another.
 - Split chunks, cache groups, min-size/min-chunks/max-request rules, runtime chunks, and named chunk options are not necessary for the first implementation.
 - Nested async blocks are a current required semantic: Unpack only scans async blocks found in initial modules when creating async groups, while webpack recursively processes nested dependency blocks. A dynamic import reachable from an async chunk must create its own async chunk group; ignoring it is a parity gap against Unpack's chosen dynamic import semantics, not a compatibility luxury.
 

--- a/packages/unpack/test/e2e-cases/shared-async-chunk/README.md
+++ b/packages/unpack/test/e2e-cases/shared-async-chunk/README.md
@@ -1,0 +1,9 @@
+# Shared async chunk across entrypoints
+
+Ported from webpack 5.108.1 `test/configCases/chunk-graph/issue-9634` and the
+Node dynamic-import behavior in
+`test/configCases/target/node-dynamic-import`. The fixture adapts the scenarios
+to Unpack's fixed Node target: one parent already has `shared`, the other does
+not, both execute the same Async Chunk, and each Entrypoint runtime independently
+requests and installs the payload through the public JavaScript API and an
+isolated Node process.

--- a/packages/unpack/test/e2e-cases/shared-async-chunk/case.json
+++ b/packages/unpack/test/e2e-cases/shared-async-chunk/case.json
@@ -1,0 +1,10 @@
+{
+  "entry": {
+    "a": "./src/a.js",
+    "b": "./src/b.js"
+  },
+  "entryAsset": "a.js",
+  "runtimeExpression": "require('../runner.cjs')()",
+  "expected": [["a", "feature", "shared"], ["b", "feature", "shared"], 2],
+  "expectedAssets": ["a.js", "b.js", "src_feature_js.js"]
+}

--- a/packages/unpack/test/e2e-cases/shared-async-chunk/runner.cjs
+++ b/packages/unpack/test/e2e-cases/shared-async-chunk/runner.cjs
@@ -1,0 +1,21 @@
+const Module = require("module");
+const path = require("path");
+
+module.exports = async function run() {
+  const originalLoad = Module._load;
+  let chunkLoads = 0;
+  Module._load = function countSharedPayloadLoads(request, parent, isMain) {
+    if (request.endsWith("src_feature_js.js")) chunkLoads += 1;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    require(path.join(process.cwd(), "a.js"));
+    require(path.join(process.cwd(), "b.js"));
+    const fromA = await globalThis.loadA();
+    const fromB = await globalThis.loadB();
+    return [fromA, fromB, chunkLoads];
+  } finally {
+    Module._load = originalLoad;
+  }
+};

--- a/packages/unpack/test/e2e-cases/shared-async-chunk/src/a.js
+++ b/packages/unpack/test/e2e-cases/shared-async-chunk/src/a.js
@@ -1,0 +1,6 @@
+import { shared } from "./shared";
+
+globalThis.loadA = async function loadA() {
+  const feature = await import("./feature");
+  return ["a", feature.value, shared];
+};

--- a/packages/unpack/test/e2e-cases/shared-async-chunk/src/b.js
+++ b/packages/unpack/test/e2e-cases/shared-async-chunk/src/b.js
@@ -1,0 +1,4 @@
+globalThis.loadB = async function loadB() {
+  const feature = await import("./feature");
+  return ["b", feature.value, feature.shared];
+};

--- a/packages/unpack/test/e2e-cases/shared-async-chunk/src/feature.js
+++ b/packages/unpack/test/e2e-cases/shared-async-chunk/src/feature.js
@@ -1,0 +1,4 @@
+import { shared } from "./shared";
+
+export const value = "feature";
+export { shared };

--- a/packages/unpack/test/e2e-cases/shared-async-chunk/src/shared.js
+++ b/packages/unpack/test/e2e-cases/shared-async-chunk/src/shared.js
@@ -1,0 +1,1 @@
+export const shared = "shared";


### PR DESCRIPTION
Closes #170

Plan shared Async Chunks from the intersection of modules available on every parent Entrypoint path, then materialize plans in stable Module Identity order. Modules available on only some paths stay in the payload, requirements reach each runtime tree, and installed-chunk state remains entry-local.

Adds webpack 5.108.1-derived public Node coverage plus focused monotonicity and parent-order determinism checks.