### PR TITLE
Support nested async splits and back edges

### DIFF
--- a/crates/unpack_core/src/chunk_graph.rs
+++ b/crates/unpack_core/src/chunk_graph.rs
@@ -1,4 +1,7 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, HashSet, VecDeque},
+};
 
 use crate::{
     CompilerOptions, ModuleGraph, ModuleId,
@@ -181,13 +184,88 @@ pub struct AsyncBlockOrigin {
 struct EntrypointAsyncPlan {
     group: ChunkGroupId,
     available_modules: HashSet<ModuleId>,
-    origins: Vec<(AsyncBlockOrigin, ModuleId)>,
+    modules: Vec<ModuleId>,
 }
 
-struct SharedAsyncPlan {
-    target: ModuleId,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum LogicalChunkGroup {
+    Entrypoint(usize),
+    Async(ModuleId),
+}
+
+struct AsyncParentPlan {
     available_modules: HashSet<ModuleId>,
-    parents: Vec<(ChunkGroupId, AsyncBlockOrigin)>,
+    origins: Vec<AsyncBlockOrigin>,
+}
+
+struct AsyncChunkPlan {
+    target: ModuleId,
+    static_modules: Vec<ModuleId>,
+    available_before: HashSet<ModuleId>,
+    available_after: HashSet<ModuleId>,
+    parents: HashMap<LogicalChunkGroup, AsyncParentPlan>,
+}
+
+impl AsyncChunkPlan {
+    fn new(
+        target: ModuleId,
+        static_modules: Vec<ModuleId>,
+        parent: LogicalChunkGroup,
+        parent_available: &HashSet<ModuleId>,
+        origin: AsyncBlockOrigin,
+    ) -> Self {
+        let available_before = parent_available.clone();
+        let mut available_after = available_before.clone();
+        available_after.extend(static_modules.iter().copied());
+        Self {
+            target,
+            static_modules,
+            available_before,
+            available_after,
+            parents: HashMap::from([(
+                parent,
+                AsyncParentPlan {
+                    available_modules: parent_available.clone(),
+                    origins: vec![origin],
+                },
+            )]),
+        }
+    }
+
+    fn add_parent(
+        &mut self,
+        parent: LogicalChunkGroup,
+        parent_available: &HashSet<ModuleId>,
+        origin: AsyncBlockOrigin,
+    ) -> bool {
+        let parent_plan = self
+            .parents
+            .entry(parent)
+            .or_insert_with(|| AsyncParentPlan {
+                available_modules: parent_available.clone(),
+                origins: Vec::new(),
+            });
+        parent_plan.available_modules = parent_available.clone();
+        if !parent_plan.origins.contains(&origin) {
+            parent_plan.origins.push(origin);
+        }
+
+        let mut parents = self.parents.values();
+        let mut available_before = parents
+            .next()
+            .map(|parent| parent.available_modules.clone())
+            .expect("Async Chunk Plan must retain at least one parent");
+        for parent in parents {
+            available_before.retain(|module| parent.available_modules.contains(module));
+        }
+        let mut available_after = available_before.clone();
+        available_after.extend(self.static_modules.iter().copied());
+        let changed =
+            self.available_before != available_before || self.available_after != available_after;
+        self.available_before = available_before;
+        self.available_after = available_after;
+        changed
+    }
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -199,6 +277,8 @@ pub struct ChunkGraph {
     module_chunks: Vec<Vec<ChunkId>>,
     module_render_ids: Vec<Option<RenderId>>,
     block_chunk_groups: HashMap<AsyncBlockOrigin, ChunkGroupId>,
+    // Includes logical loading edges omitted from the materialized graph to break cycles.
+    runtime_chunk_group_children: Vec<Vec<ChunkGroupId>>,
     module_runtime_requirements: Vec<RuntimeRequirements>,
     chunk_runtime_requirements: Vec<RuntimeRequirements>,
     runtime_tree_requirements: HashMap<ChunkGroupId, RuntimeRequirements>,
@@ -234,87 +314,111 @@ impl ChunkGraph {
                 graph.connect_chunk_and_module(entry_chunk, *module);
             }
 
-            let available_modules = initial_modules.iter().copied().collect::<HashSet<_>>();
-            let mut origins = Vec::new();
-            for module in &initial_modules {
-                if let Some(module_ref) = module_graph.module(*module) {
-                    for (block_index, block) in module_ref.blocks().iter().enumerate() {
-                        if block
-                            .dependencies()
-                            .iter()
-                            .any(|dep| dep.is_import_dependency())
-                        {
-                            let origin = AsyncBlockOrigin {
-                                module: *module,
-                                block_index,
-                            };
-                            if let Some(target) = import_block_target(module_graph, origin) {
-                                origins.push((origin, target));
-                            }
-                        }
-                    }
-                }
-            }
-
             entrypoint_plans.push(EntrypointAsyncPlan {
                 group: entry_group,
-                available_modules,
-                origins,
+                available_modules: initial_modules.iter().copied().collect(),
+                modules: initial_modules,
             });
         }
 
-        let mut shared_plans = HashMap::<ModuleId, SharedAsyncPlan>::new();
-        for entrypoint in entrypoint_plans {
-            for (origin, target) in entrypoint.origins {
-                if let Some(plan) = shared_plans.get_mut(&target) {
-                    plan.available_modules
-                        .retain(|module| entrypoint.available_modules.contains(module));
-                    plan.parents.push((entrypoint.group, origin));
+        let mut async_plans = HashMap::<ModuleId, AsyncChunkPlan>::new();
+        let mut pending = (0..entrypoint_plans.len())
+            .map(LogicalChunkGroup::Entrypoint)
+            .collect::<VecDeque<_>>();
+        while let Some(parent) = pending.pop_front() {
+            let (parent_modules, parent_available) = match parent {
+                LogicalChunkGroup::Entrypoint(index) => (
+                    entrypoint_plans[index].modules.clone(),
+                    entrypoint_plans[index].available_modules.clone(),
+                ),
+                LogicalChunkGroup::Async(target) => {
+                    let plan = async_plans
+                        .get(&target)
+                        .expect("pending Async Chunk Plan must exist");
+                    (
+                        plan.static_modules
+                            .iter()
+                            .filter(|module| !plan.available_before.contains(module))
+                            .copied()
+                            .collect(),
+                        plan.available_after.clone(),
+                    )
+                }
+            };
+
+            for (origin, target) in
+                dynamic_import_origins(module_graph, parent_modules.iter().copied())
+            {
+                if parent_available.contains(&target) {
+                    continue;
+                }
+                if let Some(plan) = async_plans.get_mut(&target) {
+                    if plan.add_parent(parent, &parent_available, origin) {
+                        pending.push_back(LogicalChunkGroup::Async(target));
+                    }
                 } else {
-                    shared_plans.insert(
+                    let static_modules = collect_static_reachable(module_graph, target, None);
+                    async_plans.insert(
                         target,
-                        SharedAsyncPlan {
+                        AsyncChunkPlan::new(
                             target,
-                            available_modules: entrypoint.available_modules.clone(),
-                            parents: vec![(entrypoint.group, origin)],
-                        },
+                            static_modules,
+                            parent,
+                            &parent_available,
+                            origin,
+                        ),
                     );
+                    pending.push_back(LogicalChunkGroup::Async(target));
                 }
             }
         }
 
-        let mut shared_plans = shared_plans.into_values().collect::<Vec<_>>();
-        shared_plans.sort_by(|left, right| {
-            let left_identity = module_graph
-                .module(left.target)
-                .expect("Shared Async target must exist in the Module Graph")
-                .identity();
-            let right_identity = module_graph
-                .module(right.target)
-                .expect("Shared Async target must exist in the Module Graph")
-                .identity();
-            left_identity.cmp(right_identity)
-        });
-        for plan in shared_plans {
-            let async_modules =
-                collect_static_reachable(module_graph, plan.target, Some(&plan.available_modules));
-            if async_modules.is_empty() {
-                continue;
-            }
+        let mut ordered_targets = async_plans.keys().copied().collect::<Vec<_>>();
+        ordered_targets
+            .sort_by(|left, right| compare_module_identities(module_graph, *left, *right));
+
+        let mut materialized_groups = HashMap::new();
+        for target in &ordered_targets {
+            let plan = &async_plans[target];
             let origin = plan
                 .parents
-                .first()
-                .map(|(_, origin)| *origin)
-                .expect("Shared Async Plan must have at least one parent origin");
+                .values()
+                .flat_map(|parent| parent.origins.iter().copied())
+                .min_by(|left, right| compare_async_origins(module_graph, *left, *right))
+                .expect("Async Chunk Plan must have at least one parent origin");
             let chunk = graph.add_chunk(None, vec![plan.target]);
-            let async_group = graph.add_chunk_group(ChunkGroupKind::Async, Some(origin));
-            graph.connect_chunk_and_group(chunk, async_group);
-            for module in async_modules {
-                graph.connect_chunk_and_module(chunk, module);
+            let group = graph.add_chunk_group(ChunkGroupKind::Async, Some(origin));
+            graph.connect_chunk_and_group(chunk, group);
+            for module in plan
+                .static_modules
+                .iter()
+                .filter(|module| !plan.available_before.contains(module))
+            {
+                graph.connect_chunk_and_module(chunk, *module);
             }
-            for (parent, origin) in plan.parents {
-                graph.block_chunk_groups.insert(origin, async_group);
-                graph.connect_chunk_groups(parent, async_group);
+            materialized_groups.insert(*target, group);
+        }
+
+        for target in ordered_targets {
+            let child_group = materialized_groups[&target];
+            let plan = &async_plans[&target];
+            let mut parents = plan.parents.iter().collect::<Vec<_>>();
+            parents.sort_by(|(left, _), (right, _)| {
+                compare_logical_groups(module_graph, **left, **right)
+            });
+            for (parent, parent_plan) in parents {
+                let parent_group = match parent {
+                    LogicalChunkGroup::Entrypoint(index) => entrypoint_plans[*index].group,
+                    LogicalChunkGroup::Async(target) => materialized_groups[target],
+                };
+                if !chunk_group_reaches(&graph, child_group, parent_group) {
+                    graph.connect_chunk_groups(parent_group, child_group);
+                } else {
+                    graph.connect_runtime_chunk_groups(parent_group, child_group);
+                }
+                for origin in &parent_plan.origins {
+                    graph.block_chunk_groups.insert(*origin, child_group);
+                }
             }
         }
 
@@ -338,6 +442,7 @@ impl ChunkGraph {
     ) -> ChunkGroupId {
         let id = ChunkGroupId::new(self.chunk_groups.len());
         self.chunk_groups.push(ChunkGroup::new(id, kind, origin));
+        self.runtime_chunk_group_children.push(Vec::new());
         id
     }
 
@@ -349,6 +454,13 @@ impl ChunkGraph {
     fn connect_chunk_groups(&mut self, parent: ChunkGroupId, child: ChunkGroupId) {
         self.chunk_groups[parent.index()].add_child(child);
         self.chunk_groups[child.index()].add_parent(parent);
+        self.connect_runtime_chunk_groups(parent, child);
+    }
+
+    fn connect_runtime_chunk_groups(&mut self, parent: ChunkGroupId, child: ChunkGroupId) {
+        if !self.runtime_chunk_group_children[parent.index()].contains(&child) {
+            self.runtime_chunk_group_children[parent.index()].push(child);
+        }
     }
 
     pub fn split_chunk(
@@ -471,7 +583,11 @@ impl ChunkGraph {
                 for chunk in group.chunks() {
                     requirements.extend(&self.chunk_runtime_requirements[chunk.index()]);
                 }
-                pending.extend(group.children().iter().copied());
+                pending.extend(
+                    self.runtime_chunk_group_children[group_id.index()]
+                        .iter()
+                        .copied(),
+                );
             }
             requirements.extend(&entry_startup_runtime_requirements());
             let (processed, modules) = resolve_runtime_modules(&requirements);
@@ -544,6 +660,102 @@ fn collect_static_reachable(
     }
 
     modules
+}
+
+fn dynamic_import_origins(
+    module_graph: &ModuleGraph,
+    modules: impl IntoIterator<Item = ModuleId>,
+) -> Vec<(AsyncBlockOrigin, ModuleId)> {
+    let mut origins = Vec::new();
+    for module in modules {
+        let module_ref = module_graph
+            .module(module)
+            .expect("Chunk planning must reference an existing Module");
+        for (block_index, block) in module_ref.blocks().iter().enumerate() {
+            if !block
+                .dependencies()
+                .iter()
+                .any(|dependency| dependency.is_import_dependency())
+            {
+                continue;
+            }
+            let origin = AsyncBlockOrigin {
+                module,
+                block_index,
+            };
+            if let Some(target) = import_block_target(module_graph, origin) {
+                origins.push((origin, target));
+            }
+        }
+    }
+    origins.sort_by(|(left_origin, left_target), (right_origin, right_target)| {
+        compare_async_origins(module_graph, *left_origin, *right_origin)
+            .then_with(|| compare_module_identities(module_graph, *left_target, *right_target))
+    });
+    origins.dedup();
+    origins
+}
+
+fn compare_async_origins(
+    module_graph: &ModuleGraph,
+    left: AsyncBlockOrigin,
+    right: AsyncBlockOrigin,
+) -> Ordering {
+    compare_module_identities(module_graph, left.module, right.module)
+        .then(left.block_index.cmp(&right.block_index))
+}
+
+fn compare_logical_groups(
+    module_graph: &ModuleGraph,
+    left: LogicalChunkGroup,
+    right: LogicalChunkGroup,
+) -> Ordering {
+    match (left, right) {
+        (LogicalChunkGroup::Entrypoint(left), LogicalChunkGroup::Entrypoint(right)) => {
+            left.cmp(&right)
+        }
+        (LogicalChunkGroup::Entrypoint(_), LogicalChunkGroup::Async(_)) => Ordering::Less,
+        (LogicalChunkGroup::Async(_), LogicalChunkGroup::Entrypoint(_)) => Ordering::Greater,
+        (LogicalChunkGroup::Async(left), LogicalChunkGroup::Async(right)) => {
+            compare_module_identities(module_graph, left, right)
+        }
+    }
+}
+
+fn compare_module_identities(
+    module_graph: &ModuleGraph,
+    left: ModuleId,
+    right: ModuleId,
+) -> Ordering {
+    let left_identity = module_graph
+        .module(left)
+        .expect("Chunk planning order must reference an existing Module")
+        .identity();
+    let right_identity = module_graph
+        .module(right)
+        .expect("Chunk planning order must reference an existing Module")
+        .identity();
+    left_identity.cmp(right_identity)
+}
+
+fn chunk_group_reaches(graph: &ChunkGraph, start: ChunkGroupId, target: ChunkGroupId) -> bool {
+    let mut visited = HashSet::new();
+    let mut pending = VecDeque::from([start]);
+    while let Some(group) = pending.pop_front() {
+        if group == target {
+            return true;
+        }
+        if !visited.insert(group) {
+            continue;
+        }
+        pending.extend(
+            graph.chunk_groups()[group.index()]
+                .children()
+                .iter()
+                .copied(),
+        );
+    }
+    false
 }
 
 fn import_block_target(module_graph: &ModuleGraph, origin: AsyncBlockOrigin) -> Option<ModuleId> {

--- a/crates/unpack_core/tests/codegen.rs
+++ b/crates/unpack_core/tests/codegen.rs
@@ -4,7 +4,7 @@ use std::{
     process::Command,
 };
 
-use unpack_core::{ChunkGroupKind, Compiler, CompilerOptions, Entry};
+use unpack_core::{AsyncBlockOrigin, ChunkGroupKind, Compiler, CompilerOptions, Entry};
 
 #[tokio::test]
 async fn seal_orchestrates_post_make_phases() -> Result<(), Box<dyn std::error::Error>> {
@@ -726,11 +726,294 @@ async fn reused_async_chunk_contains_modules_needed_by_each_entry()
     Ok(())
 }
 
+// Ported from webpack 5.108.1:
+// test/cases/chunks/nested-blocks-with-available-parent-modules
+// test/cases/chunks/nested-in-empty
+#[tokio::test]
+async fn nested_async_groups_terminate_and_collapse_available_back_edges()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    write(
+        temp.path().join("src/index.js"),
+        r#"globalThis.loadA = () => import("./a");"#,
+    )?;
+    write(
+        temp.path().join("src/a.js"),
+        r#"
+            globalThis.aValue = "a";
+            globalThis.loadB = () => import("./b");
+        "#,
+    )?;
+    write(
+        temp.path().join("src/b.js"),
+        r#"
+            export const value = "b";
+            export const loadA = () => import("./a");
+        "#,
+    )?;
+
+    let compilation = Compiler::new(CompilerOptions::new(
+        temp.path(),
+        vec![Entry::new("main", "./src/index")],
+    ))
+    .run()
+    .await?;
+    assert_eq!(
+        compilation
+            .assets()
+            .iter()
+            .filter(|asset| asset.filename.ends_with(".js"))
+            .map(|asset| asset.filename.as_str())
+            .collect::<Vec<_>>(),
+        ["main.js", "src_a_js.js", "src_b_js.js"]
+    );
+    let main_asset = compilation
+        .assets()
+        .iter()
+        .find(|asset| asset.filename == "main.js")
+        .expect("Initial Asset must exist");
+    assert!(main_asset.source.contains("__webpack_require__.d"));
+    assert!(main_asset.source.contains("__webpack_require__.r"));
+
+    let chunk_graph = compilation.chunk_graph();
+    assert_eq!(chunk_graph.chunk_groups().len(), 3);
+    let entry = chunk_graph.entrypoints()[0];
+    let a_group = chunk_graph.chunk_groups()[entry.index()].children()[0];
+    let b_group = chunk_graph.chunk_groups()[a_group.index()].children()[0];
+    assert!(
+        chunk_graph.chunk_groups()[b_group.index()]
+            .children()
+            .is_empty()
+    );
+    assert_eq!(
+        chunk_graph.chunk_groups()[a_group.index()].parents(),
+        [entry]
+    );
+    assert_eq!(
+        chunk_graph.chunk_groups()[b_group.index()].parents(),
+        [a_group]
+    );
+
+    let b_module = compilation
+        .module_graph()
+        .modules()
+        .iter()
+        .find(|module| module.identity().resource.ends_with("b.js"))
+        .expect("fixture B Module must exist");
+    assert_eq!(b_module.blocks().len(), 1);
+    assert_eq!(
+        chunk_graph.block_chunk_group(AsyncBlockOrigin {
+            module: b_module.id(),
+            block_index: 0,
+        }),
+        None,
+        "B-to-A edge must collapse because A is already available on the loading path"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn shared_async_cross_imports_do_not_materialize_a_group_cycle()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    write(
+        temp.path().join("src/entry-a.js"),
+        r#"globalThis.loadDirectA = () => import("./a");"#,
+    )?;
+    write(
+        temp.path().join("src/entry-b.js"),
+        r#"globalThis.loadDirectB = () => import("./b");"#,
+    )?;
+    write(
+        temp.path().join("src/a.js"),
+        r#"
+            globalThis.aValue = "a";
+            globalThis.loadNestedB = () => import("./b");
+        "#,
+    )?;
+    write(
+        temp.path().join("src/b.js"),
+        r#"
+            export const value = "b";
+            export const loadA = () => import("./a");
+        "#,
+    )?;
+
+    let compilation = Compiler::new(CompilerOptions::new(
+        temp.path(),
+        vec![
+            Entry::new("entry-a", "./src/entry-a"),
+            Entry::new("entry-b", "./src/entry-b"),
+        ],
+    ))
+    .run()
+    .await?;
+    let chunk_graph = compilation.chunk_graph();
+    assert_eq!(chunk_graph.chunk_groups().len(), 4);
+    let entry_a = chunk_graph.entrypoints()[0];
+    let entry_b = chunk_graph.entrypoints()[1];
+    let a_group = chunk_graph.chunk_groups()[entry_a.index()].children()[0];
+    let b_group = chunk_graph.chunk_groups()[entry_b.index()].children()[0];
+    let left_children = chunk_graph.chunk_groups()[a_group.index()].children();
+    let right_children = chunk_graph.chunk_groups()[b_group.index()].children();
+    assert_eq!(left_children.len() + right_children.len(), 1);
+    assert!(
+        !(left_children.contains(&b_group) && right_children.contains(&a_group)),
+        "globally reused Async targets must not create reciprocal Chunk Group edges"
+    );
+    for entry_asset in ["entry-a.js", "entry-b.js"] {
+        let source = &compilation
+            .assets()
+            .iter()
+            .find(|asset| asset.filename == entry_asset)
+            .expect("Entrypoint Asset must exist")
+            .source;
+        assert!(source.contains("__webpack_require__.d"));
+        assert!(source.contains("__webpack_require__.r"));
+    }
+
+    let reversed = Compiler::new(CompilerOptions::new(
+        temp.path(),
+        vec![
+            Entry::new("entry-b", "./src/entry-b"),
+            Entry::new("entry-a", "./src/entry-a"),
+        ],
+    ))
+    .run()
+    .await?;
+    assert_eq!(
+        chunk_group_topology(&compilation),
+        chunk_group_topology(&reversed),
+        "Chunk Group origins and retained materialized edges must use stable identities"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn nested_shared_parent_shrink_rescans_newly_required_modules()
+-> Result<(), Box<dyn std::error::Error>> {
+    let context = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../packages/unpack/test/e2e-cases/nested-shared-requeue")
+        .canonicalize()?;
+    let compilation = Compiler::new(CompilerOptions::new(
+        &context,
+        vec![Entry::new("main", "./src/index")],
+    ))
+    .run()
+    .await?;
+    let c_asset = compilation
+        .assets()
+        .iter()
+        .find(|asset| asset.filename == "src_c_js.js")
+        .expect("shared nested C Asset must exist");
+    assert!(
+        c_asset.source.contains(r#""./src/x.js": "#),
+        "X must be added when C's second parent shrinks the available intersection"
+    );
+
+    let find_module = |filename: &str| {
+        compilation
+            .module_graph()
+            .modules()
+            .iter()
+            .find(|module| module.identity().resource.ends_with(filename))
+            .map(|module| module.id())
+            .unwrap_or_else(|| panic!("fixture Module {filename} must exist"))
+    };
+    let p = find_module("p.js");
+    let q = find_module("q.js");
+    let x = find_module("x.js");
+    let chunk_graph = compilation.chunk_graph();
+    let c_from_p = chunk_graph
+        .block_chunk_group(AsyncBlockOrigin {
+            module: p,
+            block_index: 0,
+        })
+        .expect("P-to-C must map to an Async Chunk Group");
+    let c_from_q = chunk_graph
+        .block_chunk_group(AsyncBlockOrigin {
+            module: q,
+            block_index: 0,
+        })
+        .expect("Q-to-C must reuse the Async Chunk Group");
+    assert_eq!(c_from_p, c_from_q);
+    assert_eq!(
+        chunk_graph.chunk_groups()[c_from_p.index()].parents().len(),
+        2
+    );
+
+    let y_group = chunk_graph
+        .block_chunk_group(AsyncBlockOrigin {
+            module: x,
+            block_index: 0,
+        })
+        .expect("rescanning X must retain its nested Y split point");
+    assert!(
+        chunk_graph.chunk_groups()[y_group.index()]
+            .parents()
+            .contains(&c_from_p),
+        "requeued C must become a parent of X's nested Y group"
+    );
+
+    Ok(())
+}
+
 fn write(path: PathBuf, source: &str) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
     fs::write(path, source)
+}
+
+fn chunk_group_topology(
+    compilation: &unpack_core::Compilation,
+) -> Vec<(String, Vec<String>, Vec<String>)> {
+    let chunk_graph = compilation.chunk_graph();
+    let label = |group: unpack_core::ChunkGroupId| {
+        let group = &chunk_graph.chunk_groups()[group.index()];
+        match group.kind() {
+            ChunkGroupKind::Entrypoint { name } => format!("entry:{name}"),
+            ChunkGroupKind::Async => {
+                let origin = group
+                    .origin()
+                    .expect("Async Chunk Group must retain an origin");
+                let module = compilation
+                    .module_graph()
+                    .module(origin.module)
+                    .expect("Chunk Group origin Module must exist");
+                format!(
+                    "async:{}:{}",
+                    module.identity().resource.display(),
+                    origin.block_index
+                )
+            }
+        }
+    };
+    let mut topology = chunk_graph
+        .chunk_groups()
+        .iter()
+        .map(|group| {
+            let mut parents = group
+                .parents()
+                .iter()
+                .copied()
+                .map(&label)
+                .collect::<Vec<_>>();
+            parents.sort();
+            let mut children = group
+                .children()
+                .iter()
+                .copied()
+                .map(&label)
+                .collect::<Vec<_>>();
+            children.sort();
+            (label(group.id()), parents, children)
+        })
+        .collect::<Vec<_>>();
+    topology.sort();
+    topology
 }
 
 fn write_assets(out_dir: &Path, assets: &[unpack_core::Asset]) -> std::io::Result<()> {

--- a/docs/adr/0058-support-nested-async-split-points.md
+++ b/docs/adr/0058-support-nested-async-split-points.md
@@ -1,3 +1,15 @@
 # Support nested async split points
 
-Unpack's code splitting semantics will include nested async split points: a dynamic import reachable from an async chunk must be able to create its own async chunk group instead of being ignored or folded into the parent async chunk. This keeps dynamic import support semantic rather than limited to entry-reachable imports while still avoiding webpack's broader split-chunks, magic-comment, and import-mode feature set.
+Unpack's code splitting semantics include nested async split points: a dynamic
+import reachable from an async chunk creates its own async chunk group when its
+target is not already available on the current loading path. Planning uses a
+terminating worklist and parent available-module intersections; an available
+back edge creates no cyclic group and code generation preserves asynchronous
+Promise timing. Global target reuse retains Dependency Block mappings but omits
+any redundant parent edge that would close a cycle between already reachable
+Async Chunk Groups. Logical runtime-tree adjacency retains those loading edges
+for cycle-safe Runtime Requirement aggregation, so breaking material topology
+does not hide deeper capabilities from an Entrypoint. This keeps dynamic import
+support semantic rather than limited to entry-reachable imports while still
+avoiding webpack's broader split-chunks, magic-comment, and import-mode feature
+set.

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -91,12 +91,20 @@ Necessity:
 
 Unpack creates one entrypoint chunk group per entry, assigns statically reachable
 modules to the initial chunk, and creates or reuses async chunk groups by dynamic
-import target. Shared Async Chunk planning is two-phase: it intersects the modules
-available on every parent Entrypoint path, then emits the target's static closure
-minus that intersection. Modules available on only some parents therefore remain
-in the shared payload. Each Entrypoint keeps its own Runtime Modules and installed
-chunk state while requirements from the shared child group propagate to every
-reachable runtime tree.
+import target. A terminating worklist recursively discovers nested blocks. Each
+Async Chunk plan intersects modules available after every parent loading group,
+then emits the target's static closure minus that intersection. Newly discovered
+parents can only shrink the intersection and add required factories. A dynamic
+import back to a module already available after its parent group creates no Chunk
+Group edge and remains a Promise-based require in generated code. When global
+target reuse discovers reciprocal cross-import parents, materialization omits a
+redundant parent edge that would close a Chunk Group cycle while retaining the
+Dependency Block's target mapping. A separate logical runtime-tree adjacency
+retains every loading relationship, including the omitted material edge; runtime
+requirement traversal is cycle-safe and therefore still reaches both sides for
+each Entrypoint. Each Entrypoint keeps its own Runtime Modules and installed chunk
+state while requirements from all logically reachable nested groups propagate to
+its runtime tree.
 
 Webpack's `buildChunkGraph` is much broader. It tracks runtime per chunk group, chunk loading and async chunk flags, named async chunk reuse, async entrypoints, available-module masks, skipped modules, conditional connections, nested blocks, pre/post order indices, child/parent updates, and block-to-chunk-group links.
 
@@ -106,7 +114,8 @@ Necessity:
 - Intersecting parent available-module sets is necessary: excluding a module
   seen on only one path would make the shared payload unusable from another.
 - Split chunks, cache groups, min-size/min-chunks/max-request rules, runtime chunks, and named chunk options are not necessary for the first implementation.
-- Nested async blocks are a current required semantic: Unpack only scans async blocks found in initial modules when creating async groups, while webpack recursively processes nested dependency blocks. A dynamic import reachable from an async chunk must create its own async chunk group; ignoring it is a parity gap against Unpack's chosen dynamic import semantics, not a compatibility luxury.
+- Recursive nested-block processing and available-module back-edge collapse are
+  required parts of Unpack's implemented dynamic-import semantics.
 
 ## Runtime and asset generation
 

--- a/packages/unpack/test/e2e-cases/nested-async-back-edge/README.md
+++ b/packages/unpack/test/e2e-cases/nested-async-back-edge/README.md
@@ -1,0 +1,10 @@
+# Nested async split and available-module back edge
+
+Ported from webpack 5.108.1
+`test/cases/chunks/nested-blocks-with-available-parent-modules` and
+`test/cases/chunks/nested-in-empty`. The fixture adapts the nested loading path
+to Unpack's static-string imports and adds a B-to-A async back edge. It verifies
+finite Chunk Group construction, two emitted Async Assets, both Promise levels,
+deeper Harmony Runtime Requirement propagation through pure-script outer
+modules, and asynchronous collapse of the already-available target through the
+public JavaScript API and an isolated Node process.

--- a/packages/unpack/test/e2e-cases/nested-async-back-edge/case.json
+++ b/packages/unpack/test/e2e-cases/nested-async-back-edge/case.json
@@ -1,0 +1,5 @@
+{
+  "runtimeExpression": "require('../runner.cjs')(entry)",
+  "expected": ["a", "b", "a", true],
+  "expectedAssets": ["main.js", "src_a_js.js", "src_b_js.js"]
+}

--- a/packages/unpack/test/e2e-cases/nested-async-back-edge/runner.cjs
+++ b/packages/unpack/test/e2e-cases/nested-async-back-edge/runner.cjs
@@ -1,0 +1,9 @@
+module.exports = async function run() {
+  await globalThis.loadA();
+  const b = await globalThis.loadB();
+  let synchronous = true;
+  const back = b.loadA().then(() => [globalThis.aValue, !synchronous]);
+  synchronous = false;
+  const [backValue, wasAsynchronous] = await back;
+  return [globalThis.aValue, b.value, backValue, wasAsynchronous];
+};

--- a/packages/unpack/test/e2e-cases/nested-async-back-edge/src/a.js
+++ b/packages/unpack/test/e2e-cases/nested-async-back-edge/src/a.js
@@ -1,0 +1,2 @@
+globalThis.aValue = "a";
+globalThis.loadB = () => import("./b");

--- a/packages/unpack/test/e2e-cases/nested-async-back-edge/src/b.js
+++ b/packages/unpack/test/e2e-cases/nested-async-back-edge/src/b.js
@@ -1,0 +1,5 @@
+export const value = "b";
+
+export function loadA() {
+  return import("./a");
+}

--- a/packages/unpack/test/e2e-cases/nested-async-back-edge/src/index.js
+++ b/packages/unpack/test/e2e-cases/nested-async-back-edge/src/index.js
@@ -1,0 +1,1 @@
+globalThis.loadA = () => import("./a");

--- a/packages/unpack/test/e2e-cases/nested-shared-requeue/README.md
+++ b/packages/unpack/test/e2e-cases/nested-shared-requeue/README.md
@@ -1,0 +1,9 @@
+# Nested shared target requeue
+
+Adapted from webpack 5.108.1
+`test/cases/chunks/nested-blocks-with-available-parent-modules` and
+`test/configCases/chunk-graph/rewalk-chunk`. The C target is first discovered
+through P, where X is already available, then through Q, where X is absent.
+Shrinking C's all-parent intersection must add X to C and rescan X's nested
+dynamic import of Y. The public JavaScript API and isolated Node execution start
+with the Q path so a stale first-parent payload cannot be masked.

--- a/packages/unpack/test/e2e-cases/nested-shared-requeue/case.json
+++ b/packages/unpack/test/e2e-cases/nested-shared-requeue/case.json
@@ -1,0 +1,5 @@
+{
+  "runtimeExpression": "require('../runner.cjs')(entry)",
+  "expected": ["q", "shared", "y", "p", "shared", "y"],
+  "expectedAssets": ["main.js", "src_c_js.js", "src_p_js.js", "src_q_js.js", "src_r_js.js", "src_y_js.js"]
+}

--- a/packages/unpack/test/e2e-cases/nested-shared-requeue/runner.cjs
+++ b/packages/unpack/test/e2e-cases/nested-shared-requeue/runner.cjs
@@ -1,0 +1,11 @@
+module.exports = async function run(entry) {
+  const r = await entry.loadR();
+  const q = await r.loadQ();
+  const cFromQ = await q.loadC();
+  const yFromQ = await cFromQ.loadY();
+
+  const p = await entry.loadP();
+  const cFromP = await p.loadC();
+  const yFromP = await cFromP.loadY();
+  return [q.value, cFromQ.shared, yFromQ.value, p.value, cFromP.shared, yFromP.value];
+};

--- a/packages/unpack/test/e2e-cases/nested-shared-requeue/src/c.js
+++ b/packages/unpack/test/e2e-cases/nested-shared-requeue/src/c.js
@@ -1,0 +1,4 @@
+import { loadY, shared } from "./x";
+
+export { shared };
+export { loadY };

--- a/packages/unpack/test/e2e-cases/nested-shared-requeue/src/index.js
+++ b/packages/unpack/test/e2e-cases/nested-shared-requeue/src/index.js
@@ -1,0 +1,2 @@
+export const loadP = () => import("./p");
+export const loadR = () => import("./r");

--- a/packages/unpack/test/e2e-cases/nested-shared-requeue/src/p.js
+++ b/packages/unpack/test/e2e-cases/nested-shared-requeue/src/p.js
@@ -1,0 +1,5 @@
+import { shared } from "./x";
+
+export const value = "p";
+export { shared };
+export const loadC = () => import("./c");

--- a/packages/unpack/test/e2e-cases/nested-shared-requeue/src/q.js
+++ b/packages/unpack/test/e2e-cases/nested-shared-requeue/src/q.js
@@ -1,0 +1,2 @@
+export const value = "q";
+export const loadC = () => import("./c");

--- a/packages/unpack/test/e2e-cases/nested-shared-requeue/src/r.js
+++ b/packages/unpack/test/e2e-cases/nested-shared-requeue/src/r.js
@@ -1,0 +1,1 @@
+export const loadQ = () => import("./q");

--- a/packages/unpack/test/e2e-cases/nested-shared-requeue/src/x.js
+++ b/packages/unpack/test/e2e-cases/nested-shared-requeue/src/x.js
@@ -1,0 +1,2 @@
+export const shared = "shared";
+export const loadY = () => import("./y");

--- a/packages/unpack/test/e2e-cases/nested-shared-requeue/src/y.js
+++ b/packages/unpack/test/e2e-cases/nested-shared-requeue/src/y.js
@@ -1,0 +1,1 @@
+export const value = "y";

--- a/packages/unpack/test/e2e-cases/shared-async-cross-back-edges/README.md
+++ b/packages/unpack/test/e2e-cases/shared-async-cross-back-edges/README.md
@@ -1,0 +1,10 @@
+# Shared async targets with cross back edges
+
+Adapted from webpack 5.108.1
+`test/cases/chunks/nested-blocks-with-available-parent-modules`. Two independent
+Entrypoints reach A and B, which dynamically import each other. The fixture
+verifies that Unpack retains both globally reusable target mappings without
+materializing an A-to-B-to-A Chunk Group cycle, while logical runtime-tree
+reachability still propagates B's Harmony-only helpers into the pure-script A
+runtime. Both directions execute in isolated Entrypoint runtimes and an
+already-installed nested load remains asynchronous.

--- a/packages/unpack/test/e2e-cases/shared-async-cross-back-edges/case.json
+++ b/packages/unpack/test/e2e-cases/shared-async-cross-back-edges/case.json
@@ -1,0 +1,10 @@
+{
+  "entry": {
+    "entry-a": "./src/entry-a.js",
+    "entry-b": "./src/entry-b.js"
+  },
+  "entryAsset": "entry-a.js",
+  "runtimeExpression": "require('../runner.cjs')()",
+  "expected": ["a", "b", "a", "b", "a", true, true],
+  "expectedAssets": ["entry-a.js", "entry-b.js", "src_a_js.js", "src_b_js.js"]
+}

--- a/packages/unpack/test/e2e-cases/shared-async-cross-back-edges/runner.cjs
+++ b/packages/unpack/test/e2e-cases/shared-async-cross-back-edges/runner.cjs
@@ -1,0 +1,27 @@
+const path = require("path");
+
+module.exports = async function run() {
+  require(path.join(process.cwd(), "entry-b.js"));
+  await globalThis.loadDirectA();
+  const nestedB = await globalThis.loadNestedB();
+  let synchronous = true;
+  const backA = nestedB.loadA().then(() => [globalThis.aValue, !synchronous]);
+  synchronous = false;
+  const [backValue, wasAsynchronous] = await backA;
+  const directB = await globalThis.loadDirectB();
+  let reverseSynchronous = true;
+  const nestedA = directB
+    .loadA()
+    .then(() => [globalThis.aValue, !reverseSynchronous]);
+  reverseSynchronous = false;
+  const [reverseValue, reverseWasAsynchronous] = await nestedA;
+  return [
+    globalThis.aValue,
+    nestedB.value,
+    backValue,
+    directB.value,
+    reverseValue,
+    wasAsynchronous,
+    reverseWasAsynchronous
+  ];
+};

--- a/packages/unpack/test/e2e-cases/shared-async-cross-back-edges/src/a.js
+++ b/packages/unpack/test/e2e-cases/shared-async-cross-back-edges/src/a.js
@@ -1,0 +1,2 @@
+globalThis.aValue = "a";
+globalThis.loadNestedB = () => import("./b");

--- a/packages/unpack/test/e2e-cases/shared-async-cross-back-edges/src/b.js
+++ b/packages/unpack/test/e2e-cases/shared-async-cross-back-edges/src/b.js
@@ -1,0 +1,2 @@
+export const value = "b";
+export const loadA = () => import("./a");

--- a/packages/unpack/test/e2e-cases/shared-async-cross-back-edges/src/entry-a.js
+++ b/packages/unpack/test/e2e-cases/shared-async-cross-back-edges/src/entry-a.js
@@ -1,0 +1,1 @@
+globalThis.loadDirectA = () => import("./a");

--- a/packages/unpack/test/e2e-cases/shared-async-cross-back-edges/src/entry-b.js
+++ b/packages/unpack/test/e2e-cases/shared-async-cross-back-edges/src/entry-b.js
@@ -1,0 +1,1 @@
+globalThis.loadDirectB = () => import("./b");


### PR DESCRIPTION
Closes #171

Recursively plan nested Async Chunks with a monotone parent-availability worklist. Available back edges keep Promise timing without redundant chunks; shared cross-imports retain block mappings and logical runtime reachability while the materialized Chunk Group graph stays acyclic.

Adds webpack 5.108.1-derived isolated Node coverage for nested loading, intersection shrink/requeue, deep Runtime Requirement propagation, and cross-entry back edges.