### PR TITLE
Handle warm cache ceiling path

### DIFF
--- a/crates/unpack_core/src/build_cache.rs
+++ b/crates/unpack_core/src/build_cache.rs
@@ -14,18 +14,15 @@ use std::{
 use crate::{
     InfrastructureLogEvent, InfrastructureLogLevel, ModuleIdentity, SnapshotOptions,
     SnapshotStrategy, UnpackResolver,
-    cache_hash::stable_hash,
+    code_generation_record::CodeGenerationRecord,
+    module::BuiltModuleContent,
     pack_file::{
-        AccessStamp, AssetRenderRecordCodec, AssetRenderRecordDto, CodecRegistry, DEFAULT_MAX_AGE,
-        ModuleBuildRecordCodec,
-        ModuleBuildRecordDto, PackFile, PackFileAddress, PackFileETag, PackFileGuardDto,
-        PackFileRetention, PackFileWriteBatch, PublicationBase, ResolveRecordCodec,
-        ResolveRecordDto, SnapshotDto,
-        PackFileCompression, PackFileOpenOptions, PackFilePublicationOptions,
-/*
-        PackFileOpenOptions, PackFilePublicationOptions, PackFileRetention, PackFileWriteBatch,
+        AccessStamp, AssetRenderRecordCodec, AssetRenderRecordDto, CodeGenerationRecordCodec,
+        CodeGenerationRecordDto, CodecRegistry, DEFAULT_MAX_AGE, ModuleBuildRecordCodec,
+        ModuleBuildRecordDto, PackFile, PackFileAddress, PackFileCompression, PackFileETag,
+        PackFileGuardDto, PackFileOpenOptions, PackFilePublicationOptions,
+        PackFileRestore as PackFileRecordRestore, PackFileRetention, PackFileWriteBatch,
         PublicationBase, ResolveRecordCodec, ResolveRecordDto, SnapshotDto,
-*/
     },
     parser::ParsedModule,
     rendered_source::RenderedSource,
@@ -34,6 +31,8 @@ use crate::{
 
 const RESOLVE_CACHE_NAMESPACE: CacheNamespace = CacheNamespace::new("unpack/resolve");
 const MODULE_BUILD_CACHE_NAMESPACE: CacheNamespace = CacheNamespace::new("unpack/module-build");
+const CODE_GENERATION_CACHE_NAMESPACE: CacheNamespace =
+    CacheNamespace::new("unpack/code-generation");
 const ASSET_RENDER_CACHE_NAMESPACE: CacheNamespace = CacheNamespace::new("unpack/asset-render");
 const CACHE_PROFILE_LOGGER: &str = "unpack.Cache.Profile";
 const CACHE_WRITER_LOGGER: &str = "unpack.Cache.Writer";
@@ -93,6 +92,7 @@ pub(crate) struct BuildCache {
     resolve_build_dependency_snapshot_strategy: SnapshotStrategy,
     build_dependency_file_system_info: FileSystemInfo,
     diagnostics: Arc<CacheDiagnostics>,
+    clock: Arc<dyn CacheClock>,
     inner: Arc<Mutex<BuildCacheInner>>,
 }
 
@@ -359,9 +359,17 @@ struct PublishBarrier {
 }
 
 #[cfg(test)]
+#[derive(Debug, Clone)]
+struct RestoreBarrier {
+    entered: Arc<std::sync::Barrier>,
+    release: Arc<std::sync::Barrier>,
+}
+
+#[cfg(test)]
 #[derive(Debug)]
 struct ManualCacheClock {
     now_millis: AtomicU64,
+    calls: AtomicU64,
 }
 
 #[cfg(test)]
@@ -369,17 +377,23 @@ impl ManualCacheClock {
     fn at_millis(now_millis: u64) -> Self {
         Self {
             now_millis: AtomicU64::new(now_millis),
+            calls: AtomicU64::new(0),
         }
     }
 
     fn set_millis(&self, now_millis: u64) {
         self.now_millis.store(now_millis, Ordering::SeqCst);
     }
+
+    fn calls(&self) -> u64 {
+        self.calls.load(Ordering::SeqCst)
+    }
 }
 
 #[cfg(test)]
 impl CacheClock for ManualCacheClock {
     fn now(&self) -> AccessStamp {
+        self.calls.fetch_add(1, Ordering::SeqCst);
         AccessStamp::from_millis(self.now_millis.load(Ordering::SeqCst))
     }
 }
@@ -458,8 +472,125 @@ impl fmt::Debug for CacheEntry {
     }
 }
 
+#[derive(Debug)]
+enum CacheLayerLookup {
+    Hit(CacheEntry),
+    Deferred(PersistentRestore),
+    Miss,
+}
+
+enum PreparedPersistentRecord {
+    Resolve(PackFileRecordRestore<ResolveRecordDto>),
+    ModuleBuild(PackFileRecordRestore<ModuleBuildRecordDto>),
+    CodeGeneration(PackFileRecordRestore<CodeGenerationRecordDto>),
+    AssetRender(PackFileRecordRestore<AssetRenderRecordDto>),
+}
+
+#[derive(Debug, Clone)]
+struct PersistentRestore {
+    pack_file: Arc<Mutex<PackFile>>,
+    reader_generation: u64,
+    address: PackFileAddress,
+    etag: Option<PackFileETag>,
+    cache_etag: Option<CacheETag>,
+    namespace: CacheNamespace,
+    diagnostics: Arc<CacheDiagnostics>,
+    #[cfg(test)]
+    barrier: Option<RestoreBarrier>,
+}
+
+impl PersistentRestore {
+    fn restore(&self) -> Option<CacheEntry> {
+        let started = Instant::now();
+        let prepared = {
+            let mut pack_file = self
+                .pack_file
+                .lock()
+                .expect("PackFile mutex should not be poisoned");
+            match self.namespace {
+                RESOLVE_CACHE_NAMESPACE => PreparedPersistentRecord::Resolve(
+                    pack_file.prepare_restore(&self.address, self.etag.as_ref())?,
+                ),
+                MODULE_BUILD_CACHE_NAMESPACE => PreparedPersistentRecord::ModuleBuild(
+                    pack_file.prepare_restore(&self.address, self.etag.as_ref())?,
+                ),
+                CODE_GENERATION_CACHE_NAMESPACE => PreparedPersistentRecord::CodeGeneration(
+                    pack_file.prepare_restore(&self.address, self.etag.as_ref())?,
+                ),
+                ASSET_RENDER_CACHE_NAMESPACE => PreparedPersistentRecord::AssetRender(
+                    pack_file.prepare_restore(&self.address, self.etag.as_ref())?,
+                ),
+                _ => return None,
+            }
+        };
+        #[cfg(test)]
+        if let Some(barrier) = &self.barrier {
+            barrier.entered.wait();
+            barrier.release.wait();
+        }
+
+        let restored = match prepared {
+            PreparedPersistentRecord::Resolve(prepared) => {
+                let record = ResolveRecord::try_from(prepared.decode()?).ok()?;
+                CacheEntry::new(CacheItemFamily::Resolve, self.cache_etag.clone(), record)
+            }
+            PreparedPersistentRecord::ModuleBuild(prepared) => {
+                let record = ModuleBuildRecord::try_from(prepared.decode()?).ok()?;
+                CacheEntry::new(
+                    CacheItemFamily::ModuleBuild,
+                    self.cache_etag.clone(),
+                    record,
+                )
+            }
+            PreparedPersistentRecord::CodeGeneration(prepared) => {
+                let record = prepared.decode()?.into_record_after_codec_validation();
+                CacheEntry::new(
+                    CacheItemFamily::CodeGeneration,
+                    self.cache_etag.clone(),
+                    record,
+                )
+            }
+            PreparedPersistentRecord::AssetRender(prepared) => {
+                let record = RenderedSource::try_from(prepared.decode()?).ok()?;
+                CacheEntry::new(
+                    CacheItemFamily::AssetRender,
+                    self.cache_etag.clone(),
+                    record,
+                )
+            }
+        };
+        self.diagnostics.profile(format!(
+            "restore items=1; deserialization items=1 duration_us={}",
+            started.elapsed().as_micros()
+        ));
+        Some(restored)
+    }
+
+    fn reads_from(&self, other: &Self) -> bool {
+        self.reader_generation == other.reader_generation
+            && Arc::ptr_eq(&self.pack_file, &other.pack_file)
+    }
+}
+
+#[derive(Debug)]
+struct PersistentTouch {
+    pack_file: Arc<Mutex<PackFile>>,
+    address: PackFileAddress,
+    etag: Option<PackFileETag>,
+    stamp: AccessStamp,
+}
+
+impl PersistentTouch {
+    fn apply(&self) -> bool {
+        self.pack_file
+            .lock()
+            .expect("PackFile mutex should not be poisoned")
+            .touch(&self.address, self.etag.as_ref(), self.stamp)
+    }
+}
+
 trait CacheLayer: fmt::Debug + Send + Sync {
-    fn get(&mut self, address: &CacheAddress, etag: Option<&CacheETag>) -> Option<CacheEntry>;
+    fn lookup(&mut self, address: &CacheAddress, etag: Option<&CacheETag>) -> CacheLayerLookup;
     fn store(&mut self, address: CacheAddress, entry: CacheEntry);
     fn clear(&mut self) {}
     fn prepare_persistent(
@@ -474,13 +605,13 @@ trait CacheLayer: fmt::Debug + Send + Sync {
     ) -> bool {
         false
     }
-    fn touch(
-        &mut self,
+    fn plan_touch(
+        &self,
         _address: &CacheAddress,
         _etag: Option<&CacheETag>,
         _stamp: AccessStamp,
-    ) -> bool {
-        false
+    ) -> Option<PersistentTouch> {
+        None
     }
     fn on_compilation_completed(&mut self) -> Vec<CacheItemFamily> {
         Vec::new()
@@ -496,6 +627,8 @@ trait CacheLayer: fmt::Debug + Send + Sync {
     fn has_publication(&self) -> bool {
         false
     }
+    #[cfg(test)]
+    fn install_restore_barrier(&mut self, _barrier: RestoreBarrier) {}
     #[allow(dead_code)]
     fn evict(&mut self, address: &CacheAddress) -> bool;
     #[cfg(test)]
@@ -550,21 +683,26 @@ impl MemoryCacheLayer {
 }
 
 impl CacheLayer for MemoryCacheLayer {
-    fn get(&mut self, address: &CacheAddress, etag: Option<&CacheETag>) -> Option<CacheEntry> {
+    fn lookup(&mut self, address: &CacheAddress, etag: Option<&CacheETag>) -> CacheLayerLookup {
         if self.retention == MemoryRetention::Unbounded {
             return self
                 .entries
                 .get(address)
                 .filter(|entry| entry.entry.etag.as_ref() == etag)
-                .map(|entry| entry.entry.clone());
+                .map_or(CacheLayerLookup::Miss, |entry| {
+                    CacheLayerLookup::Hit(entry.entry.clone())
+                });
         }
         let active_generation = self.active_generation();
-        let entry = self
+        let Some(entry) = self
             .entries
             .get_mut(address)
-            .filter(|entry| entry.entry.etag.as_ref() == etag)?;
+            .filter(|entry| entry.entry.etag.as_ref() == etag)
+        else {
+            return CacheLayerLookup::Miss;
+        };
         entry.last_used_generation = active_generation;
-        Some(entry.entry.clone())
+        CacheLayerLookup::Hit(entry.entry.clone())
     }
 
     fn store(&mut self, address: CacheAddress, entry: CacheEntry) {
@@ -616,7 +754,8 @@ impl CacheLayer for MemoryCacheLayer {
 struct PackFileCacheLayer {
     root: Option<PathBuf>,
     registry: CodecRegistry,
-    pack_file: Option<PackFile>,
+    pack_file: Option<Arc<Mutex<PackFile>>>,
+    reader_generation: u64,
     compression: PackFileCompression,
     open_options: PackFileOpenOptions,
     publication_base: PublicationBase,
@@ -624,6 +763,8 @@ struct PackFileCacheLayer {
     pending: HashMap<CacheAddress, CacheEntry>,
     diagnostics: Arc<CacheDiagnostics>,
     _writer_marker: Option<CacheWriterMarker>,
+    #[cfg(test)]
+    restore_barrier: Option<RestoreBarrier>,
 }
 
 #[derive(Debug)]
@@ -738,20 +879,30 @@ impl PackFileCacheLayer {
         let root = options.cache_location.clone();
         let compression = options.compression.into();
         let open_options = PackFileOpenOptions::new(options.allow_collecting_memory);
-        let pack_file = root
-            .as_ref()
-            .map(|root| PackFile::open_with_options(root, registry.clone(), open_options));
+        let pack_file = root.as_ref().map(|root| {
+            Arc::new(Mutex::new(PackFile::open_with_options(
+                root,
+                registry.clone(),
+                open_options,
+            )))
+        });
         let has_standalone_guard = pack_file.as_ref().is_some_and(|pack_file| {
-            pack_file.guard().is_some_and(|guard| {
-                guard.build_dependencies.entries.is_empty()
-                    && guard.resolve_build_dependencies.entries.is_empty()
-            })
+            pack_file
+                .lock()
+                .expect("PackFile mutex should not be poisoned")
+                .guard()
+                .is_some_and(|guard| {
+                    guard.build_dependencies.entries.is_empty()
+                        && guard.resolve_build_dependencies.entries.is_empty()
+                })
         });
         let publication_base = if has_standalone_guard {
             PublicationBase::PreserveEntries {
                 expected_revision: pack_file
                     .as_ref()
                     .expect("standalone PackFile should be open")
+                    .lock()
+                    .expect("PackFile mutex should not be poisoned")
                     .revision(),
             }
         } else {
@@ -767,6 +918,7 @@ impl PackFileCacheLayer {
             root,
             registry,
             pack_file,
+            reader_generation: 0,
             compression,
             open_options,
             publication_base,
@@ -777,6 +929,8 @@ impl PackFileCacheLayer {
             pending: HashMap::new(),
             diagnostics,
             _writer_marker: writer_marker,
+            #[cfg(test)]
+            restore_barrier: None,
         }
     }
 
@@ -790,12 +944,20 @@ impl PackFileCacheLayer {
             self.pending.clear();
             return Ok(());
         };
-        let before_entries = self.pack_file.as_ref().map_or(0, PackFile::entry_count);
+        let before_entries = self.pack_file.as_ref().map_or(0, |pack_file| {
+            pack_file
+                .lock()
+                .expect("PackFile mutex should not be poisoned")
+                .entry_count()
+        });
         let queued_items = self.pending.len();
         let serialization_started = Instant::now();
         let mut batch = PackFileWriteBatch::new();
         if let Some(pack_file) = &self.pack_file {
-            pack_file.copy_access_updates_to(&mut batch);
+            pack_file
+                .lock()
+                .expect("PackFile mutex should not be poisoned")
+                .copy_access_updates_to(&mut batch);
         }
         for (address, entry) in &self.pending {
             let pack_address = address.to_pack_file_address();
@@ -821,9 +983,16 @@ impl PackFileCacheLayer {
                     let dto = ModuleBuildRecordDto::try_from(record.as_ref())?;
                     batch.insert(&self.registry, pack_address, pack_etag, dto)?;
                 }
-                CacheItemFamily::CodeGeneration => unreachable!(
-                    "Code Generation Results are Compilation-owned and cannot be persisted"
-                ),
+                CacheItemFamily::CodeGeneration => {
+                    let record = entry.value::<CodeGenerationRecord>().ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "Code Generation Cache Item contains an unexpected value",
+                        )
+                    })?;
+                    let dto = CodeGenerationRecordDto::from(record.as_ref());
+                    batch.insert(&self.registry, pack_address, pack_etag, dto)?;
+                }
                 CacheItemFamily::AssetRender => {
                     let record = entry.value::<RenderedSource>().ok_or_else(|| {
                         io::Error::new(
@@ -862,66 +1031,39 @@ impl PackFileCacheLayer {
         self.publication_base = PublicationBase::PreserveEntries {
             expected_revision: pack_file.revision(),
         };
-        self.pack_file = Some(pack_file);
+        self.pack_file = Some(Arc::new(Mutex::new(pack_file)));
+        self.reader_generation = self.reader_generation.wrapping_add(1);
         self.active = true;
         Ok(())
     }
 }
 
 impl CacheLayer for PackFileCacheLayer {
-    fn get(&mut self, address: &CacheAddress, etag: Option<&CacheETag>) -> Option<CacheEntry> {
+    fn lookup(&mut self, address: &CacheAddress, etag: Option<&CacheETag>) -> CacheLayerLookup {
         if let Some(entry) = self
             .pending
             .get(address)
             .filter(|entry| entry.etag.as_ref() == etag)
         {
-            return Some(entry.clone());
+            return CacheLayerLookup::Hit(entry.clone());
         }
         if !self.active {
-            return None;
+            return CacheLayerLookup::Miss;
         }
-        let started = Instant::now();
-        let pack_file = self.pack_file.as_mut()?;
-        let pack_address = address.to_pack_file_address();
-        let pack_etag = etag.map(CacheETag::to_pack_file_etag);
-        let restored = match address.namespace {
-            RESOLVE_CACHE_NAMESPACE => {
-                let dto = pack_file.get_resolve_record(&pack_address, pack_etag.as_ref())?;
-                let record = ResolveRecord::try_from((*dto).clone()).ok()?;
-                Some(CacheEntry::new(
-                    CacheItemFamily::Resolve,
-                    etag.cloned(),
-                    record,
-                ))
-            }
-            MODULE_BUILD_CACHE_NAMESPACE => {
-                let dto = pack_file.get_module_build_record(&pack_address, pack_etag.as_ref())?;
-                let record = ModuleBuildRecord::try_from((*dto).clone()).ok()?;
-                Some(CacheEntry::new(
-                    CacheItemFamily::ModuleBuild,
-                    etag.cloned(),
-                    record,
-                ))
-            }
-            ASSET_RENDER_CACHE_NAMESPACE => {
-                let dto =
-                    pack_file.get::<AssetRenderRecordDto>(&pack_address, pack_etag.as_ref())?;
-                let record = RenderedSource::try_from((*dto).clone()).ok()?;
-                Some(CacheEntry::new(
-                    CacheItemFamily::AssetRender,
-                    etag.cloned(),
-                    record,
-                ))
-            }
-            _ => None,
+        let Some(pack_file) = self.pack_file.as_ref() else {
+            return CacheLayerLookup::Miss;
         };
-        if restored.is_some() {
-            self.diagnostics.profile(format!(
-                "restore items=1; deserialization items=1 duration_us={}",
-                started.elapsed().as_micros()
-            ));
-        }
-        restored
+        CacheLayerLookup::Deferred(PersistentRestore {
+            pack_file: Arc::clone(pack_file),
+            reader_generation: self.reader_generation,
+            address: address.to_pack_file_address(),
+            etag: etag.map(CacheETag::to_pack_file_etag),
+            cache_etag: etag.cloned(),
+            namespace: address.namespace,
+            diagnostics: Arc::clone(&self.diagnostics),
+            #[cfg(test)]
+            barrier: self.restore_barrier.take(),
+        })
     }
 
     fn store(&mut self, address: CacheAddress, entry: CacheEntry) {
@@ -932,6 +1074,7 @@ impl CacheLayer for PackFileCacheLayer {
     fn clear(&mut self) {
         self.pending.clear();
         self.active = false;
+        self.reader_generation = self.reader_generation.wrapping_add(1);
         self.publication_base = PublicationBase::ReplaceAll;
     }
 
@@ -946,38 +1089,43 @@ impl CacheLayer for PackFileCacheLayer {
         resolve_build_dependency_snapshot_strategy: SnapshotStrategy,
     ) -> bool {
         let build_strategy = if !build_inputs.is_empty()
-            && build_inputs.iter().all(|path| automatic_build_inputs.contains(path))
+            && build_inputs
+                .iter()
+                .all(|path| automatic_build_inputs.contains(path))
         {
             SnapshotStrategy::timestamp()
         } else {
             build_dependency_snapshot_strategy
         };
         let active = self.pack_file.as_ref().is_some_and(|pack_file| {
-            pack_file.guard().is_some_and(|candidate| {
-                let build_dependencies =
-                    Snapshot::try_from(candidate.build_dependencies.clone()).ok();
-                let resolve_build_dependencies =
-                    Snapshot::try_from(candidate.resolve_build_dependencies.clone()).ok();
-                candidate.version == guard.version
-                    && build_dependencies.is_some_and(|snapshot| {
-                        snapshot.has_exact_paths(build_inputs.iter().cloned())
-                            && file_system_info.is_snapshot_valid_sync(
+            pack_file
+                .lock()
+                .expect("PackFile mutex should not be poisoned")
+                .guard()
+                .is_some_and(|candidate| {
+                    let build_dependencies =
+                        Snapshot::try_from(candidate.build_dependencies.clone()).ok();
+                    let resolve_build_dependencies =
+                        Snapshot::try_from(candidate.resolve_build_dependencies.clone()).ok();
+                    candidate.version == guard.version
+                        && build_dependencies.is_some_and(|snapshot| {
+                            snapshot.has_exact_paths(build_inputs.iter().cloned())
+                                && file_system_info
+                                    .is_snapshot_valid_sync(&snapshot, build_strategy)
+                        })
+                        && resolve_build_dependencies.is_some_and(|snapshot| {
+                            file_system_info.is_snapshot_valid_sync(
                                 &snapshot,
-                                build_strategy,
+                                resolve_build_dependency_snapshot_strategy,
+                            ) || snapshot.has_valid_paths_sync(
+                                resolved_build_inputs.iter().cloned(),
+                                resolve_build_dependency_snapshot_strategy,
+                                file_system_info,
                             )
-                    })
-                    && resolve_build_dependencies.is_some_and(|snapshot| {
-                        file_system_info.is_snapshot_valid_sync(
-                            &snapshot,
-                            resolve_build_dependency_snapshot_strategy,
-                        ) || snapshot.has_valid_paths_sync(
-                            resolved_build_inputs.iter().cloned(),
-                            resolve_build_dependency_snapshot_strategy,
-                            file_system_info,
-                        )
-                    })
-            })
+                        })
+                })
         });
+        self.reader_generation = self.reader_generation.wrapping_add(1);
         self.active = active;
         self.publication_base = if active {
             PublicationBase::PreserveEntries {
@@ -985,28 +1133,41 @@ impl CacheLayer for PackFileCacheLayer {
                     .pack_file
                     .as_ref()
                     .expect("active PackFile should be open")
+                    .lock()
+                    .expect("PackFile mutex should not be poisoned")
                     .revision(),
             }
         } else {
             PublicationBase::ReplaceAll
         };
-        self.pack_file.as_ref().and_then(PackFile::guard) != Some(guard)
+        self.pack_file
+            .as_ref()
+            .and_then(|pack_file| {
+                pack_file
+                    .lock()
+                    .expect("PackFile mutex should not be poisoned")
+                    .guard()
+                    .cloned()
+            })
+            .as_ref()
+            != Some(guard)
     }
 
-    fn touch(
-        &mut self,
+    fn plan_touch(
+        &self,
         address: &CacheAddress,
         etag: Option<&CacheETag>,
         stamp: AccessStamp,
-    ) -> bool {
+    ) -> Option<PersistentTouch> {
         if !self.active {
-            return false;
+            return None;
         }
-        let pack_address = address.to_pack_file_address();
-        let pack_etag = etag.map(CacheETag::to_pack_file_etag);
-        self.pack_file
-            .as_mut()
-            .is_some_and(|pack_file| pack_file.touch(&pack_address, pack_etag.as_ref(), stamp))
+        self.pack_file.as_ref().map(|pack_file| PersistentTouch {
+            pack_file: Arc::clone(pack_file),
+            address: address.to_pack_file_address(),
+            etag: etag.map(CacheETag::to_pack_file_etag),
+            stamp,
+        })
     }
 
     fn publish(
@@ -1020,6 +1181,11 @@ impl CacheLayer for PackFileCacheLayer {
 
     fn has_publication(&self) -> bool {
         self.active
+    }
+
+    #[cfg(test)]
+    fn install_restore_barrier(&mut self, barrier: RestoreBarrier) {
+        self.restore_barrier = Some(barrier);
     }
 
     fn evict(&mut self, address: &CacheAddress) -> bool {
@@ -1054,6 +1220,31 @@ struct Cache {
     work: CacheWorkCounters,
 }
 
+struct CacheRestore {
+    layer_index: usize,
+    restore: PersistentRestore,
+}
+
+enum CacheGet<V> {
+    Ready {
+        value: Option<Arc<V>>,
+        persistent_access_changed: bool,
+    },
+    Deferred(CacheRestore),
+}
+
+impl<V> CacheGet<V> {
+    fn persistent_access_changed(&self) -> bool {
+        matches!(
+            self,
+            Self::Ready {
+                persistent_access_changed: true,
+                ..
+            }
+        )
+    }
+}
+
 impl Cache {
     fn from_options(options: &CacheOptions, diagnostics: Arc<CacheDiagnostics>) -> Self {
         let mut layers = Vec::new();
@@ -1078,48 +1269,136 @@ impl Cache {
         }
     }
 
-    fn get<V>(
+    fn begin_get<V>(
         &mut self,
         family: CacheItemFamily,
         address: &CacheAddress,
         etag: Option<&CacheETag>,
         stamp: AccessStamp,
-    ) -> (Option<Arc<V>>, bool)
+    ) -> CacheGet<V>
     where
         V: Send + Sync + 'static,
     {
         for index in 0..self.layers.len() {
-            let entry = self.layers[index].layer.get(address, etag);
-            let Some(entry) = entry else {
-                continue;
-            };
-            let Some(value) = entry.value::<V>() else {
-                continue;
-            };
-
-            if index > 0 {
-                for earlier in &mut self.layers[..index] {
-                    if earlier.writable {
-                        earlier.layer.store(address.clone(), entry.clone());
+            match self.layers[index].layer.lookup(address, etag) {
+                CacheLayerLookup::Hit(entry) => {
+                    if let Some((value, persistent_access_changed)) =
+                        self.use_entry(family, address, etag, stamp, index, entry)
+                    {
+                        return CacheGet::Ready {
+                            value: Some(value),
+                            persistent_access_changed,
+                        };
                     }
                 }
-                self.work.for_family_mut(family).restores += 1;
+                CacheLayerLookup::Deferred(restore) => {
+                    return CacheGet::Deferred(CacheRestore {
+                        layer_index: index,
+                        restore,
+                    });
+                }
+                CacheLayerLookup::Miss => {}
             }
-            self.work.for_family_mut(family).hits += 1;
-            let mut persistent_access_changed = false;
-            for slot in self
-                .layers
-                .iter_mut()
-                .filter(|slot| slot.kind == CacheLayerKind::Persistent)
-            {
-                let touched = slot.layer.touch(address, etag, stamp);
-                persistent_access_changed |= touched && slot.writable;
-            }
-            return (Some(value), persistent_access_changed);
         }
 
         self.work.for_family_mut(family).misses += 1;
-        (None, false)
+        CacheGet::Ready {
+            value: None,
+            persistent_access_changed: false,
+        }
+    }
+
+    fn finish_restore<V>(
+        &mut self,
+        family: CacheItemFamily,
+        address: &CacheAddress,
+        etag: Option<&CacheETag>,
+        stamp: AccessStamp,
+        plan: CacheRestore,
+        restored: Option<CacheEntry>,
+    ) -> CacheGet<V>
+    where
+        V: Send + Sync + 'static,
+    {
+        for index in 0..plan.layer_index {
+            if let CacheLayerLookup::Hit(entry) = self.layers[index].layer.lookup(address, etag)
+                && let Some((value, persistent_access_changed)) =
+                    self.use_entry(family, address, etag, stamp, index, entry)
+            {
+                return CacheGet::Ready {
+                    value: Some(value),
+                    persistent_access_changed,
+                };
+            }
+        }
+
+        match self.layers[plan.layer_index].layer.lookup(address, etag) {
+            CacheLayerLookup::Hit(entry) => {
+                if let Some((value, persistent_access_changed)) =
+                    self.use_entry(family, address, etag, stamp, plan.layer_index, entry)
+                {
+                    return CacheGet::Ready {
+                        value: Some(value),
+                        persistent_access_changed,
+                    };
+                }
+            }
+            CacheLayerLookup::Deferred(current) if current.reads_from(&plan.restore) => {
+                if let Some(entry) = restored
+                    && let Some((value, persistent_access_changed)) =
+                        self.use_entry(family, address, etag, stamp, plan.layer_index, entry)
+                {
+                    return CacheGet::Ready {
+                        value: Some(value),
+                        persistent_access_changed,
+                    };
+                }
+            }
+            CacheLayerLookup::Deferred(current) => {
+                return CacheGet::Deferred(CacheRestore {
+                    layer_index: plan.layer_index,
+                    restore: current,
+                });
+            }
+            CacheLayerLookup::Miss => {}
+        }
+
+        self.work.for_family_mut(family).misses += 1;
+        CacheGet::Ready {
+            value: None,
+            persistent_access_changed: false,
+        }
+    }
+
+    fn use_entry<V>(
+        &mut self,
+        family: CacheItemFamily,
+        address: &CacheAddress,
+        etag: Option<&CacheETag>,
+        stamp: AccessStamp,
+        layer_index: usize,
+        entry: CacheEntry,
+    ) -> Option<(Arc<V>, bool)>
+    where
+        V: Send + Sync + 'static,
+    {
+        let value = entry.value::<V>()?;
+        if layer_index > 0 {
+            for earlier in &mut self.layers[..layer_index] {
+                if earlier.writable {
+                    earlier.layer.store(address.clone(), entry.clone());
+                }
+            }
+            self.work.for_family_mut(family).restores += 1;
+        }
+        self.work.for_family_mut(family).hits += 1;
+        let persistent_access_changed = self
+            .layers
+            .iter()
+            .filter(|slot| slot.kind == CacheLayerKind::Persistent && slot.writable)
+            .find_map(|slot| slot.layer.plan_touch(address, etag, stamp))
+            .is_some_and(|touch| touch.apply());
+        Some((value, persistent_access_changed))
     }
 
     fn store<V>(
@@ -1231,6 +1510,17 @@ impl Cache {
             .iter()
             .find(|slot| slot.kind == CacheLayerKind::Persistent)
             .is_some_and(|slot| slot.layer.has_publication())
+    }
+
+    #[cfg(test)]
+    fn install_restore_barrier(&mut self, barrier: RestoreBarrier) {
+        if let Some(slot) = self
+            .layers
+            .iter_mut()
+            .find(|slot| slot.kind == CacheLayerKind::Persistent)
+        {
+            slot.layer.install_restore_barrier(barrier);
+        }
     }
 }
 
@@ -1422,33 +1712,48 @@ impl ResolveRecord {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ModuleBuildRecord {
-    parsed: ParsedModule,
-    source: String,
-    source_hash: Option<u64>,
+    built_content: Arc<BuiltModuleContent>,
     snapshot: Snapshot,
 }
 
 impl ModuleBuildRecord {
-    pub(crate) fn new(parsed: ParsedModule, source: String, snapshot: Snapshot) -> Self {
-        let source_hash = Some(stable_hash(&source));
+    pub(crate) fn new(built_content: Arc<BuiltModuleContent>, snapshot: Snapshot) -> Self {
         Self {
-            parsed,
-            source,
-            source_hash,
+            built_content,
             snapshot,
         }
     }
 
     pub(crate) fn parsed(&self) -> &ParsedModule {
-        &self.parsed
+        self.built_content.parsed()
     }
 
-    pub(crate) fn cloned_parts(&self) -> (ParsedModule, String, Option<u64>) {
-        (self.parsed.clone(), self.source.clone(), self.source_hash)
+    pub(crate) fn built_content(&self) -> &Arc<BuiltModuleContent> {
+        &self.built_content
     }
 
-    pub(crate) fn source_hash(&self) -> Option<u64> {
-        self.source_hash
+    pub(crate) fn persistent_parts(&self) -> (&ParsedModule, &str, Option<u64>) {
+        (
+            self.built_content.parsed(),
+            self.built_content.source(),
+            Some(self.built_content.source_hash()),
+        )
+    }
+
+    pub(crate) fn from_persistent_parts(
+        parsed: ParsedModule,
+        source: String,
+        source_hash: u64,
+        snapshot: Snapshot,
+    ) -> Self {
+        Self {
+            built_content: Arc::new(BuiltModuleContent::from_persistent_parts(
+                parsed,
+                source,
+                source_hash,
+            )),
+            snapshot,
+        }
     }
 
     pub(crate) fn snapshot(&self) -> &Snapshot {
@@ -1497,13 +1802,14 @@ impl BuildCache {
         diagnostics.profile(
             "restore items=0; deserialization items=0; contract=trusted-local,linux-supported,single-writer coordination=none",
         );
-        let inner = BuildCacheInner::new(&options, clock, diagnostics.clone());
+        let inner = BuildCacheInner::new(&options, Arc::clone(&clock), diagnostics.clone());
         Self {
             options,
             build_dependency_snapshot_strategy,
             resolve_build_dependency_snapshot_strategy,
             build_dependency_file_system_info,
             diagnostics,
+            clock,
             inner: Arc::new(Mutex::new(inner)),
         }
     }
@@ -1518,6 +1824,13 @@ impl BuildCache {
 
     pub(crate) fn module_builds(&self) -> ModuleBuildCache {
         self.facade(MODULE_BUILD_CACHE_NAMESPACE, CacheItemFamily::ModuleBuild)
+    }
+
+    pub(crate) fn code_generations(&self) -> CacheFacade<ModuleIdentity, CodeGenerationRecord> {
+        self.facade(
+            CODE_GENERATION_CACHE_NAMESPACE,
+            CacheItemFamily::CodeGeneration,
+        )
     }
 
     pub(crate) fn asset_renders<K>(&self) -> CacheFacade<K, RenderedSource> {
@@ -1608,7 +1921,9 @@ impl BuildCache {
             .lock()
             .expect("build cache mutex should not be poisoned");
         let build_validation_strategy = if !build_inputs.is_empty()
-            && build_inputs.iter().all(|path| automatic_build_inputs.contains(path))
+            && build_inputs
+                .iter()
+                .all(|path| automatic_build_inputs.contains(path))
         {
             SnapshotStrategy::timestamp()
         } else {
@@ -1684,11 +1999,18 @@ impl BuildCache {
         if let Some(error) = &inner.persistent_guard_error {
             return Err(io::Error::new(io::ErrorKind::InvalidData, error.clone()));
         }
-        let guard = inner.persistent_guard.clone().unwrap_or_else(|| PackFileGuardDto {
-            version: self.cache_version().into_bytes(),
-            build_dependencies: SnapshotDto { entries: Vec::new() },
-            resolve_build_dependencies: SnapshotDto { entries: Vec::new() },
-        });
+        let guard = inner
+            .persistent_guard
+            .clone()
+            .unwrap_or_else(|| PackFileGuardDto {
+                version: self.cache_version().into_bytes(),
+                build_dependencies: SnapshotDto {
+                    entries: Vec::new(),
+                },
+                resolve_build_dependencies: SnapshotDto {
+                    entries: Vec::new(),
+                },
+            });
         let stamp = inner.clock.now();
         inner
             .cache
@@ -1708,6 +2030,19 @@ impl BuildCache {
             .lock()
             .expect("build cache mutex should not be poisoned")
             .publish_barrier = Some(PublishBarrier { entered, release });
+    }
+
+    #[cfg(test)]
+    fn install_restore_barrier(
+        &self,
+        entered: Arc<std::sync::Barrier>,
+        release: Arc<std::sync::Barrier>,
+    ) {
+        self.inner
+            .lock()
+            .expect("build cache mutex should not be poisoned")
+            .cache
+            .install_restore_barrier(RestoreBarrier { entered, release });
     }
 
     pub(crate) fn flush_to_filesystem(&self) -> io::Result<()> {
@@ -1805,29 +2140,61 @@ where
             return None;
         }
 
-        let mut inner = self
-            .build_cache
-            .inner
-            .lock()
-            .expect("build cache mutex should not be poisoned");
         let address = CacheAddress {
             namespace: self.namespace,
             identifier: key.cache_identifier(),
         };
         // Access timestamps only matter for the filesystem layer. Avoid a clock
-        // syscall on every cache lookup for disabled/memory caches (the hot path
-        // used by the make-phase benchmark).
-        let stamp = if self.build_cache.options.kind == CacheKind::Filesystem {
-            inner.clock.now()
+        // syscall for memory caches and read-only persistent caches, which never
+        // record access updates.
+        let stamp = if self.build_cache.options.kind == CacheKind::Filesystem
+            && !self.build_cache.options.readonly
+        {
+            self.build_cache.clock.now()
         } else {
             AccessStamp::from_millis(0)
         };
-        let (value, persistent_access_changed) =
-            inner.cache.get(self.family, &address, etag, stamp);
-        if persistent_access_changed {
-            inner.dirty_generation = inner.dirty_generation.saturating_add(1);
+
+        let mut result = {
+            let mut inner = self
+                .build_cache
+                .inner
+                .lock()
+                .expect("build cache mutex should not be poisoned");
+            let result = inner.cache.begin_get(self.family, &address, etag, stamp);
+            if result.persistent_access_changed() {
+                inner.dirty_generation = inner.dirty_generation.saturating_add(1);
+            }
+            result
+        };
+
+        loop {
+            match result {
+                CacheGet::Ready { value, .. } => return value,
+                CacheGet::Deferred(plan) => {
+                    let restored = plan.restore.restore();
+                    result = {
+                        let mut inner = self
+                            .build_cache
+                            .inner
+                            .lock()
+                            .expect("build cache mutex should not be poisoned");
+                        let result = inner.cache.finish_restore(
+                            self.family,
+                            &address,
+                            etag,
+                            stamp,
+                            plan,
+                            restored,
+                        );
+                        if result.persistent_access_changed() {
+                            inner.dirty_generation = inner.dirty_generation.saturating_add(1);
+                        }
+                        result
+                    };
+                }
+            }
         }
-        value
     }
 
     pub(crate) fn store(&self, key: K, etag: Option<CacheETag>, value: V) {
@@ -1835,15 +2202,15 @@ where
             return;
         }
 
+        let address = CacheAddress {
+            namespace: self.namespace,
+            identifier: key.cache_identifier(),
+        };
         let mut inner = self
             .build_cache
             .inner
             .lock()
             .expect("build cache mutex should not be poisoned");
-        let address = CacheAddress {
-            namespace: self.namespace,
-            identifier: key.cache_identifier(),
-        };
         if inner.cache.store(self.family, address, etag, value) {
             inner.dirty_generation = inner.dirty_generation.saturating_add(1);
         }
@@ -1874,6 +2241,7 @@ fn persistent_codec_registry() -> CodecRegistry {
     CodecRegistry::new()
         .with_resolve_record(ResolveRecordCodec::current())
         .with_module_build_record(ModuleBuildRecordCodec::current())
+        .with_code_generation_record(CodeGenerationRecordCodec::current())
         .with_asset_render_record(AssetRenderRecordCodec::current())
 }
 
@@ -2091,6 +2459,118 @@ mod tests {
                 evictions: 1,
             }
         );
+    }
+
+    #[tokio::test]
+    async fn slow_persistent_decode_does_not_block_memory_or_other_persistent_hits()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempdir()?;
+        let resource = temp.path().join("src/dep.js");
+        write(&resource, "export const value = 1;")?;
+        let file_system_info = FileSystemInfo::new();
+        let record = ResolveRecord::new(
+            ModuleIdentity::new(resource.clone()),
+            resource.clone(),
+            BTreeSet::from([resource]),
+            BTreeSet::new(),
+            BTreeSet::new(),
+            &file_system_info,
+            SnapshotStrategy::timestamp(),
+        )
+        .await?;
+        let persistent_key = ResolveRequest::new(temp.path(), "./persistent");
+        let other_persistent_key = ResolveRequest::new(temp.path(), "./other-persistent");
+        let memory_key = ResolveRequest::new(temp.path(), "./memory");
+        let mut options = CacheOptions::filesystem();
+        options.cache_location = Some(temp.path().join("cache"));
+
+        let first = BuildCache::new(options.clone(), SnapshotOptions::default());
+        first
+            .normal_module_factory()
+            .store(persistent_key.clone(), None, record.clone());
+        first
+            .normal_module_factory()
+            .store(other_persistent_key.clone(), None, record.clone());
+        first.flush_to_filesystem()?;
+        drop(first);
+
+        options.readonly = true;
+        let clock = Arc::new(ManualCacheClock::at_millis(1_000));
+        let second =
+            BuildCache::new_with_clock(options, SnapshotOptions::default(), Arc::clone(&clock));
+        let facade = second.normal_module_factory();
+        facade.store(memory_key.clone(), None, record);
+        let restore_entered = Arc::new(std::sync::Barrier::new(2));
+        let restore_release = Arc::new(std::sync::Barrier::new(2));
+        second.install_restore_barrier(restore_entered.clone(), restore_release.clone());
+
+        let restore_facade = facade.clone();
+        let restore_thread = std::thread::spawn(move || restore_facade.get(&persistent_key, None));
+        restore_entered.wait();
+
+        let memory_facade = facade.clone();
+        let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+        let memory_thread = std::thread::spawn(move || {
+            completed_tx
+                .send(memory_facade.get(&memory_key, None).is_some())
+                .expect("memory-hit observation should still be received");
+        });
+        let completed_before_restore_release =
+            completed_rx.recv_timeout(Duration::from_secs(1)).ok();
+
+        let other_persistent_facade = facade.clone();
+        let (other_completed_tx, other_completed_rx) = std::sync::mpsc::channel();
+        let other_persistent_thread = std::thread::spawn(move || {
+            other_completed_tx
+                .send(
+                    other_persistent_facade
+                        .get(&other_persistent_key, None)
+                        .is_some(),
+                )
+                .expect("persistent-hit observation should still be received");
+        });
+        let other_completed_before_restore_release =
+            other_completed_rx.recv_timeout(Duration::from_secs(1)).ok();
+
+        restore_release.wait();
+        assert!(
+            restore_thread
+                .join()
+                .expect("restore thread should finish")
+                .is_some()
+        );
+        memory_thread
+            .join()
+            .expect("memory-hit thread should finish");
+        other_persistent_thread
+            .join()
+            .expect("other persistent-hit thread should finish");
+        assert_eq!(
+            completed_before_restore_release,
+            Some(true),
+            "persistent deserialization must not hold the global BuildCache lock"
+        );
+        assert_eq!(
+            other_completed_before_restore_release,
+            Some(true),
+            "record decoding must not hold the PackFile reader lock"
+        );
+        assert_eq!(
+            clock.calls(),
+            0,
+            "read-only cache hits do not need access stamps"
+        );
+        assert_eq!(
+            second.work_counters().for_family(CacheItemFamily::Resolve),
+            CacheItemWork {
+                hits: 3,
+                misses: 0,
+                stores: 1,
+                restores: 2,
+                evictions: 0,
+            }
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -15,7 +15,7 @@ use crate::{
     build_cache::{BuildCache, CacheETag, CacheIdentifier, CacheKey},
     cache_hash::StableHasher,
     code_generation_record::{
-        CodeGenerationReplacement, CodeGenerationResult, CodeGenerationSource,
+        CodeGenerationRecord, CodeGenerationReplacement, CodeGenerationResult, CodeGenerationSource,
     },
     id_assignment::RenderId,
     rendered_source::RenderedSource,
@@ -54,6 +54,98 @@ struct CodeGenerationInput<'a> {
     module_graph: &'a ModuleGraph,
     chunk_graph: &'a ChunkGraph,
     module_render_ids: &'a HashMap<ModuleId, RenderId>,
+}
+
+fn code_generation_etag(input: &CodeGenerationInput<'_>) -> CacheETag {
+    let CodeGenerationInput {
+        module,
+        module_graph,
+        chunk_graph,
+        module_render_ids,
+    } = input;
+    let mut hasher = StableHasher::default();
+    hasher.write(b"unpack/code-generation/etag/2");
+    // Parsed dependency/template inputs may be changed independently of source
+    // text by future module transforms, so they remain part of the item ETag.
+    module.source_hash().hash(&mut hasher);
+    module
+        .build_error()
+        .map(ToString::to_string)
+        .hash(&mut hasher);
+    module.is_harmony().hash(&mut hasher);
+    module
+        .code_generation_local_input_digest()
+        .hash(&mut hasher);
+    hash_used_export_names(module, &mut hasher);
+    module_render_ids.get(&module.id()).hash(&mut hasher);
+
+    for dependency_id in 0..module.dependencies().len() {
+        module_graph
+            .module_for_dependency(module.id(), None, dependency_id)
+            .and_then(|target| module_render_ids.get(&target))
+            .hash(&mut hasher);
+    }
+
+    for (block_index, block) in module.blocks().iter().enumerate() {
+        for dependency_id in 0..block.dependencies().len() {
+            module_graph
+                .module_for_dependency(module.id(), Some(block_index), dependency_id)
+                .and_then(|target| module_render_ids.get(&target))
+                .hash(&mut hasher);
+        }
+        chunk_graph
+            .block_chunk_group(AsyncBlockOrigin {
+                module: module.id(),
+                block_index,
+            })
+            .and_then(|group_id| {
+                chunk_graph.chunk_groups()[group_id.index()]
+                    .chunks()
+                    .first()
+            })
+            .and_then(|chunk_id| chunk_graph.chunk(*chunk_id))
+            .map(Chunk::render_id)
+            .hash(&mut hasher);
+    }
+
+    CacheETag::new(hasher.finish().to_le_bytes())
+}
+
+fn hash_used_export_names(module: &Module, hasher: &mut StableHasher) {
+    for dependency in module
+        .presentational_dependencies()
+        .iter()
+        .chain(module.dependencies())
+        .chain(
+            module
+                .blocks()
+                .iter()
+                .flat_map(|block| block.dependencies()),
+        )
+    {
+        match dependency {
+            Dependency::HarmonyExportSpecifier(dependency) => {
+                hasher.write_u8(0);
+                module
+                    .exports_info()
+                    .get_used_name(&dependency.name)
+                    .hash(hasher);
+            }
+            Dependency::HarmonyExportExpression(_) => {
+                hasher.write_u8(1);
+                module.exports_info().get_used_name("default").hash(hasher);
+            }
+            Dependency::HarmonyExportImportedSpecifier(dependency) => {
+                hasher.write_u8(2);
+                dependency
+                    .name
+                    .as_deref()
+                    .and_then(|name| module.exports_info().get_used_name(name))
+                    .hash(hasher);
+            }
+            _ => {}
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -134,6 +226,7 @@ enum InitFragmentStage {
     HarmonyStarReexport,
 }
 
+#[cfg(test)]
 pub(crate) fn generate_code(
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
@@ -141,12 +234,33 @@ pub(crate) fn generate_code(
     generate_code_with(module_graph, chunk_graph, generate_module_code)
 }
 
+pub(crate) fn generate_code_cached(
+    module_graph: &ModuleGraph,
+    chunk_graph: &ChunkGraph,
+    build_cache: &BuildCache,
+) -> CodeGenerationOutcome {
+    let cache = build_cache.code_generations();
+    generate_code_with(module_graph, chunk_graph, |input| {
+        let key = input.module.identity().clone();
+        let etag = code_generation_etag(&input);
+        if let Some(record) = cache.get(&key, Some(&etag)) {
+            if record.is_compatible_with(input.module.source()) {
+                return Ok(record.as_ref().clone());
+            }
+        }
+
+        let record = generate_module_code(input)?;
+        cache.store(key, Some(etag), record.clone());
+        Ok(record)
+    })
+}
+
 fn generate_code_with(
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
     mut generate_module: impl FnMut(
         CodeGenerationInput<'_>,
-    ) -> std::result::Result<CodeGenerationResult, Error>,
+    ) -> std::result::Result<CodeGenerationRecord, Error>,
 ) -> CodeGenerationOutcome {
     let module_render_ids = module_graph
         .modules()
@@ -178,12 +292,15 @@ fn generate_code_with(
             chunk_graph,
             module_render_ids: &module_render_ids,
         };
-        let result = generate_module(input).unwrap_or_else(|error| {
+        let record = generate_module(input).unwrap_or_else(|error| {
             errors.push(error.clone());
-            CodeGenerationResult::new(CodeGenerationSource::Raw {
+            CodeGenerationRecord::new(CodeGenerationSource::Raw {
                 source: render_failed_module_content(&error),
             })
         });
+        let result = record
+            .into_result(module.source())
+            .expect("generated Code Generation Record must match its Module source");
         let previous = results.insert(module.id(), result);
         assert!(
             previous.is_none(),
@@ -625,7 +742,7 @@ fn render_module_table(
 
 fn generate_module_code(
     input: CodeGenerationInput<'_>,
-) -> std::result::Result<CodeGenerationResult, Error> {
+) -> std::result::Result<CodeGenerationRecord, Error> {
     let CodeGenerationInput {
         module,
         module_graph,
@@ -633,7 +750,7 @@ fn generate_module_code(
         module_render_ids,
     } = input;
     if let Some(error) = module.build_error() {
-        return Ok(CodeGenerationResult::new(CodeGenerationSource::Raw {
+        return Ok(CodeGenerationRecord::new(CodeGenerationSource::Raw {
             source: render_failed_module_content(error),
         }));
     }
@@ -701,9 +818,10 @@ fn generate_module_code(
 
     let init = render_init_fragments(init_fragments);
     Ok(
-        CodeGenerationResult::new(CodeGenerationSource::OriginalWithReplacements {
+        CodeGenerationRecord::new(CodeGenerationSource::OriginalWithReplacements {
             prefix: init,
-            original_source: module.source().to_string(),
+            original_source_len: u32::try_from(module.source_len())
+                .expect("Module source length must fit the Code Generation cache format"),
             original_name: module_render_name,
             replacements: source
                 .replacements()
@@ -1143,14 +1261,16 @@ fn json_render_id(render_id: &RenderId) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{collections::HashMap, fs};
 
-    use rspack_sources::{ConcatSource, OriginalSource, Source};
+    use rspack_sources::{ConcatSource, OriginalSource, ReplacementEnforce, Source};
 
     use crate::{
         CacheOptions, Compiler, CompilerOptions, ConstDependency, Dependency, Entry, Error,
         ModuleGraph, ModuleId, ModuleIdentity, SnapshotOptions, SourceRange,
-        build_cache::{BuildCache, CacheIdentifier, CacheKey, CacheNamespace},
+        build_cache::{
+            BuildCache, CacheIdentifier, CacheItemFamily, CacheItemWork, CacheKey, CacheNamespace,
+        },
         id_assignment::{RenderId, assign_chunk_render_ids, assign_module_render_ids},
         runtime::RuntimeModule,
     };
@@ -1160,6 +1280,7 @@ mod tests {
         CodeGenerationResults, CodeGenerationSource, ModuleRenderManifest, RenderedSource,
         RuntimeRequirement, emit_asset,
     };
+    use crate::code_generation_record::{CodeGenerationRecord, CodeGenerationReplacement};
 
     #[test]
     fn asset_render_facade_uses_stable_namespace_and_manifest_identity() {
@@ -1248,6 +1369,130 @@ mod tests {
     }
 
     #[test]
+    fn code_generation_cache_invalidates_template_inputs_when_source_is_unchanged() {
+        let options = CompilerOptions::new("/project", vec![Entry::new("main", "./index")]);
+        let build = |expression: &str| {
+            let mut module_graph = ModuleGraph::default();
+            let module = module_graph.add_module(ModuleIdentity::new("/project/index.js"));
+            module_graph
+                .module_mut(module)
+                .expect("fixture Module should exist")
+                .finish_build(
+                    Vec::new(),
+                    Vec::new(),
+                    vec![Dependency::Const(ConstDependency::new(
+                        expression,
+                        SourceRange::new(0, 5),
+                    ))],
+                    "value".to_string(),
+                    1,
+                );
+            let mut chunk_graph = crate::ChunkGraph::build(&options, &module_graph, &[module]);
+            assign_module_render_ids(&options, &module_graph, &mut chunk_graph);
+            assign_chunk_render_ids(&options, &module_graph, &mut chunk_graph);
+            (module_graph, chunk_graph, module)
+        };
+        let build_cache = BuildCache::new(CacheOptions::memory(), SnapshotOptions::default());
+
+        let (first_graph, first_chunks, first_module) = build("first");
+        let first = super::generate_code_cached(&first_graph, &first_chunks, &build_cache);
+        assert_eq!(
+            first.results.results[&first_module]
+                .source()
+                .source()
+                .into_string_lossy(),
+            "first"
+        );
+
+        let (second_graph, second_chunks, second_module) = build("second");
+        let second = super::generate_code_cached(&second_graph, &second_chunks, &build_cache);
+        assert_eq!(
+            second.results.results[&second_module]
+                .source()
+                .source()
+                .into_string_lossy(),
+            "second"
+        );
+        assert_eq!(
+            build_cache
+                .work_counters()
+                .for_family(CacheItemFamily::CodeGeneration),
+            CacheItemWork {
+                hits: 0,
+                misses: 2,
+                stores: 2,
+                restores: 0,
+                evictions: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn incompatible_cached_replacement_recipe_is_regenerated() {
+        let options = CompilerOptions::new("/project", vec![Entry::new("main", "./index")]);
+        let mut module_graph = ModuleGraph::default();
+        let module = module_graph.add_module(ModuleIdentity::new("/project/index.js"));
+        module_graph
+            .module_mut(module)
+            .expect("fixture Module should exist")
+            .finish_build(Vec::new(), Vec::new(), Vec::new(), "éx".to_string(), 1);
+        let mut chunk_graph = crate::ChunkGraph::build(&options, &module_graph, &[module]);
+        assign_module_render_ids(&options, &module_graph, &mut chunk_graph);
+        assign_chunk_render_ids(&options, &module_graph, &mut chunk_graph);
+        let module_render_ids = HashMap::from([(
+            module,
+            chunk_graph
+                .module_render_id(module)
+                .expect("fixture Module should have a Render ID")
+                .clone(),
+        )]);
+        let module_ref = module_graph
+            .module(module)
+            .expect("fixture Module should exist");
+        let input = super::CodeGenerationInput {
+            module: module_ref,
+            module_graph: &module_graph,
+            chunk_graph: &chunk_graph,
+            module_render_ids: &module_render_ids,
+        };
+        let etag = super::code_generation_etag(&input);
+        let build_cache = BuildCache::new(CacheOptions::memory(), SnapshotOptions::default());
+        let cache = build_cache.code_generations();
+        cache.store(
+            module_ref.identity().clone(),
+            Some(etag.clone()),
+            CodeGenerationRecord::new(CodeGenerationSource::OriginalWithReplacements {
+                prefix: String::new(),
+                original_source_len: 3,
+                original_name: "fixture.js".to_string(),
+                replacements: vec![CodeGenerationReplacement {
+                    start: 1,
+                    end: 1,
+                    content: "invalid-boundary".to_string(),
+                    name: None,
+                    enforce: ReplacementEnforce::Normal,
+                }],
+                suffix: String::new(),
+            }),
+        );
+
+        let outcome = super::generate_code_cached(&module_graph, &chunk_graph, &build_cache);
+        assert_eq!(
+            outcome.results.results[&module]
+                .source()
+                .source()
+                .into_string_lossy(),
+            "éx"
+        );
+        assert!(
+            cache
+                .get(module_ref.identity(), Some(&etag))
+                .expect("regenerated Code Generation Record should be stored")
+                .is_compatible_with(module_ref.source())
+        );
+    }
+
+    #[test]
     fn module_attributable_generation_errors_become_throwing_results() {
         let options = CompilerOptions::new("/project", vec![Entry::new("main", "./index")]);
         let mut module_graph = ModuleGraph::default();
@@ -1269,23 +1514,40 @@ mod tests {
         assign_module_render_ids(&options, &module_graph, &mut chunk_graph);
         assign_chunk_render_ids(&options, &module_graph, &mut chunk_graph);
 
-        let outcome = super::generate_code(&module_graph, &chunk_graph);
-
+        let build_cache = BuildCache::new(CacheOptions::memory(), SnapshotOptions::default());
+        for outcome in [
+            super::generate_code_cached(&module_graph, &chunk_graph, &build_cache),
+            super::generate_code_cached(&module_graph, &chunk_graph, &build_cache),
+        ] {
+            assert_eq!(
+                outcome.errors,
+                [Error::CodeGeneration {
+                    module,
+                    path: "/project/index.js".into(),
+                    message: "dependency source range 0..99 exceeds module source length 5"
+                        .to_string(),
+                }]
+            );
+            assert!(outcome.errors[0].is_compilation_error());
+            assert!(
+                outcome.results.results[&module]
+                    .source()
+                    .source()
+                    .into_string_lossy()
+                    .contains("throw new Error")
+            );
+        }
         assert_eq!(
-            outcome.errors,
-            [Error::CodeGeneration {
-                module,
-                path: "/project/index.js".into(),
-                message: "dependency source range 0..99 exceeds module source length 5".to_string(),
-            }]
-        );
-        assert!(outcome.errors[0].is_compilation_error());
-        assert!(
-            outcome.results.results[&module]
-                .source()
-                .source()
-                .into_string_lossy()
-                .contains("throw new Error")
+            build_cache
+                .work_counters()
+                .for_family(CacheItemFamily::CodeGeneration),
+            CacheItemWork {
+                hits: 0,
+                misses: 2,
+                stores: 0,
+                restores: 0,
+                evictions: 0,
+            }
         );
     }
 

--- a/crates/unpack_core/src/code_generation_record.rs
+++ b/crates/unpack_core/src/code_generation_record.rs
@@ -5,17 +5,62 @@ use rspack_sources::{
 use crate::runtime::RuntimeRequirements;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CodeGenerationRecord {
+    source: CodeGenerationSource,
+    runtime_requirements: RuntimeRequirements,
+}
+
+impl CodeGenerationRecord {
+    pub(crate) fn new(source: CodeGenerationSource) -> Self {
+        Self {
+            source,
+            runtime_requirements: RuntimeRequirements::default(),
+        }
+    }
+
+    pub(crate) fn source(&self) -> &CodeGenerationSource {
+        &self.source
+    }
+
+    pub(crate) fn runtime_requirements(&self) -> &RuntimeRequirements {
+        &self.runtime_requirements
+    }
+
+    pub(crate) fn with_runtime_requirements(
+        mut self,
+        runtime_requirements: RuntimeRequirements,
+    ) -> Self {
+        self.runtime_requirements = runtime_requirements;
+        self
+    }
+
+    pub(crate) fn is_compatible_with(&self, original_source: &str) -> bool {
+        self.source.is_compatible_with(original_source)
+    }
+
+    pub(crate) fn into_result(self, original_source: &str) -> Option<CodeGenerationResult> {
+        if !self.is_compatible_with(original_source) {
+            return None;
+        }
+        Some(CodeGenerationResult {
+            source: self.source.into_render(original_source),
+            runtime_requirements: self.runtime_requirements,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CodeGenerationResult {
     source: ConcatSource,
     runtime_requirements: RuntimeRequirements,
 }
 
 impl CodeGenerationResult {
+    #[cfg(test)]
     pub(crate) fn new(record_source: CodeGenerationSource) -> Self {
-        Self {
-            source: record_source.render(),
-            runtime_requirements: RuntimeRequirements::default(),
-        }
+        CodeGenerationRecord::new(record_source)
+            .into_result("")
+            .expect("test Code Generation source should be compatible")
     }
 
     pub(crate) fn source(&self) -> &ConcatSource {
@@ -26,6 +71,7 @@ impl CodeGenerationResult {
         &self.runtime_requirements
     }
 
+    #[cfg(test)]
     pub(crate) fn with_runtime_requirements(
         mut self,
         runtime_requirements: RuntimeRequirements,
@@ -42,7 +88,7 @@ pub(crate) enum CodeGenerationSource {
     },
     OriginalWithReplacements {
         prefix: String,
-        original_source: String,
+        original_source_len: u32,
         original_name: String,
         replacements: Vec<CodeGenerationReplacement>,
         suffix: String,
@@ -50,35 +96,65 @@ pub(crate) enum CodeGenerationSource {
 }
 
 impl CodeGenerationSource {
-    fn render(&self) -> ConcatSource {
+    fn is_compatible_with(&self, original_source: &str) -> bool {
+        let Self::OriginalWithReplacements {
+            original_source_len,
+            replacements,
+            ..
+        } = self
+        else {
+            return true;
+        };
+        if usize::try_from(*original_source_len).ok() != Some(original_source.len()) {
+            return false;
+        }
+        replacements.iter().all(|replacement| {
+            let Some((start, end)) = usize::try_from(replacement.start)
+                .ok()
+                .zip(usize::try_from(replacement.end).ok())
+            else {
+                return false;
+            };
+            start <= end
+                && end <= original_source.len()
+                && original_source.is_char_boundary(start)
+                && original_source.is_char_boundary(end)
+        })
+    }
+
+    fn into_render(self, original_source: &str) -> ConcatSource {
         let mut source = ConcatSource::default();
         match self {
             Self::Raw { source: raw } => {
-                source.add(RawStringSource::from(raw.clone()));
+                source.add(RawStringSource::from(raw));
             }
             Self::OriginalWithReplacements {
                 prefix,
-                original_source,
+                original_source_len,
                 original_name,
                 replacements,
                 suffix,
             } => {
+                debug_assert_eq!(
+                    usize::try_from(original_source_len).ok(),
+                    Some(original_source.len())
+                );
                 let mut replaced = ReplaceSource::new(OriginalSource::new(
-                    original_source.clone(),
-                    original_name.clone(),
+                    original_source.to_string(),
+                    original_name,
                 ));
                 for replacement in replacements {
                     replaced.replace_with_enforce(
                         replacement.start,
                         replacement.end,
-                        replacement.content.clone(),
-                        replacement.name.clone(),
+                        replacement.content,
+                        replacement.name,
                         replacement.enforce,
                     );
                 }
-                source.add(RawStringSource::from(prefix.clone()));
+                source.add(RawStringSource::from(prefix));
                 source.add(replaced);
-                source.add(RawStringSource::from(suffix.clone()));
+                source.add(RawStringSource::from(suffix));
             }
         }
         source
@@ -103,5 +179,37 @@ impl From<&Replacement> for CodeGenerationReplacement {
             name: replacement.name().map(str::to_string),
             enforce: replacement.enforce(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rspack_sources::ReplacementEnforce;
+
+    use super::{CodeGenerationRecord, CodeGenerationReplacement, CodeGenerationSource};
+
+    fn replacement_record(start: u32, end: u32, source_len: u32) -> CodeGenerationRecord {
+        CodeGenerationRecord::new(CodeGenerationSource::OriginalWithReplacements {
+            prefix: String::new(),
+            original_source_len: source_len,
+            original_name: "fixture.js".to_string(),
+            replacements: vec![CodeGenerationReplacement {
+                start,
+                end,
+                content: "replacement".to_string(),
+                name: None,
+                enforce: ReplacementEnforce::Normal,
+            }],
+            suffix: String::new(),
+        })
+    }
+
+    #[test]
+    fn replacement_recipe_must_match_current_utf8_source_boundaries() {
+        let source = "éx";
+        assert!(replacement_record(2, 3, 3).is_compatible_with(source));
+        assert!(replacement_record(1, 3, 3).into_result(source).is_none());
+        assert!(replacement_record(0, 1, 3).into_result(source).is_none());
+        assert!(replacement_record(2, 3, 2).into_result(source).is_none());
     }
 }

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -228,7 +228,11 @@ impl Compilation {
             self.render_ids_assigned,
             "Render IDs must be assigned before code generation"
         );
-        let outcome = code_generation::generate_code(&self.module_graph, &self.chunk_graph);
+        let outcome = code_generation::generate_code_cached(
+            &self.module_graph,
+            &self.chunk_graph,
+            &self.build_cache,
+        );
         self.errors.extend(outcome.errors);
         self.code_generation_results = Some(outcome.results);
         self.asset_render_manifest = None;

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -923,6 +923,11 @@ mod tests {
         assert_eq!(second_cache.resolve_hits, 2);
         assert_eq!(second_cache.module_hits, 2);
         assert_eq!(asset_sources(&first), asset_sources(&second));
+        assert_ne!(
+            first.module_graph().modules().as_ptr(),
+            second.module_graph().modules().as_ptr(),
+            "a later Compiler must assemble a fresh ModuleGraph"
+        );
         let restored_work = second_compiler.build_cache.work_counters();
         assert_eq!(
             restored_work.for_family(CacheItemFamily::Resolve),
@@ -936,6 +941,16 @@ mod tests {
         );
         assert_eq!(
             restored_work.for_family(CacheItemFamily::ModuleBuild),
+            CacheItemWork {
+                hits: 2,
+                misses: 0,
+                stores: 0,
+                restores: 2,
+                evictions: 0,
+            }
+        );
+        assert_eq!(
+            restored_work.for_family(CacheItemFamily::CodeGeneration),
             CacheItemWork {
                 hits: 2,
                 misses: 0,
@@ -967,6 +982,16 @@ mod tests {
                 evictions: 0,
             }
         );
+        assert_eq!(
+            repopulated_work.for_family(CacheItemFamily::CodeGeneration),
+            CacheItemWork {
+                hits: 4,
+                misses: 0,
+                stores: 0,
+                restores: 2,
+                evictions: 0,
+            }
+        );
         assert_eq!(asset_sources(&second), asset_sources(&third));
         assert_ne!(
             second.module_graph().modules().as_ptr(),
@@ -976,6 +1001,32 @@ mod tests {
             second.chunk_graph().chunks().as_ptr(),
             third.chunk_graph().chunks().as_ptr()
         );
+        for restored_module in second.module_graph().modules() {
+            let cached_record = second_compiler
+                .build_cache
+                .module_builds()
+                .get(restored_module.identity(), None)
+                .expect("restored Module Build Record should remain in Memory Cache");
+            let rebuilt_module = third
+                .module_graph()
+                .modules()
+                .iter()
+                .find(|module| module.identity() == restored_module.identity())
+                .expect("later ModuleGraph should contain the same Module Identity");
+
+            assert!(
+                !std::ptr::eq(restored_module, rebuilt_module),
+                "each Compilation must create a distinct Module object"
+            );
+            assert!(Arc::ptr_eq(
+                restored_module.built_content(),
+                cached_record.built_content()
+            ));
+            assert!(Arc::ptr_eq(
+                restored_module.built_content(),
+                rebuilt_module.built_content()
+            ));
+        }
 
         Ok(())
     }

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -14,7 +14,7 @@ use crate::{
     CompilerOptions, Dependency, DependencyKind, Error, FactorizedModule, ModuleGraph, ModuleId,
     ModuleIdentity, NormalModuleFactory, Result, SnapshotStrategy, UnpackResolver,
     build_cache::{BuildCache, ModuleBuildCache, ModuleBuildRecord},
-    cache_hash::stable_hash,
+    module::BuiltModuleContent,
     parser::{ParsedModule, parse_module_dependencies},
     snapshot::{FileSystemInfo, SnapshotCache},
 };
@@ -379,11 +379,10 @@ impl BuildTask {
             if valid {
                 let process_dependencies =
                     process_dependencies_task(self.module_id, &issuer_context, record.parsed());
-                let (parsed, source, source_hash) = record.cloned_parts();
                 state
                     .lock()
                     .await
-                    .finish_build(self.module_id, parsed, source, source_hash)?;
+                    .finish_build(self.module_id, Arc::clone(record.built_content()))?;
                 return Ok(process_dependencies.into_iter().collect());
             }
         }
@@ -414,10 +413,11 @@ impl BuildTask {
             process_dependencies_task(self.module_id, &issuer_context, &parsed);
 
         if !services.module_build_cache.is_enabled() {
+            let built_content = Arc::new(BuiltModuleContent::new(parsed, source));
             state
                 .lock()
                 .await
-                .finish_build(self.module_id, parsed, source, None)?;
+                .finish_build(self.module_id, built_content)?;
             return Ok(process_dependencies.into_iter().collect());
         }
 
@@ -425,13 +425,13 @@ impl BuildTask {
             .file_system_info
             .create_file_snapshot(&self.resource, &source, services.module_snapshot_strategy)
             .await?;
-        let record = ModuleBuildRecord::new(parsed.clone(), source.clone(), snapshot);
-        let source_hash = record.source_hash();
+        let built_content = Arc::new(BuiltModuleContent::new(parsed, source));
+        let record = ModuleBuildRecord::new(Arc::clone(&built_content), snapshot);
 
         state
             .lock()
             .await
-            .finish_build(self.module_id, parsed, source, source_hash)?;
+            .finish_build(self.module_id, built_content)?;
         services
             .module_build_cache
             .store(self.identity, None, record);
@@ -621,22 +621,13 @@ impl MakeState {
     fn finish_build(
         &mut self,
         module_id: ModuleId,
-        parsed: ParsedModule,
-        source: String,
-        source_hash: Option<u64>,
+        built_content: Arc<BuiltModuleContent>,
     ) -> Result<()> {
         let module = self
             .module_graph
             .module_mut(module_id)
             .ok_or(Error::MissingModule(module_id))?;
-        let source_hash = source_hash.unwrap_or_else(|| stable_hash(&source));
-        module.finish_build(
-            parsed.dependencies,
-            parsed.blocks,
-            parsed.presentational_dependencies,
-            source,
-            source_hash,
-        );
+        module.finish_build_content(built_content);
         Ok(())
     }
 

--- a/crates/unpack_core/src/module.rs
+++ b/crates/unpack_core/src/module.rs
@@ -1,8 +1,16 @@
-use std::path::PathBuf;
+use std::{
+    hash::{Hash, Hasher},
+    path::PathBuf,
+    sync::Arc,
+};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{AsyncDependenciesBlock, Dependency, Error, ExportsInfo, cache_hash::stable_hash};
+use crate::{
+    AsyncDependenciesBlock, Dependency, Error, ExportsInfo,
+    cache_hash::{StableHasher, stable_hash},
+    parser::ParsedModule,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ModuleId(usize);
@@ -21,15 +29,60 @@ impl ModuleId {
 pub struct Module {
     id: ModuleId,
     identity: ModuleIdentity,
-    dependencies: Vec<Dependency>,
-    blocks: Vec<AsyncDependenciesBlock>,
-    presentational_dependencies: Vec<Dependency>,
+    built_content: Arc<BuiltModuleContent>,
     exports_info: ExportsInfo,
-    source: String,
-    source_len: usize,
-    source_hash: u64,
     build_error: Option<Error>,
     harmony: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct BuiltModuleContent {
+    parsed: ParsedModule,
+    source: String,
+    source_hash: u64,
+    code_generation_local_input_digest: u64,
+}
+
+impl BuiltModuleContent {
+    pub(crate) fn new(parsed: ParsedModule, source: String) -> Self {
+        let source_hash = stable_hash(&source);
+        Self::from_persistent_parts(parsed, source, source_hash)
+    }
+
+    pub(crate) fn from_persistent_parts(
+        parsed: ParsedModule,
+        source: String,
+        source_hash: u64,
+    ) -> Self {
+        let mut hasher = StableHasher::default();
+        hasher.write(b"unpack/code-generation/local-inputs/1");
+        parsed.dependencies.hash(&mut hasher);
+        parsed.blocks.hash(&mut hasher);
+        parsed.presentational_dependencies.hash(&mut hasher);
+        let code_generation_local_input_digest = hasher.finish();
+        Self {
+            parsed,
+            source,
+            source_hash,
+            code_generation_local_input_digest,
+        }
+    }
+
+    pub(crate) fn parsed(&self) -> &ParsedModule {
+        &self.parsed
+    }
+
+    pub(crate) fn source(&self) -> &str {
+        &self.source
+    }
+
+    pub(crate) fn source_hash(&self) -> u64 {
+        self.source_hash
+    }
+
+    pub(crate) fn code_generation_local_input_digest(&self) -> u64 {
+        self.code_generation_local_input_digest
+    }
 }
 
 impl Module {
@@ -37,13 +90,11 @@ impl Module {
         Self {
             id,
             identity,
-            dependencies: Vec::new(),
-            blocks: Vec::new(),
-            presentational_dependencies: Vec::new(),
+            built_content: Arc::new(BuiltModuleContent::new(
+                ParsedModule::default(),
+                String::new(),
+            )),
             exports_info: ExportsInfo::default(),
-            source: String::new(),
-            source_len: 0,
-            source_hash: stable_hash(""),
             build_error: None,
             harmony: false,
         }
@@ -58,15 +109,15 @@ impl Module {
     }
 
     pub fn dependencies(&self) -> &[Dependency] {
-        &self.dependencies
+        &self.built_content.parsed.dependencies
     }
 
     pub fn blocks(&self) -> &[AsyncDependenciesBlock] {
-        &self.blocks
+        &self.built_content.parsed.blocks
     }
 
     pub fn presentational_dependencies(&self) -> &[Dependency] {
-        &self.presentational_dependencies
+        &self.built_content.parsed.presentational_dependencies
     }
 
     pub fn exports_info(&self) -> &ExportsInfo {
@@ -74,15 +125,24 @@ impl Module {
     }
 
     pub fn source(&self) -> &str {
-        &self.source
+        self.built_content.source()
     }
 
     pub fn source_len(&self) -> usize {
-        self.source_len
+        self.built_content.source.len()
     }
 
     pub fn source_hash(&self) -> u64 {
-        self.source_hash
+        self.built_content.source_hash()
+    }
+
+    pub(crate) fn code_generation_local_input_digest(&self) -> u64 {
+        self.built_content.code_generation_local_input_digest()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn built_content(&self) -> &Arc<BuiltModuleContent> {
+        &self.built_content
     }
 
     pub fn build_error(&self) -> Option<&Error> {
@@ -93,6 +153,7 @@ impl Module {
         self.harmony
     }
 
+    #[cfg(test)]
     pub(crate) fn finish_build(
         &mut self,
         dependencies: Vec<Dependency>,
@@ -101,28 +162,32 @@ impl Module {
         source: String,
         source_hash: u64,
     ) {
-        self.exports_info = ExportsInfo::from_dependencies(&dependencies);
-        self.harmony = dependencies
+        self.finish_build_content(Arc::new(BuiltModuleContent::from_persistent_parts(
+            ParsedModule {
+                dependencies,
+                blocks,
+                presentational_dependencies,
+            },
+            source,
+            source_hash,
+        )));
+    }
+
+    pub(crate) fn finish_build_content(&mut self, content: Arc<BuiltModuleContent>) {
+        self.exports_info = ExportsInfo::from_dependencies(&content.parsed.dependencies);
+        self.harmony = content
+            .parsed
+            .dependencies
             .iter()
-            .chain(&presentational_dependencies)
+            .chain(&content.parsed.presentational_dependencies)
             .any(Dependency::is_harmony_dependency);
-        self.source_len = source.len();
-        self.source_hash = source_hash;
-        self.source = source;
-        self.dependencies = dependencies;
-        self.blocks = blocks;
-        self.presentational_dependencies = presentational_dependencies;
+        self.built_content = content;
         self.build_error = None;
     }
 
     pub(crate) fn fail_build(&mut self, error: Error, source: String) {
         self.exports_info = ExportsInfo::default();
-        self.source_len = source.len();
-        self.source_hash = stable_hash(&source);
-        self.source = source;
-        self.dependencies.clear();
-        self.blocks.clear();
-        self.presentational_dependencies.clear();
+        self.built_content = Arc::new(BuiltModuleContent::new(ParsedModule::default(), source));
         self.build_error = Some(error);
         self.harmony = false;
     }

--- a/crates/unpack_core/src/pack_file.rs
+++ b/crates/unpack_core/src/pack_file.rs
@@ -1343,8 +1343,9 @@ mod tests {
         assert_eq!(ModuleBuildRecordDto::try_from(&module_record)?, module_dto);
 
         let mut runtime_requirements = RuntimeRequirements::default();
-        runtime_requirements.insert(RuntimeRequirement::Require);
-        runtime_requirements.insert(RuntimeRequirement::EnsureChunk);
+        for requirement in ALL_RUNTIME_REQUIREMENTS {
+            runtime_requirements.insert(requirement);
+        }
         let code_generation_record =
             CodeGenerationRecord::new(CodeGenerationSource::OriginalWithReplacements {
                 prefix: "prefix".to_string(),
@@ -2697,7 +2698,21 @@ impl CodeGenerationRecordDto {
     }
 }
 
-const RUNTIME_REQUIREMENT_MASK: u16 = (1 << 9) - 1;
+const ALL_RUNTIME_REQUIREMENTS: [RuntimeRequirement; 11] = [
+    RuntimeRequirement::ModuleFactories,
+    RuntimeRequirement::ModuleCache,
+    RuntimeRequirement::Require,
+    RuntimeRequirement::DefinePropertyGetters,
+    RuntimeRequirement::HasOwnProperty,
+    RuntimeRequirement::MakeNamespaceObject,
+    RuntimeRequirement::EnsureChunk,
+    RuntimeRequirement::EnsureChunkHandlers,
+    RuntimeRequirement::GetChunkFilename,
+    RuntimeRequirement::ModuleFactoriesAddOnly,
+    RuntimeRequirement::ReturnExportsFromRuntime,
+];
+
+const RUNTIME_REQUIREMENT_MASK: u16 = (1 << ALL_RUNTIME_REQUIREMENTS.len()) - 1;
 
 fn encode_runtime_requirements(requirements: &RuntimeRequirements) -> u16 {
     requirements.iter().fold(0, |mask, requirement| {
@@ -2710,17 +2725,7 @@ fn decode_runtime_requirements(mask: u16) -> Option<RuntimeRequirements> {
         return None;
     }
     let mut requirements = RuntimeRequirements::default();
-    for requirement in [
-        RuntimeRequirement::ModuleFactories,
-        RuntimeRequirement::ModuleCache,
-        RuntimeRequirement::Require,
-        RuntimeRequirement::DefinePropertyGetters,
-        RuntimeRequirement::HasOwnProperty,
-        RuntimeRequirement::MakeNamespaceObject,
-        RuntimeRequirement::EnsureChunk,
-        RuntimeRequirement::GetChunkFilename,
-        RuntimeRequirement::ReturnExportsFromRuntime,
-    ] {
+    for requirement in ALL_RUNTIME_REQUIREMENTS {
         if mask & (1 << runtime_requirement_bit(requirement)) != 0 {
             requirements.insert(requirement);
         }
@@ -2739,6 +2744,8 @@ const fn runtime_requirement_bit(requirement: RuntimeRequirement) -> u16 {
         RuntimeRequirement::EnsureChunk => 6,
         RuntimeRequirement::GetChunkFilename => 7,
         RuntimeRequirement::ReturnExportsFromRuntime => 8,
+        RuntimeRequirement::EnsureChunkHandlers => 9,
+        RuntimeRequirement::ModuleFactoriesAddOnly => 10,
     }
 }
 

--- a/crates/unpack_core/src/pack_file.rs
+++ b/crates/unpack_core/src/pack_file.rs
@@ -68,6 +68,7 @@ mod tests {
             PackFileReadStats {
                 index_reads: 1,
                 content_reads: 0,
+                content_pack_reads: 0,
                 content_bytes_read: 0,
                 decoded_records: 0,
                 retained_content_bytes: 0,
@@ -94,6 +95,98 @@ mod tests {
         assert!(stats.content_bytes_read > 0);
         assert_eq!(stats.decoded_records, 1);
 
+        Ok(())
+    }
+
+    #[test]
+    fn uncompressed_content_pack_is_read_once_and_reused_across_records()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempdir()?;
+        let first = PackFileAddress::new("unpack/dummy", b"first");
+        let second = PackFileAddress::new("unpack/dummy", b"second");
+        let registry = CodecRegistry::new().with_codec::<DummyItem, _>(DummyCodec);
+        let mut batch = PackFileWriteBatch::new();
+        batch.insert(&registry, first.clone(), None, DummyItem(vec![1; 96]))?;
+        batch.insert(&registry, second.clone(), None, DummyItem(vec![2; 96]))?;
+        PackFile::publish_batch_with_options(
+            temp.path(),
+            None,
+            PublicationBase::ReplaceAll,
+            batch,
+            PackFilePublicationOptions::new(
+                PackFileRetention::new(AccessStamp::from_millis(1_000), DEFAULT_MAX_AGE),
+                PackFileCompression::None,
+            ),
+        )?;
+
+        let index = decode_index(&fs::read(PackFile::index_path(temp.path()))?)
+            .expect("decode uncompressed PackFile index");
+        let first_content = &index.entries[&first].content;
+        let second_content = &index.entries[&second].content;
+        assert_eq!(first_content.file, second_content.file);
+        let content_path = temp.path().join(&first_content.file);
+        let pack_size = usize::try_from(first_content.pack_size)?;
+
+        let mut reopened =
+            PackFile::open_with_options(temp.path(), registry, PackFileOpenOptions::new(false));
+        assert_eq!(
+            reopened.get::<DummyItem>(&first, None).as_deref(),
+            Some(&DummyItem(vec![1; 96]))
+        );
+        assert_eq!(reopened.read_stats().content_pack_reads, 1);
+        assert_eq!(reopened.read_stats().retained_content_bytes, pack_size);
+
+        fs::remove_file(content_path)?;
+        assert_eq!(
+            reopened.get::<DummyItem>(&second, None).as_deref(),
+            Some(&DummyItem(vec![2; 96]))
+        );
+        assert_eq!(reopened.read_stats().content_pack_reads, 1);
+        assert_eq!(reopened.read_stats().retained_content_bytes, pack_size);
+        Ok(())
+    }
+
+    #[test]
+    fn retained_content_pack_rejects_conflicting_index_metadata()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempdir()?;
+        let first = PackFileAddress::new("unpack/dummy", b"first");
+        let second = PackFileAddress::new("unpack/dummy", b"second");
+        let registry = CodecRegistry::new().with_codec::<DummyItem, _>(DummyCodec);
+        let mut batch = PackFileWriteBatch::new();
+        batch.insert(&registry, first.clone(), None, DummyItem(vec![1; 32]))?;
+        batch.insert(&registry, second.clone(), None, DummyItem(vec![2; 32]))?;
+        PackFile::publish_batch_with_options(
+            temp.path(),
+            None,
+            PublicationBase::ReplaceAll,
+            batch,
+            PackFilePublicationOptions::new(
+                PackFileRetention::new(AccessStamp::from_millis(1_000), DEFAULT_MAX_AGE),
+                PackFileCompression::None,
+            ),
+        )?;
+
+        let index_path = PackFile::index_path(temp.path());
+        let mut index = decode_index(&fs::read(&index_path)?).expect("decode PackFile index");
+        assert_eq!(
+            index.entries[&first].content.file,
+            index.entries[&second].content.file
+        );
+        index
+            .entries
+            .get_mut(&second)
+            .expect("second entry should exist")
+            .content
+            .compression = PackFileCompression::Gzip;
+        fs::write(index_path, encode_index(&index)?)?;
+
+        let mut reopened = PackFile::open(temp.path(), registry);
+        assert_eq!(
+            reopened.get::<DummyItem>(&first, None).as_deref(),
+            Some(&DummyItem(vec![1; 32]))
+        );
+        assert!(reopened.get::<DummyItem>(&second, None).is_none());
         Ok(())
     }
 
@@ -251,7 +344,7 @@ mod tests {
         let record = CodeGenerationRecordDto {
             source: CodeGenerationSourceDto::OriginalWithReplacements {
                 prefix: "(() => {\n".to_string(),
-                original_source: "export const value = before;".to_string(),
+                original_source_len: 28,
                 original_name: "./src/index.js".to_string(),
                 replacements: vec![CodeGenerationReplacementDto {
                     start: 21,
@@ -262,6 +355,7 @@ mod tests {
                 }],
                 suffix: "\n})".to_string(),
             },
+            runtime_requirements: RUNTIME_REQUIREMENT_MASK,
         };
         let registry =
             CodecRegistry::new().with_code_generation_record(CodeGenerationRecordCodec::current());
@@ -294,13 +388,14 @@ mod tests {
             source: CodeGenerationSourceDto::Raw {
                 source: "throw new Error('failed module');".to_string(),
             },
+            runtime_requirements: 0,
         };
-        assert_eq!(codec.decode(&codec.encode(&raw)?), Some(raw));
+        assert_eq!(codec.decode(&codec.encode(&raw)?), Some(raw.clone()));
 
         let invalid_range = CodeGenerationRecordDto {
             source: CodeGenerationSourceDto::OriginalWithReplacements {
                 prefix: String::new(),
-                original_source: "short".to_string(),
+                original_source_len: 5,
                 original_name: "./short.js".to_string(),
                 replacements: vec![CodeGenerationReplacementDto {
                     start: 0,
@@ -311,6 +406,7 @@ mod tests {
                 }],
                 suffix: String::new(),
             },
+            runtime_requirements: 0,
         };
         assert!(codec.encode(&invalid_range).is_err());
 
@@ -318,9 +414,21 @@ mod tests {
             source: CodeGenerationSourceDto::Raw {
                 source: "valid".to_string(),
             },
+            runtime_requirements: 0,
         })?;
-        unknown_tag[0] = 0xff;
+        unknown_tag[4] = 0xff;
         assert!(codec.decode(&unknown_tag).is_none());
+
+        let unknown_requirement = CodeGenerationRecordDto {
+            source: CodeGenerationSourceDto::Raw {
+                source: "valid".to_string(),
+            },
+            runtime_requirements: 1 << 15,
+        };
+        assert!(codec.encode(&unknown_requirement).is_err());
+        let mut corrupted_requirement = codec.encode(&raw)?;
+        corrupted_requirement[..4].copy_from_slice(&(1_u32 << 15).to_le_bytes());
+        assert!(codec.decode(&corrupted_requirement).is_none());
         Ok(())
     }
 
@@ -1234,23 +1342,28 @@ mod tests {
         let module_record = ModuleBuildRecord::try_from(module_dto.clone())?;
         assert_eq!(ModuleBuildRecordDto::try_from(&module_record)?, module_dto);
 
-        let code_generation_source = CodeGenerationSource::OriginalWithReplacements {
-            prefix: "prefix".to_string(),
-            original_source: "before".to_string(),
-            original_name: "./fixture.js".to_string(),
-            replacements: vec![CodeGenerationReplacement {
-                start: 0,
-                end: 6,
-                content: "after".to_string(),
-                name: None,
-                enforce: ReplacementEnforce::Normal,
-            }],
-            suffix: "suffix".to_string(),
-        };
-        let code_generation_dto = CodeGenerationRecordDto::from(&code_generation_source);
+        let mut runtime_requirements = RuntimeRequirements::default();
+        runtime_requirements.insert(RuntimeRequirement::Require);
+        runtime_requirements.insert(RuntimeRequirement::EnsureChunk);
+        let code_generation_record =
+            CodeGenerationRecord::new(CodeGenerationSource::OriginalWithReplacements {
+                prefix: "prefix".to_string(),
+                original_source_len: 6,
+                original_name: "./fixture.js".to_string(),
+                replacements: vec![CodeGenerationReplacement {
+                    start: 0,
+                    end: 6,
+                    content: "after".to_string(),
+                    name: None,
+                    enforce: ReplacementEnforce::Normal,
+                }],
+                suffix: "suffix".to_string(),
+            })
+            .with_runtime_requirements(runtime_requirements);
+        let code_generation_dto = CodeGenerationRecordDto::from(&code_generation_record);
         assert_eq!(
-            CodeGenerationSource::try_from(code_generation_dto)?,
-            code_generation_source
+            CodeGenerationRecord::try_from(code_generation_dto)?,
+            code_generation_record
         );
         Ok(())
     }
@@ -1442,7 +1555,8 @@ mod tests {
 
         let path = PathBytes(vec![b'/', b'p', b'k', b'g', 0xff]);
         assert_eq!(
-            path.to_path_buf()
+            path.clone()
+                .into_path_buf()
                 .expect("Linux path bytes should be recoverable")
                 .as_os_str()
                 .as_bytes(),
@@ -1742,11 +1856,7 @@ use std::{
 
 use brotli::{CompressorWriter, Decompressor};
 use flate2::{Compression as GzipLevel, read::GzDecoder, write::GzEncoder};
-#[cfg(test)]
 use rspack_sources::ReplacementEnforce;
-
-#[cfg(test)]
-use crate::code_generation_record::{CodeGenerationReplacement, CodeGenerationSource};
 
 use crate::{
     AsyncDependenciesBlock, ConstDependency, Dependency, EntryDependency,
@@ -1756,8 +1866,12 @@ use crate::{
     ModuleDependency, ModuleIdentity, ModuleType, NullDependency, SourceRange,
     build_cache::{ModuleBuildRecord, ResolveRecord},
     cache_hash::stable_hash,
+    code_generation_record::{
+        CodeGenerationRecord, CodeGenerationReplacement, CodeGenerationSource,
+    },
     parser::ParsedModule,
     rendered_source::RenderedSource,
+    runtime::{RuntimeRequirement, RuntimeRequirements},
     snapshot::{PersistentManagedItemState, PersistentSnapshotEntry, Snapshot},
 };
 
@@ -1789,13 +1903,11 @@ const BROTLI_WINDOW_BITS: u32 = 22;
 const GZIP_LEVEL: u32 = 6;
 const RESOLVE_RECORD_CODEC_ID: StableCodecId = StableCodecId::new(*b"unpack.rslv.c001");
 const MODULE_BUILD_RECORD_CODEC_ID: StableCodecId = StableCodecId::new(*b"unpack.modb.c001");
-#[cfg(test)]
-const CODE_GENERATION_RECORD_CODEC_ID: StableCodecId = StableCodecId::new(*b"unpack.cgen.c001");
+const CODE_GENERATION_RECORD_CODEC_ID: StableCodecId = StableCodecId::new(*b"unpack.cgen.c003");
 const ASSET_RENDER_RECORD_CODEC_ID: StableCodecId = StableCodecId::new(*b"unpack.astr.c001");
 pub(crate) const RESOLVE_RECORD_TYPE_ID: StableTypeId = StableTypeId::new(*b"unpack.resolve.1");
 pub(crate) const MODULE_BUILD_RECORD_TYPE_ID: StableTypeId =
     StableTypeId::new(*b"unpack.moduleb.1");
-#[cfg(test)]
 pub(crate) const CODE_GENERATION_RECORD_TYPE_ID: StableTypeId =
     StableTypeId::new(*b"unpack.codegen.1");
 pub(crate) const ASSET_RENDER_RECORD_TYPE_ID: StableTypeId =
@@ -1980,13 +2092,13 @@ impl PathBytes {
     }
 
     #[cfg(unix)]
-    pub(crate) fn to_path_buf(&self) -> Option<PathBuf> {
-        Some(PathBuf::from(std::ffi::OsString::from_vec(self.0.clone())))
+    pub(crate) fn into_path_buf(self) -> Option<PathBuf> {
+        Some(PathBuf::from(std::ffi::OsString::from_vec(self.0)))
     }
 
     #[cfg(not(unix))]
-    pub(crate) fn to_path_buf(&self) -> Option<PathBuf> {
-        String::from_utf8(self.0.clone()).ok().map(PathBuf::from)
+    pub(crate) fn into_path_buf(self) -> Option<PathBuf> {
+        String::from_utf8(self.0).ok().map(PathBuf::from)
     }
 }
 
@@ -2074,13 +2186,12 @@ pub(crate) struct AssetRenderRecordDto {
     pub(crate) source_map: Option<String>,
 }
 
-#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CodeGenerationRecordDto {
     pub(crate) source: CodeGenerationSourceDto,
+    pub(crate) runtime_requirements: u16,
 }
 
-#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CodeGenerationSourceDto {
     Raw {
@@ -2088,14 +2199,13 @@ pub(crate) enum CodeGenerationSourceDto {
     },
     OriginalWithReplacements {
         prefix: String,
-        original_source: String,
+        original_source_len: u32,
         original_name: String,
         replacements: Vec<CodeGenerationReplacementDto>,
         suffix: String,
     },
 }
 
-#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CodeGenerationReplacementDto {
     pub(crate) start: u32,
@@ -2105,7 +2215,6 @@ pub(crate) struct CodeGenerationReplacementDto {
     pub(crate) enforce: ReplacementEnforceDto,
 }
 
-#[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ReplacementEnforceDto {
     Pre,
@@ -2465,7 +2574,7 @@ impl TryFrom<&ModuleBuildRecord> for ModuleBuildRecordDto {
     type Error = io::Error;
 
     fn try_from(record: &ModuleBuildRecord) -> io::Result<Self> {
-        let (parsed, source, source_hash) = record.cloned_parts();
+        let (parsed, source, source_hash) = record.persistent_parts();
         let source_hash = source_hash.ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -2473,8 +2582,8 @@ impl TryFrom<&ModuleBuildRecord> for ModuleBuildRecordDto {
             )
         })?;
         let dto = Self {
-            parsed: ParsedModuleDto::try_from(&parsed)?,
-            source,
+            parsed: ParsedModuleDto::try_from(parsed)?,
+            source: source.to_string(),
             source_hash,
             snapshot: SnapshotDto::try_from(record.snapshot())?,
         };
@@ -2487,31 +2596,36 @@ impl TryFrom<ModuleBuildRecordDto> for ModuleBuildRecord {
     type Error = io::Error;
 
     fn try_from(record: ModuleBuildRecordDto) -> io::Result<Self> {
-        validate_module_build_record(&record)?;
-        Ok(ModuleBuildRecord::new(
-            ParsedModule::try_from(&record.parsed)?,
-            record.source,
-            Snapshot::try_from(record.snapshot)?,
+        let ModuleBuildRecordDto {
+            parsed,
+            source,
+            source_hash,
+            snapshot,
+        } = record;
+        Ok(ModuleBuildRecord::from_persistent_parts(
+            ParsedModule::try_from(parsed)?,
+            source,
+            source_hash,
+            Snapshot::try_from(snapshot)?,
         ))
     }
 }
 
-#[cfg(test)]
-impl From<&CodeGenerationSource> for CodeGenerationRecordDto {
-    fn from(record: &CodeGenerationSource) -> Self {
-        let source = match record {
+impl From<&CodeGenerationRecord> for CodeGenerationRecordDto {
+    fn from(record: &CodeGenerationRecord) -> Self {
+        let source = match record.source() {
             CodeGenerationSource::Raw { source } => CodeGenerationSourceDto::Raw {
                 source: source.clone(),
             },
             CodeGenerationSource::OriginalWithReplacements {
                 prefix,
-                original_source,
+                original_source_len,
                 original_name,
                 replacements,
                 suffix,
             } => CodeGenerationSourceDto::OriginalWithReplacements {
                 prefix: prefix.clone(),
-                original_source: original_source.clone(),
+                original_source_len: *original_source_len,
                 original_name: original_name.clone(),
                 replacements: replacements
                     .iter()
@@ -2530,27 +2644,37 @@ impl From<&CodeGenerationSource> for CodeGenerationRecordDto {
                 suffix: suffix.clone(),
             },
         };
-        Self { source }
+        Self {
+            source,
+            runtime_requirements: encode_runtime_requirements(record.runtime_requirements()),
+        }
     }
 }
 
-#[cfg(test)]
-impl TryFrom<CodeGenerationRecordDto> for CodeGenerationSource {
+impl TryFrom<CodeGenerationRecordDto> for CodeGenerationRecord {
     type Error = io::Error;
 
     fn try_from(record: CodeGenerationRecordDto) -> io::Result<Self> {
         validate_code_generation_record(&record)?;
-        let source = match record.source {
+        Ok(record.into_record_after_codec_validation())
+    }
+}
+
+impl CodeGenerationRecordDto {
+    pub(crate) fn into_record_after_codec_validation(self) -> CodeGenerationRecord {
+        let runtime_requirements = decode_runtime_requirements(self.runtime_requirements)
+            .expect("Code Generation codec must reject unknown Runtime Requirements");
+        let source = match self.source {
             CodeGenerationSourceDto::Raw { source } => CodeGenerationSource::Raw { source },
             CodeGenerationSourceDto::OriginalWithReplacements {
                 prefix,
-                original_source,
+                original_source_len,
                 original_name,
                 replacements,
                 suffix,
             } => CodeGenerationSource::OriginalWithReplacements {
                 prefix,
-                original_source,
+                original_source_len,
                 original_name,
                 replacements: replacements
                     .into_iter()
@@ -2569,7 +2693,52 @@ impl TryFrom<CodeGenerationRecordDto> for CodeGenerationSource {
                 suffix,
             },
         };
-        Ok(source)
+        CodeGenerationRecord::new(source).with_runtime_requirements(runtime_requirements)
+    }
+}
+
+const RUNTIME_REQUIREMENT_MASK: u16 = (1 << 9) - 1;
+
+fn encode_runtime_requirements(requirements: &RuntimeRequirements) -> u16 {
+    requirements.iter().fold(0, |mask, requirement| {
+        mask | (1 << runtime_requirement_bit(requirement))
+    })
+}
+
+fn decode_runtime_requirements(mask: u16) -> Option<RuntimeRequirements> {
+    if mask & !RUNTIME_REQUIREMENT_MASK != 0 {
+        return None;
+    }
+    let mut requirements = RuntimeRequirements::default();
+    for requirement in [
+        RuntimeRequirement::ModuleFactories,
+        RuntimeRequirement::ModuleCache,
+        RuntimeRequirement::Require,
+        RuntimeRequirement::DefinePropertyGetters,
+        RuntimeRequirement::HasOwnProperty,
+        RuntimeRequirement::MakeNamespaceObject,
+        RuntimeRequirement::EnsureChunk,
+        RuntimeRequirement::GetChunkFilename,
+        RuntimeRequirement::ReturnExportsFromRuntime,
+    ] {
+        if mask & (1 << runtime_requirement_bit(requirement)) != 0 {
+            requirements.insert(requirement);
+        }
+    }
+    Some(requirements)
+}
+
+const fn runtime_requirement_bit(requirement: RuntimeRequirement) -> u16 {
+    match requirement {
+        RuntimeRequirement::ModuleFactories => 0,
+        RuntimeRequirement::ModuleCache => 1,
+        RuntimeRequirement::Require => 2,
+        RuntimeRequirement::DefinePropertyGetters => 3,
+        RuntimeRequirement::HasOwnProperty => 4,
+        RuntimeRequirement::MakeNamespaceObject => 5,
+        RuntimeRequirement::EnsureChunk => 6,
+        RuntimeRequirement::GetChunkFilename => 7,
+        RuntimeRequirement::ReturnExportsFromRuntime => 8,
     }
 }
 
@@ -2610,7 +2779,7 @@ fn validate_module_build_record(record: &ModuleBuildRecordDto) -> io::Result<()>
 }
 
 fn path_from_bytes(path: PathBytes) -> io::Result<PathBuf> {
-    path.to_path_buf().ok_or_else(|| {
+    path.into_path_buf().ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::InvalidData,
             "PackFile path bytes are invalid on this platform",
@@ -2749,32 +2918,34 @@ impl TryFrom<&ParsedModule> for ParsedModuleDto {
     }
 }
 
-impl TryFrom<&ParsedModuleDto> for ParsedModule {
+impl TryFrom<ParsedModuleDto> for ParsedModule {
     type Error = io::Error;
 
-    fn try_from(parsed: &ParsedModuleDto) -> io::Result<Self> {
+    fn try_from(parsed: ParsedModuleDto) -> io::Result<Self> {
+        let ParsedModuleDto {
+            dependencies,
+            blocks,
+            presentational_dependencies,
+        } = parsed;
         Ok(Self {
-            dependencies: parsed
-                .dependencies
-                .iter()
+            dependencies: dependencies
+                .into_iter()
                 .map(dependency_from_dto)
                 .collect::<io::Result<_>>()?,
-            blocks: parsed
-                .blocks
-                .iter()
+            blocks: blocks
+                .into_iter()
                 .map(|block| {
                     Ok(AsyncDependenciesBlock::new(
                         block
                             .dependencies
-                            .iter()
+                            .into_iter()
                             .map(dependency_from_dto)
                             .collect::<io::Result<_>>()?,
                     ))
                 })
                 .collect::<io::Result<_>>()?,
-            presentational_dependencies: parsed
-                .presentational_dependencies
-                .iter()
+            presentational_dependencies: presentational_dependencies
+                .into_iter()
                 .map(dependency_from_dto)
                 .collect::<io::Result<_>>()?,
         })
@@ -2829,7 +3000,7 @@ fn dependency_to_dto(dependency: &Dependency) -> io::Result<DependencyDto> {
     })
 }
 
-fn dependency_from_dto(dependency: &DependencyDto) -> io::Result<Dependency> {
+fn dependency_from_dto(dependency: DependencyDto) -> io::Result<Dependency> {
     Ok(match dependency {
         DependencyDto::Entry { module } => Dependency::Entry(EntryDependency {
             module: module_dependency_from_dto(module)?,
@@ -2837,7 +3008,7 @@ fn dependency_from_dto(dependency: &DependencyDto) -> io::Result<Dependency> {
         DependencyDto::HarmonyImportSideEffect { module, import_var } => {
             Dependency::HarmonyImportSideEffect(HarmonyImportSideEffectDependency {
                 module: module_dependency_from_dto(module)?,
-                import_var: import_var.clone(),
+                import_var,
             })
         }
         DependencyDto::HarmonyImportSpecifier {
@@ -2848,32 +3019,29 @@ fn dependency_from_dto(dependency: &DependencyDto) -> io::Result<Dependency> {
             shorthand,
         } => Dependency::HarmonyImportSpecifier(HarmonyImportSpecifierDependency {
             module: module_dependency_from_dto(module)?,
-            ids: ids.clone(),
-            name: name.clone(),
-            usage_range: (*usage_range).into(),
-            shorthand: *shorthand,
+            ids,
+            name,
+            usage_range: usage_range.into(),
+            shorthand,
         }),
         DependencyDto::HarmonyExportHeader {
             declaration_range,
             statement_range,
         } => Dependency::HarmonyExportHeader(HarmonyExportHeaderDependency {
             declaration_range: declaration_range.map(Into::into),
-            statement_range: (*statement_range).into(),
+            statement_range: statement_range.into(),
         }),
         DependencyDto::HarmonyExportSpecifier { id, name } => {
-            Dependency::HarmonyExportSpecifier(HarmonyExportSpecifierDependency {
-                id: id.clone(),
-                name: name.clone(),
-            })
+            Dependency::HarmonyExportSpecifier(HarmonyExportSpecifierDependency { id, name })
         }
         DependencyDto::HarmonyExportExpression {
             range,
             statement_range,
             declaration_id,
         } => Dependency::HarmonyExportExpression(HarmonyExportExpressionDependency {
-            range: (*range).into(),
-            statement_range: (*statement_range).into(),
-            declaration_id: declaration_id.clone(),
+            range: range.into(),
+            statement_range: statement_range.into(),
+            declaration_id,
         }),
         DependencyDto::HarmonyExportImportedSpecifier {
             module,
@@ -2882,14 +3050,14 @@ fn dependency_from_dto(dependency: &DependencyDto) -> io::Result<Dependency> {
             is_star,
         } => Dependency::HarmonyExportImportedSpecifier(HarmonyExportImportedSpecifierDependency {
             module: module_dependency_from_dto(module)?,
-            ids: ids.clone(),
-            name: name.clone(),
-            is_star: *is_star,
+            ids,
+            name,
+            is_star,
         }),
         DependencyDto::Null => Dependency::Null(NullDependency),
         DependencyDto::Const { expression, range } => Dependency::Const(ConstDependency {
-            expression: expression.clone(),
-            range: (*range).into(),
+            expression,
+            range: range.into(),
         }),
         DependencyDto::Import { module } => Dependency::Import(ImportDependency {
             module: module_dependency_from_dto(module)?,
@@ -2916,10 +3084,10 @@ fn module_dependency_to_dto(dependency: &ModuleDependency) -> io::Result<ModuleD
     })
 }
 
-fn module_dependency_from_dto(dependency: &ModuleDependencyDto) -> io::Result<ModuleDependency> {
+fn module_dependency_from_dto(dependency: ModuleDependencyDto) -> io::Result<ModuleDependency> {
     Ok(ModuleDependency {
-        request: dependency.request.clone(),
-        user_request: dependency.user_request.clone(),
+        request: dependency.request,
+        user_request: dependency.user_request,
         source_order: dependency
             .source_order
             .map(usize::try_from)
@@ -2962,7 +3130,6 @@ impl PackFileItem for ModuleBuildRecordDto {
     const TYPE_ID: StableTypeId = MODULE_BUILD_RECORD_TYPE_ID;
 }
 
-#[cfg(test)]
 impl PackFileItem for CodeGenerationRecordDto {
     const TYPE_ID: StableTypeId = CODE_GENERATION_RECORD_TYPE_ID;
 }
@@ -3040,7 +3207,6 @@ impl CodecRegistry {
         self
     }
 
-    #[cfg(test)]
     pub(crate) fn with_code_generation_record(mut self, codec: CodeGenerationRecordCodec) -> Self {
         self.register::<CodeGenerationRecordDto, _>(codec);
         self
@@ -3168,13 +3334,11 @@ impl ItemCodec<ModuleBuildRecordDto> for ModuleBuildRecordCodec {
     }
 }
 
-#[cfg(test)]
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct CodeGenerationRecordCodec {
     codec_id: StableCodecId,
 }
 
-#[cfg(test)]
 impl CodeGenerationRecordCodec {
     pub(crate) const fn current() -> Self {
         Self {
@@ -3183,7 +3347,6 @@ impl CodeGenerationRecordCodec {
     }
 }
 
-#[cfg(test)]
 impl ItemCodec<CodeGenerationRecordDto> for CodeGenerationRecordCodec {
     fn codec_id(&self) -> StableCodecId {
         self.codec_id
@@ -3192,6 +3355,7 @@ impl ItemCodec<CodeGenerationRecordDto> for CodeGenerationRecordCodec {
     fn encode(&self, value: &CodeGenerationRecordDto) -> io::Result<Vec<u8>> {
         validate_code_generation_record(value)?;
         let mut encoder = Encoder::default();
+        encoder.write_u32(u32::from(value.runtime_requirements));
         match &value.source {
             CodeGenerationSourceDto::Raw { source } => {
                 encoder.write_u8(0);
@@ -3199,14 +3363,14 @@ impl ItemCodec<CodeGenerationRecordDto> for CodeGenerationRecordCodec {
             }
             CodeGenerationSourceDto::OriginalWithReplacements {
                 prefix,
-                original_source,
+                original_source_len,
                 original_name,
                 replacements,
                 suffix,
             } => {
                 encoder.write_u8(1);
                 encoder.write_record_string(prefix)?;
-                encoder.write_record_string(original_source)?;
+                encoder.write_u32(*original_source_len);
                 encoder.write_record_string(original_name)?;
                 encoder.write_count(replacements.len())?;
                 for replacement in replacements {
@@ -3228,13 +3392,14 @@ impl ItemCodec<CodeGenerationRecordDto> for CodeGenerationRecordCodec {
 
     fn decode(&self, bytes: &[u8]) -> Option<CodeGenerationRecordDto> {
         let mut decoder = Decoder::new(bytes);
+        let runtime_requirements = u16::try_from(decoder.read_u32()?).ok()?;
         let source = match decoder.read_u8()? {
             0 => CodeGenerationSourceDto::Raw {
                 source: decoder.read_record_string()?,
             },
             1 => {
                 let prefix = decoder.read_record_string()?;
-                let original_source = decoder.read_record_string()?;
+                let original_source_len = decoder.read_u32()?;
                 let original_name = decoder.read_record_string()?;
                 let replacement_count = decoder.read_count()?;
                 let mut replacements = Vec::with_capacity(replacement_count);
@@ -3254,7 +3419,7 @@ impl ItemCodec<CodeGenerationRecordDto> for CodeGenerationRecordCodec {
                 }
                 CodeGenerationSourceDto::OriginalWithReplacements {
                     prefix,
-                    original_source,
+                    original_source_len,
                     original_name,
                     replacements,
                     suffix: decoder.read_record_string()?,
@@ -3263,16 +3428,24 @@ impl ItemCodec<CodeGenerationRecordDto> for CodeGenerationRecordCodec {
             _ => return None,
         };
         decoder.finish()?;
-        let record = CodeGenerationRecordDto { source };
+        let record = CodeGenerationRecordDto {
+            source,
+            runtime_requirements,
+        };
         validate_code_generation_record(&record).ok()?;
         Some(record)
     }
 }
 
-#[cfg(test)]
 fn validate_code_generation_record(record: &CodeGenerationRecordDto) -> io::Result<()> {
+    if record.runtime_requirements & !RUNTIME_REQUIREMENT_MASK != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Code Generation Record contains unknown Runtime Requirements",
+        ));
+    }
     let CodeGenerationSourceDto::OriginalWithReplacements {
-        original_source,
+        original_source_len,
         replacements,
         ..
     } = &record.source
@@ -3292,11 +3465,7 @@ fn validate_code_generation_record(record: &CodeGenerationRecordDto) -> io::Resu
                 "Code Generation Record replacement end is invalid",
             )
         })?;
-        if start > end
-            || end > original_source.len()
-            || !original_source.is_char_boundary(start)
-            || !original_source.is_char_boundary(end)
-        {
+        if start > end || end > usize::try_from(*original_source_len).unwrap_or(usize::MAX) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Code Generation Record contains an invalid replacement range",
@@ -4151,6 +4320,7 @@ struct ContentReference {
 struct PackFileReadStats {
     index_reads: usize,
     content_reads: usize,
+    content_pack_reads: usize,
     content_bytes_read: usize,
     decoded_records: usize,
     retained_content_bytes: usize,
@@ -4163,9 +4333,45 @@ pub(crate) struct PackFile {
     index: PackFileIndex,
     access_updates: BTreeMap<PackFileAddress, AccessStamp>,
     allow_collecting_memory: bool,
-    content_buffers: HashMap<PathBuf, Vec<u8>>,
+    content_buffers: HashMap<PathBuf, RetainedContentPack>,
     #[cfg(test)]
     reads: PackFileReadStats,
+}
+
+#[derive(Debug)]
+struct RetainedContentPack {
+    compression: PackFileCompression,
+    pack_size: u64,
+    content: Arc<[u8]>,
+}
+
+#[derive(Debug)]
+pub(crate) struct PackFileRestore<T> {
+    registry: CodecRegistry,
+    type_id: StableTypeId,
+    codec_id: StableCodecId,
+    checksum: u64,
+    content: Arc<[u8]>,
+    start: usize,
+    end: usize,
+    marker: std::marker::PhantomData<fn() -> T>,
+}
+
+impl<T: PackFileItem> PackFileRestore<T> {
+    pub(crate) fn decode(self) -> Option<T> {
+        let frame = self.content.get(self.start..self.end)?;
+        let (type_id, codec_id, payload) = decode_indexed_content(frame, self.checksum)?;
+        if type_id != self.type_id || codec_id != self.codec_id {
+            return None;
+        }
+        self.registry.decode::<T>(type_id, codec_id, payload)
+    }
+}
+
+struct LoadedContent {
+    content: Arc<[u8]>,
+    start: usize,
+    end: usize,
 }
 
 impl PackFile {
@@ -4249,36 +4455,14 @@ impl PackFile {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn get<T: PackFileItem>(
         &mut self,
         address: &PackFileAddress,
         etag: Option<&PackFileETag>,
     ) -> Option<Arc<T>> {
-        let entry = self.index.entries.get(address)?.clone();
-        if entry.etag.as_ref() != etag || entry.type_id != T::TYPE_ID {
-            return None;
-        }
-        if self.registry.codecs.get(&entry.type_id)?.codec_id() != entry.codec_id {
-            return None;
-        }
-
-        #[cfg(test)]
-        {
-            self.reads.content_reads += 1;
-        }
-        let frame = self.read_content_frame(&entry.content)?;
-        #[cfg(test)]
-        {
-            self.reads.content_bytes_read += frame.len();
-        }
-        if checksum(&frame) != entry.content.checksum {
-            return None;
-        }
-        let (type_id, codec_id, payload) = decode_content(&frame)?;
-        if type_id != entry.type_id || codec_id != entry.codec_id {
-            return None;
-        }
-        let value = self.registry.decode::<T>(type_id, codec_id, payload)?;
+        let restore = self.prepare_restore(address, etag)?;
+        let value = restore.decode()?;
         #[cfg(test)]
         {
             self.reads.decoded_records += 1;
@@ -4286,29 +4470,108 @@ impl PackFile {
         Some(Arc::new(value))
     }
 
-    fn read_content_frame(&mut self, reference: &ContentReference) -> Option<Vec<u8>> {
-        let path = self.root.join(&reference.file);
-        if reference.compression == PackFileCompression::None {
-            return read_content_reference(&path, reference);
+    pub(crate) fn prepare_restore<T: PackFileItem>(
+        &mut self,
+        address: &PackFileAddress,
+        etag: Option<&PackFileETag>,
+    ) -> Option<PackFileRestore<T>> {
+        let entry = self.index.entries.get(address)?.clone();
+        if entry.etag.as_ref() != etag || entry.type_id != T::TYPE_ID {
+            return None;
         }
+        if self.registry.codecs.get(&entry.type_id)?.codec_id() != entry.codec_id {
+            return None;
+        }
+        #[cfg(test)]
+        {
+            self.reads.content_reads += 1;
+        }
+        let loaded = self.load_content(&entry.content)?;
+        #[cfg(test)]
+        {
+            self.reads.content_bytes_read += loaded.end.checked_sub(loaded.start)?;
+        }
+        Some(PackFileRestore {
+            registry: self.registry.clone(),
+            type_id: entry.type_id,
+            codec_id: entry.codec_id,
+            checksum: entry.content.checksum,
+            content: loaded.content,
+            start: loaded.start,
+            end: loaded.end,
+            marker: std::marker::PhantomData,
+        })
+    }
 
+    fn load_content(&mut self, reference: &ContentReference) -> Option<LoadedContent> {
+        let path = self.root.join(&reference.file);
         if self.allow_collecting_memory {
-            let pack = read_content_pack(&path, reference.compression, reference.pack_size)?;
-            return content_frame_from_pack(&pack, reference);
+            if reference.compression == PackFileCompression::None {
+                let content = Arc::<[u8]>::from(read_content_reference(&path, reference)?);
+                let end = content.len();
+                return Some(LoadedContent {
+                    content,
+                    start: 0,
+                    end,
+                });
+            }
+            #[cfg(test)]
+            {
+                self.reads.content_pack_reads += 1;
+            }
+            let content = Arc::<[u8]>::from(read_content_pack(
+                &path,
+                reference.compression,
+                reference.pack_size,
+            )?);
+            let (start, end) = content_frame_range(content.len(), reference)?;
+            return Some(LoadedContent {
+                content,
+                start,
+                end,
+            });
         }
 
         if !self.content_buffers.contains_key(&reference.file) {
-            let pack = read_content_pack(&path, reference.compression, reference.pack_size)?;
+            #[cfg(test)]
+            {
+                self.reads.content_pack_reads += 1;
+            }
+            let pack = Arc::<[u8]>::from(read_content_pack(
+                &path,
+                reference.compression,
+                reference.pack_size,
+            )?);
             #[cfg(test)]
             {
                 self.reads.retained_content_bytes =
                     self.reads.retained_content_bytes.checked_add(pack.len())?;
             }
-            self.content_buffers.insert(reference.file.clone(), pack);
+            self.content_buffers.insert(
+                reference.file.clone(),
+                RetainedContentPack {
+                    compression: reference.compression,
+                    pack_size: reference.pack_size,
+                    content: pack,
+                },
+            );
         }
-        content_frame_from_pack(self.content_buffers.get(&reference.file)?, reference)
+        let retained = self.content_buffers.get(&reference.file)?;
+        if retained.compression != reference.compression
+            || retained.pack_size != reference.pack_size
+        {
+            return None;
+        }
+        let content = Arc::clone(&retained.content);
+        let (start, end) = content_frame_range(content.len(), reference)?;
+        Some(LoadedContent {
+            content,
+            start,
+            end,
+        })
     }
 
+    #[cfg(test)]
     pub(crate) fn get_resolve_record(
         &mut self,
         address: &PackFileAddress,
@@ -4317,6 +4580,7 @@ impl PackFile {
         self.get(address, etag)
     }
 
+    #[cfg(test)]
     pub(crate) fn get_module_build_record(
         &mut self,
         address: &PackFileAddress,
@@ -4952,10 +5216,22 @@ fn read_decompressed_pack(reader: impl Read, expected_size: usize) -> Option<Vec
 }
 
 fn content_frame_from_pack(pack: &[u8], reference: &ContentReference) -> Option<Vec<u8>> {
+    Some(content_frame_slice_from_pack(pack, reference)?.to_vec())
+}
+
+fn content_frame_slice_from_pack<'a>(
+    pack: &'a [u8],
+    reference: &ContentReference,
+) -> Option<&'a [u8]> {
+    let (start, end) = content_frame_range(pack.len(), reference)?;
+    pack.get(start..end)
+}
+
+fn content_frame_range(pack_len: usize, reference: &ContentReference) -> Option<(usize, usize)> {
     let start = usize::try_from(reference.offset).ok()?;
     let length = usize::try_from(reference.length).ok()?;
     let end = start.checked_add(length)?;
-    Some(pack.get(start..end)?.to_vec())
+    (end <= pack_len).then_some((start, end))
 }
 
 fn read_content_reference(path: &Path, reference: &ContentReference) -> Option<Vec<u8>> {
@@ -5128,6 +5404,27 @@ fn encode_content(
 
 fn decode_content(bytes: &[u8]) -> Option<(StableTypeId, StableCodecId, &[u8])> {
     let body = decode_frame(bytes, CONTENT_MAGIC, MAX_CONTENT_BYTES)?;
+    decode_content_body(body, true)
+}
+
+fn decode_indexed_content(
+    bytes: &[u8],
+    expected_checksum: u64,
+) -> Option<(StableTypeId, StableCodecId, &[u8])> {
+    // The checksummed index binds the frame checksum and bounds. Verify
+    // the complete referenced frame once, then parse its two legacy nested
+    // checksums without hashing the same payload two more times.
+    if checksum(bytes) != expected_checksum {
+        return None;
+    }
+    let body = decode_frame_unchecked(bytes, CONTENT_MAGIC, MAX_CONTENT_BYTES)?;
+    decode_content_body(body, false)
+}
+
+fn decode_content_body(
+    body: &[u8],
+    verify_payload_checksum: bool,
+) -> Option<(StableTypeId, StableCodecId, &[u8])> {
     let mut decoder = Decoder::new(body);
     let type_id = StableTypeId(decoder.read_exact()?);
     let codec_id = StableCodecId(decoder.read_exact()?);
@@ -5141,7 +5438,8 @@ fn decode_content(bytes: &[u8]) -> Option<(StableTypeId, StableCodecId, &[u8])> 
     let payload = body.get(start..end)?;
     decoder.position = end;
     decoder.finish()?;
-    (checksum(payload) == expected_checksum).then_some((type_id, codec_id, payload))
+    (!verify_payload_checksum || checksum(payload) == expected_checksum)
+        .then_some((type_id, codec_id, payload))
 }
 
 fn encode_frame(magic: &[u8], body: &[u8], maximum: usize) -> io::Result<Vec<u8>> {
@@ -5169,6 +5467,19 @@ fn encode_frame(magic: &[u8], body: &[u8], maximum: usize) -> io::Result<Vec<u8>
 }
 
 fn decode_frame<'a>(bytes: &'a [u8], magic: &[u8], maximum: usize) -> Option<&'a [u8]> {
+    let (body, expected_checksum) = decode_frame_parts(bytes, magic, maximum)?;
+    (checksum(body) == expected_checksum).then_some(body)
+}
+
+fn decode_frame_unchecked<'a>(bytes: &'a [u8], magic: &[u8], maximum: usize) -> Option<&'a [u8]> {
+    decode_frame_parts(bytes, magic, maximum).map(|(body, _)| body)
+}
+
+fn decode_frame_parts<'a>(
+    bytes: &'a [u8],
+    magic: &[u8],
+    maximum: usize,
+) -> Option<(&'a [u8], u64)> {
     if bytes.len() > maximum || !bytes.starts_with(magic) {
         return None;
     }
@@ -5181,7 +5492,7 @@ fn decode_frame<'a>(bytes: &'a [u8], magic: &[u8], maximum: usize) -> Option<&'a
         return None;
     }
     let body = bytes.get(header_end..end)?;
-    (checksum(body) == expected_checksum).then_some(body)
+    Some((body, expected_checksum))
 }
 
 fn checksum(bytes: &[u8]) -> u64 {

--- a/packages/unpack/test/persistent-cache-contract.test.ts
+++ b/packages/unpack/test/persistent-cache-contract.test.ts
@@ -12,7 +12,10 @@ import {
   runCacheProcessExpectTermination,
   runColdWarmBuilds
 } from "./cache-process-harness.js";
-import type { CacheProcessObservation } from "./cache-process-harness.js";
+import type {
+  CacheItemWorkObservation,
+  CacheProcessObservation
+} from "./cache-process-harness.js";
 
 test("omitted cache follows mode while both-disabled module Snapshots remain valid configuration", async () => {
   await assertOmittedCacheBehavior("development", "before");
@@ -419,13 +422,13 @@ test("unchanged Resolve and Module Build work restores in an independent process
     assert.deepEqual(cold.cacheWork, {
       resolve: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
       moduleBuild: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
-      codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
+      codeGeneration: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
       assetRender: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 }
     });
     assert.deepEqual(warm.cacheWork, {
       resolve: { hits: 2, misses: 0, stores: 0, restores: 2, evictions: 0 },
       moduleBuild: { hits: 2, misses: 0, stores: 0, restores: 2, evictions: 0 },
-      codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
+      codeGeneration: { hits: 2, misses: 0, stores: 0, restores: 2, evictions: 0 },
       assetRender: { hits: 1, misses: 0, stores: 0, restores: 1, evictions: 0 }
     });
   } finally {
@@ -433,7 +436,7 @@ test("unchanged Resolve and Module Build work restores in an independent process
   }
 });
 
-test("Code Generation runs once per module in each independent Compilation", async () => {
+test("Code Generation records restore unchanged modules and invalidate changed inputs", async () => {
   const fixture = await createFixture({
     "src/index.js": [
       "export async function load() {",
@@ -465,14 +468,26 @@ test("Code Generation runs once per module in each independent Compilation", asy
   try {
     const cold = await runCacheProcess(request(coldOutput));
     assert.equal(cold.error, null);
-    assertNoCodeGenerationCacheWork(cold);
+    assertCodeGenerationCacheWork(cold, {
+      hits: 0,
+      misses: 2,
+      stores: 2,
+      restores: 0,
+      evictions: 0
+    });
     const coldFiles = await readAssetRenderFixture(coldOutput);
 
     const warm = await runCacheProcess(request(warmOutput));
     assert.equal(warm.error, null);
     assert.notEqual(cold.pid, warm.pid);
     assert.notEqual(cold.instanceId, warm.instanceId);
-    assertNoCodeGenerationCacheWork(warm);
+    assertCodeGenerationCacheWork(warm, {
+      hits: 2,
+      misses: 0,
+      stores: 0,
+      restores: 2,
+      evictions: 0
+    });
     assert.deepEqual(await readAssetRenderFixture(warmOutput), coldFiles);
     assert.deepEqual(warm.assetDetails, cold.assetDetails);
 
@@ -483,7 +498,13 @@ test("Code Generation runs once per module in each independent Compilation", asy
     );
     const changed = await runCacheProcess(request(changedOutput));
     assert.equal(changed.error, null);
-    assertNoCodeGenerationCacheWork(changed);
+    assertCodeGenerationCacheWork(changed, {
+      hits: 1,
+      misses: 1,
+      stores: 1,
+      restores: 1,
+      evictions: 0
+    });
     assert.match(
       await readFile(join(changedOutput, "src_feature_js.js"), "utf8"),
       /after/
@@ -506,7 +527,13 @@ test("Code Generation runs once per module in each independent Compilation", asy
     );
     const graphChanged = await runCacheProcess(request(graphOutput));
     assert.equal(graphChanged.error, null);
-    assertNoCodeGenerationCacheWork(graphChanged);
+    assertCodeGenerationCacheWork(graphChanged, {
+      hits: 1,
+      misses: 2,
+      stores: 2,
+      restores: 1,
+      evictions: 0
+    });
     assert.deepEqual(graphChanged.assets, [
       "main.js",
       "main.js.map",
@@ -657,13 +684,13 @@ test("resolved Build Dependency requests guard PackFile entries across processes
     assert.deepEqual(cold.cacheWork, {
       resolve: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 },
       moduleBuild: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 },
-      codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
+      codeGeneration: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 },
       assetRender: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 }
     });
     assert.deepEqual(relabeledWarm.cacheWork, {
       resolve: { hits: 1, misses: 0, stores: 0, restores: 1, evictions: 0 },
       moduleBuild: { hits: 1, misses: 0, stores: 0, restores: 1, evictions: 0 },
-      codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
+      codeGeneration: { hits: 1, misses: 0, stores: 0, restores: 1, evictions: 0 },
       assetRender: { hits: 1, misses: 0, stores: 0, restores: 1, evictions: 0 }
     });
     assert.deepEqual(changed.cacheWork, cold.cacheWork);
@@ -805,7 +832,7 @@ test("a source mutation rebuilds only the affected Module Build record", async (
     assert.deepEqual(cold.cacheWork, {
       resolve: { hits: 0, misses: 3, stores: 3, restores: 0, evictions: 0 },
       moduleBuild: { hits: 0, misses: 3, stores: 3, restores: 0, evictions: 0 },
-      codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
+      codeGeneration: { hits: 0, misses: 3, stores: 3, restores: 0, evictions: 0 },
       assetRender: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 }
     });
 
@@ -820,7 +847,7 @@ test("a source mutation rebuilds only the affected Module Build record", async (
     assert.deepEqual(changed.cacheWork, {
       resolve: { hits: 3, misses: 0, stores: 0, restores: 3, evictions: 0 },
       moduleBuild: { hits: 3, misses: 0, stores: 1, restores: 3, evictions: 0 },
-      codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
+      codeGeneration: { hits: 2, misses: 1, stores: 1, restores: 2, evictions: 0 },
       assetRender: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 }
     });
     assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /after/);
@@ -857,14 +884,14 @@ test("cache version is an exact container guard at the same location", async () 
       assert.deepEqual(cold.cacheWork, {
         resolve: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
         moduleBuild: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
-        codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
+        codeGeneration: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
         assetRender: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 }
       });
     }
     assert.deepEqual(warmV2.cacheWork, {
       resolve: { hits: 2, misses: 0, stores: 0, restores: 2, evictions: 0 },
       moduleBuild: { hits: 2, misses: 0, stores: 0, restores: 2, evictions: 0 },
-      codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
+      codeGeneration: { hits: 2, misses: 0, stores: 0, restores: 2, evictions: 0 },
       assetRender: { hits: 1, misses: 0, stores: 0, restores: 1, evictions: 0 }
     });
   } finally {
@@ -924,7 +951,7 @@ test("legacy JSON and CBOR cache files remain untouched and are treated as cold"
     assert.deepEqual(observation.cacheWork, {
       resolve: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
       moduleBuild: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
-      codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
+      codeGeneration: { hits: 0, misses: 2, stores: 2, restores: 0, evictions: 0 },
       assetRender: { hits: 0, misses: 1, stores: 1, restores: 0, evictions: 0 }
     });
     assert.deepEqual(await readFile(manifestPath), manifest);
@@ -1078,19 +1105,16 @@ function singleModuleCacheWork(kind: "cold" | "warm") {
   return {
     resolve: { ...item },
     moduleBuild: { ...item },
-    codeGeneration: { hits: 0, misses: 0, stores: 0, restores: 0, evictions: 0 },
+    codeGeneration: { ...item },
     assetRender: { ...item }
   };
 }
 
-function assertNoCodeGenerationCacheWork(observation: CacheProcessObservation) {
-  assert.deepEqual(observation.cacheWork?.codeGeneration, {
-    hits: 0,
-    misses: 0,
-    stores: 0,
-    restores: 0,
-    evictions: 0
-  });
+function assertCodeGenerationCacheWork(
+  observation: CacheProcessObservation,
+  expected: CacheItemWorkObservation
+) {
+  assert.deepEqual(observation.cacheWork?.codeGeneration, expected);
 }
 
 async function readAssetRenderFixture(outputPath: string) {


### PR DESCRIPTION
## Summary
- Update warm-cache handling and related cache-boundary behavior across the core pipeline.
- Refine code-generation and module/compilation paths to align with the new warm-cache ceiling flow.
- Adjust pack-file/build-cache interactions and add related coverage in the persistent cache contract tests.

## Why
- Ensure cache warmup and ceiling logic remains consistent across build, code-generation, and packaging behavior.

## Testing
- Not run in this PR.
