### PR TITLE
Benchmark JavaScript modules with swc-loader

### DIFF
--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -1,6 +1,6 @@
 # Cross-Bundler Benchmark
 
-The Cross-Bundler Benchmark compares Unpack with webpack, Rspack, Rolldown, Metro, Parcel, and Turbopack on the `large` and `loader` Benchmark Fixtures. The `large` fixture is derived from webpack's `benchmark/cases/all` workload and generated locally so benchmark runs do not need network access. The `loader` fixture uses the same module graph and checksum as `large`, but webpack and Rspack run every JavaScript module through `swc-loader`. Adapters without webpack-compatible loader rules, including the current Unpack and Turbopack adapters, report `unsupported`. The results are diagnostic signals for maintainers; they are not merge gates and they are not compatibility claims.
+The Cross-Bundler Benchmark compares Unpack with webpack, Rspack, Rolldown, Metro, Parcel, and Turbopack on the `large` and `loader` Benchmark Fixtures. The `large` fixture is derived from webpack's `benchmark/cases/all` workload and generated locally so benchmark runs do not need network access. The `loader` fixture uses the same module graph and checksum as `large`, but webpack and Rspack run every JavaScript module plus the fixture's `rome.ts` entry through `swc-loader`. Adapters without webpack-compatible loader rules, including the current Unpack and Turbopack adapters, report `unsupported`. The results are diagnostic signals for maintainers; they are not merge gates and they are not compatibility claims.
 
 ## Local Run
 

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -56,7 +56,7 @@ trace server with `pnpm next internal trace <trace.log>` or
 
 ## Result Shape
 
-The runner emits a Markdown summary and can write the raw JSON report with `--output-json`.
+The runner emits a Markdown summary with the loader results in the first table and the results without loaders in a separate second table. It can also write the raw JSON report with `--output-json`.
 
 Important fields:
 

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -1,6 +1,6 @@
 # Cross-Bundler Benchmark
 
-The Cross-Bundler Benchmark compares Unpack with webpack, Rspack, Rolldown, Metro, Parcel, and Turbopack on the `large` and `loader` Benchmark Fixtures. The `large` fixture is derived from webpack's `benchmark/cases/all` workload and generated locally so benchmark runs do not need network access. The `loader` fixture uses the same `large` workload with an added webpack-compatible loader pipeline for webpack and Rspack. The Turbopack CLI adapter materializes equivalent JavaScript modules for the loader inputs because the pinned standalone CLI does not expose webpack loader rules. Adapters without a loader-fixture path report `unsupported`. The results are diagnostic signals for maintainers; they are not merge gates and they are not compatibility claims.
+The Cross-Bundler Benchmark compares Unpack with webpack, Rspack, Rolldown, Metro, Parcel, and Turbopack on the `large` and `loader` Benchmark Fixtures. The `large` fixture is derived from webpack's `benchmark/cases/all` workload and generated locally so benchmark runs do not need network access. The `loader` fixture uses the same module graph and checksum as `large`, but webpack and Rspack run every JavaScript module through `swc-loader`. Adapters without webpack-compatible loader rules, including the current Unpack and Turbopack adapters, report `unsupported`. The results are diagnostic signals for maintainers; they are not merge gates and they are not compatibility claims.
 
 ## Local Run
 

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -10,10 +10,12 @@
   "dependencies": {
     "@babel/plugin-transform-modules-commonjs": "7.29.7",
     "@rspack/core": "2.1.1",
+    "@swc/core": "1.15.43",
     "@unpack-js/core": "workspace:*",
     "metro": "0.85.0",
     "parcel": "2.16.4",
     "rolldown": "1.1.3",
+    "swc-loader": "0.2.7",
     "webpack": "5.108.1"
   }
 }

--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -531,19 +531,24 @@ function webpackLoaderRules(fixture) {
   }
 
   return [
-    {
-      test: /\.js$/,
-      loader: SWC_LOADER,
-      options: {
-        jsc: {
-          parser: { syntax: "ecmascript" },
-          target: "es2022"
-        },
-        module: { type: "es6" },
-        sourceMaps: false
-      }
-    }
+    swcLoaderRule(/\.js$/, "ecmascript"),
+    swcLoaderRule(/\.ts$/, "typescript")
   ];
+}
+
+function swcLoaderRule(test, syntax) {
+  return {
+    test,
+    loader: SWC_LOADER,
+    options: {
+      jsc: {
+        parser: { syntax },
+        target: "es2022"
+      },
+      module: { type: "es6" },
+      sourceMaps: false
+    }
+  };
 }
 
 function assertNoWebpackLoaderFixture(fixture, bundler) {

--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -15,6 +15,7 @@ const DEFAULT_UNPACK_TRACING_FILTER = "unpack_core=trace,unpack_node=trace";
 const TURBOPACK_TRACING_ENV = "TURBOPACK_TRACING";
 const DEFAULT_TURBOPACK_TRACING_FILTER = "turbo-tasks";
 const METRO_COMMONJS_TRANSFORMER = require.resolve("./metro-commonjs-transformer.cjs");
+const SWC_LOADER = require.resolve("swc-loader");
 const UNPACK_PACKAGE_ROOT = resolve(dirname(require.resolve("@unpack-js/core")), "..");
 
 export const adapters = {
@@ -317,7 +318,6 @@ export const adapters = {
 
   turbopack: {
     name: "turbopack",
-    supportsLoaderFixture: true,
     outputDir: ({ fixture }) => join(fixture.context, "dist"),
     versionSource: ({ options }) => {
       if (options.turbopackBinary) {
@@ -372,8 +372,6 @@ export const adapters = {
           "Turbopack requires --turbopack-binary or --turbopack-repo pointing at a fixed Next.js checkout"
         );
       }
-      await materializeTurbopackLoaderFixture(fixture);
-
       const args = [
         "build",
         "--dir",
@@ -534,8 +532,16 @@ function webpackLoaderRules(fixture) {
 
   return [
     {
-      test: /\.benchdata$/,
-      loader: join(fixture.context, "loaders/benchmark-loader.cjs")
+      test: /\.js$/,
+      loader: SWC_LOADER,
+      options: {
+        jsc: {
+          parser: { syntax: "ecmascript" },
+          target: "es2022"
+        },
+        module: { type: "es6" },
+        sourceMaps: false
+      }
     }
   ];
 }
@@ -546,39 +552,6 @@ function assertNoWebpackLoaderFixture(fixture, bundler) {
   }
 
   throw unsupported(`${bundler} does not support the loader benchmark fixture`);
-}
-
-async function materializeTurbopackLoaderFixture(fixture) {
-  if (!fixture.requiresWebpackLoaders) {
-    return;
-  }
-
-  const entryPath = resolve(fixture.context, fixture.entry);
-  const entrySource = await readFile(entryPath, "utf8");
-  const rewrittenEntrySource = entrySource.replace(
-    /(\.\/loader-data\/item\d+\.benchdata)(?=")/g,
-    "$1.js"
-  );
-  if (rewrittenEntrySource !== entrySource) {
-    await writeFile(entryPath, rewrittenEntrySource, "utf8");
-  }
-
-  for (let index = 0; index < fixture.loaderModuleCount; index += 1) {
-    const dataPath = join(fixture.context, `src/loader-data/item${index}.benchdata`);
-    const value = Number.parseInt((await readFile(dataPath, "utf8")).trim(), 10);
-    if (!Number.isFinite(value)) {
-      throw new Error(`benchmark loader expected a numeric payload in ${dataPath}`);
-    }
-    await writeFile(
-      `${dataPath}.js`,
-      [
-        `const value = ${value};`,
-        "export default value;",
-        "export { value as loadedValue };"
-      ].join("\n") + "\n",
-      "utf8"
-    );
-  }
 }
 
 function runUnpackCompiler(compiler) {

--- a/packages/benchmarks/src/fixture.mjs
+++ b/packages/benchmarks/src/fixture.mjs
@@ -3,7 +3,6 @@ import { dirname, join } from "node:path";
 
 const WEBPACK_ALL_COMMIT = "d3a1ca290b4b887757a45901288ea30f86b2f842";
 const LARGE_BASE_CHECKSUM = 100000;
-const LOADER_MODULE_COUNT = 300;
 const THREE_COPY_COUNT = 10;
 const THREE_PARTS_PER_COPY = 20;
 const ROME_MODULE_COUNT = 80;
@@ -20,9 +19,7 @@ export const FIXTURE_SHAPES = {
   loader: {
     name: "loader",
     kind: "loader",
-    moduleCount: LOADER_MODULE_COUNT,
-    expectedChecksum:
-      largeExpectedChecksum() + loaderExpectedChecksum(LOADER_MODULE_COUNT)
+    expectedChecksum: largeExpectedChecksum()
   }
 };
 
@@ -168,11 +165,7 @@ export async function createBenchmarkFixture(rootDir, shape) {
   await rm(context, { recursive: true, force: true });
   await mkdir(context, { recursive: true });
 
-  if (shape.kind === "loader") {
-    await writeLoaderFixture(context, shape);
-  } else {
-    await writeWebpackAllFixture(context, shape);
-  }
+  await writeWebpackAllFixture(context, shape);
 
   return {
     name: shape.name,
@@ -180,7 +173,6 @@ export async function createBenchmarkFixture(rootDir, shape) {
     entry: "./src/index.js",
     expectedChecksum: shape.expectedChecksum,
     fixtureKind: shape.kind,
-    loaderModuleCount: shape.moduleCount ?? 0,
     requiresWebpackLoaders: shape.kind === "loader",
     warmBuildMutationApplied: false
   };
@@ -195,10 +187,7 @@ export async function applyWarmBuildMutation(fixture) {
   await writeSource(
     join(fixture.context, "src/index.js"),
     webpackAllEntrySource(
-      {
-        kind: fixture.fixtureKind,
-        moduleCount: fixture.loaderModuleCount
-      },
+      { kind: fixture.fixtureKind },
       { excludedCopy: WARM_BUILD_GRAPH_COPY }
     )
   );
@@ -212,7 +201,7 @@ async function writeWebpackAllFixture(context, shape) {
     benchmarkCase: {
       source: "webpack/benchmark/cases/all",
       commit: WEBPACK_ALL_COMMIT,
-      loaderOverlay: shape.kind === "loader"
+      loaderTransform: shape.kind === "loader" ? "swc-loader" : null
     },
     dependencies: WEBPACK_ALL_DEPENDENCIES
   });
@@ -230,21 +219,6 @@ async function writeWebpackAllFixture(context, shape) {
   await writeWebpackAllPackages(context);
   await writeThreeCopies(context);
   await writeRomeTree(context);
-}
-
-async function writeLoaderFixture(context, shape) {
-  await writeWebpackAllFixture(context, shape);
-  await writeSource(
-    join(context, "loaders/benchmark-loader.cjs"),
-    benchmarkLoaderSource()
-  );
-
-  for (let index = 0; index < shape.moduleCount; index += 1) {
-    await writeSource(
-      join(context, `src/loader-data/item${index}.benchdata`),
-      `${index + 1}\n`
-    );
-  }
 }
 
 async function writeWebpackAllPackages(context) {
@@ -468,11 +442,9 @@ ${copyImports.join("\n")}
 import "./rome.ts";
 
 import { benchmarkChecksum } from "./__benchmark_checksum.js";
-${loaderEntryImports(shape)}
 
 ${copyChecksumSource}
-${loaderChecksumSource(shape)}
-export const checksum = benchmarkChecksum + copyChecksum + loaderChecksum;
+export const checksum = benchmarkChecksum + copyChecksum;
 export default { checksum };
 
 console.log("Hello World", checksum);
@@ -504,54 +476,6 @@ function romeEntrySource() {
   return `import "./rome/internal/cli/cli";
 
 console.log("Hello World");
-`;
-}
-
-function loaderEntryImports(shape) {
-  if (shape.kind !== "loader") {
-    return "";
-  }
-
-  const imports = [];
-  for (let index = 0; index < shape.moduleCount; index += 1) {
-    imports.push(`import value${index} from "./loader-data/item${index}.benchdata";`);
-  }
-
-  return `
-// webpack-compatible loader overlay
-${imports.join("\n")}
-`;
-}
-
-function loaderChecksumSource(shape) {
-  if (shape.kind !== "loader") {
-    return "const loaderChecksum = 0;";
-  }
-
-  const values = [];
-  for (let index = 0; index < shape.moduleCount; index += 1) {
-    values.push(`value${index}`);
-  }
-
-  return `const loaderValues = [
-  ${values.join(",\n  ")}
-];
-
-const loaderChecksum = loaderValues.reduce((total, value) => total + value, 0);`;
-}
-
-function benchmarkLoaderSource() {
-  return `module.exports = function benchmarkLoader(source) {
-  const value = Number.parseInt(String(source).trim(), 10);
-  if (!Number.isFinite(value)) {
-    throw new Error("benchmark loader expected a numeric payload");
-  }
-  return [
-    \`const value = \${value};\`,
-    "export default value;",
-    "export { value as loadedValue };"
-  ].join("\\n");
-};
 `;
 }
 
@@ -635,10 +559,6 @@ export const helperName = ${JSON.stringify(helper)};
 
 function checksumSource(checksum) {
   return `export const benchmarkChecksum = ${checksum};\n`;
-}
-
-function loaderExpectedChecksum(moduleCount) {
-  return (moduleCount * (moduleCount + 1)) / 2;
 }
 
 function largeExpectedChecksum() {

--- a/packages/benchmarks/src/runner.mjs
+++ b/packages/benchmarks/src/runner.mjs
@@ -67,12 +67,26 @@ export async function runBenchmark(options = {}) {
 }
 
 export function toSummaryMarkdown(report) {
+  const groups = [
+    ["### Loader Benchmarks", report.results.filter((result) => result.fixture === "loader")],
+    [
+      "### Benchmarks Without Loaders",
+      report.results.filter((result) => result.fixture !== "loader")
+    ]
+  ].filter(([, results]) => results.length > 0);
+
+  return `${groups
+    .map(([heading, results]) => `${heading}\n\n${toSummaryTable(results)}`)
+    .join("\n\n")}\n`;
+}
+
+function toSummaryTable(results) {
   const lines = [
     "| fixture | bundler | version/source | cold_build_ms | warm_build_ms | no_cache_build_ms | output_bytes | status |",
     "| --- | --- | --- | ---: | ---: | ---: | ---: | --- |"
   ];
 
-  for (const result of report.results) {
+  for (const result of results) {
     lines.push(
       [
         result.fixture,
@@ -87,7 +101,7 @@ export function toSummaryMarkdown(report) {
     );
   }
 
-  return `${lines.join("\n")}\n`;
+  return lines.join("\n");
 }
 
 async function runBundlerBenchmark({ adapter, bundler, fixture, workspaceDir, options }) {

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -241,7 +241,21 @@ test("webpack-compatible adapters build the loader benchmark fixture", async () 
     );
     assert.match(loaderEntry, /@material-ui\/core/);
     assert.match(loaderEntry, /\.\/rome\.ts/);
-    assert.match(loaderEntry, /\.\/loader-data\/item0\.benchdata/);
+    assert.doesNotMatch(loaderEntry, /loader-data|benchdata/);
+
+    const rspackConfig = createRspackBenchmarkConfig({
+      fixture: {
+        context: join(workspace, "fixtures", "loader"),
+        entry: "./src/index.js",
+        requiresWebpackLoaders: true
+      },
+      outputDir: join(workspace, "output"),
+      cacheDir: join(workspace, "cache")
+    });
+    assert.equal(rspackConfig.module.rules.length, 1);
+    assert.equal(rspackConfig.module.rules[0].test.test("src/index.js"), true);
+    assert.equal(rspackConfig.module.rules[0].test.test("src/rome.ts"), false);
+    assert.match(rspackConfig.module.rules[0].loader, /swc-loader/);
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }
@@ -475,61 +489,8 @@ printf 'raw trace\\n' > "${sourceTraceDir}/trace.log"
   }
 });
 
-test("turbopack adapter materializes loader fixture inputs as JavaScript modules", async () => {
-  const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
-
-  try {
-    const binary = join(workspace, "tools", "turbopack-cli");
-    const argsLog = join(workspace, "turbopack-args.txt");
-    const fixtureContext = join(workspace, "fixture");
-    const cacheDir = join(workspace, "cache");
-
-    await mkdir(join(workspace, "tools"), { recursive: true });
-    await mkdir(join(fixtureContext, "src", "loader-data"), { recursive: true });
-    await writeFile(
-      binary,
-      `#!/bin/sh\nprintf '%s\\n' "$@" > "${argsLog}"\n`,
-      "utf8"
-    );
-    await chmod(binary, 0o755);
-    await writeFile(
-      join(fixtureContext, "src", "index.js"),
-      [
-        'import value0 from "./loader-data/item0.benchdata";',
-        'import value1 from "./loader-data/item1.benchdata";',
-        "export const checksum = value0 + value1;"
-      ].join("\n") + "\n",
-      "utf8"
-    );
-    await writeFile(join(fixtureContext, "src", "loader-data", "item0.benchdata"), "1\n");
-    await writeFile(join(fixtureContext, "src", "loader-data", "item1.benchdata"), "2\n");
-
-    await adapters.turbopack.build({
-      fixture: {
-        context: fixtureContext,
-        entry: "./src/index.js",
-        loaderModuleCount: 2,
-        requiresWebpackLoaders: true
-      },
-      cacheDir,
-      options: {
-        turbopackBinary: binary
-      }
-    });
-
-    const entry = await readFile(join(fixtureContext, "src", "index.js"), "utf8");
-    assert.match(entry, /\.\/loader-data\/item0\.benchdata\.js/);
-    assert.doesNotMatch(entry, /\.\/loader-data\/item0\.benchdata"/);
-
-    const materialized = await readFile(
-      join(fixtureContext, "src", "loader-data", "item0.benchdata.js"),
-      "utf8"
-    );
-    assert.match(materialized, /const value = 1;/);
-    assert.match(materialized, /export default value;/);
-  } finally {
-    await rm(workspace, { recursive: true, force: true });
-  }
+test("turbopack does not claim support for the swc-loader fixture", () => {
+  assert.equal(adapters.turbopack.supportsLoaderFixture, undefined);
 });
 
 test("turbopack prepare patches build shutdown to flush persistent cache", async () => {

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -19,6 +19,25 @@ import { runBenchmark, toSummaryMarkdown } from "../src/runner.mjs";
 
 const execFileAsync = promisify(execFile);
 
+test("summary renders loader results before a separate non-loader table", () => {
+  const summary = toSummaryMarkdown({
+    results: [
+      summaryResult({ fixture: "large", bundler: "webpack" }),
+      summaryResult({ fixture: "loader", bundler: "rspack" })
+    ]
+  });
+
+  const loaderHeading = summary.indexOf("### Loader Benchmarks");
+  const nonLoaderHeading = summary.indexOf("### Benchmarks Without Loaders");
+  assert.ok(loaderHeading >= 0);
+  assert.ok(nonLoaderHeading > loaderHeading);
+  assert.equal(summary.match(/\| fixture \| bundler \|/g)?.length, 2);
+  assert.match(summary.slice(loaderHeading, nonLoaderHeading), /\| loader \| rspack \|/);
+  assert.doesNotMatch(summary.slice(loaderHeading, nonLoaderHeading), /\| large \|/);
+  assert.match(summary.slice(nonLoaderHeading), /\| large \| webpack \|/);
+  assert.doesNotMatch(summary.slice(nonLoaderHeading), /\| loader \|/);
+});
+
 test("runner emits persistent-cache and no-cache measurements for a verified bundle", async () => {
   const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
   const calls = [];
@@ -547,6 +566,19 @@ test("turbopack prepare patches build shutdown to flush persistent cache", async
     await rm(workspace, { recursive: true, force: true });
   }
 });
+
+function summaryResult({ fixture, bundler }) {
+  return {
+    fixture,
+    bundler,
+    version_source: `${bundler}@1.0.0`,
+    cold_build_ms: 10,
+    warm_build_ms: 5,
+    no_cache_build_ms: 8,
+    output_bytes: 100,
+    status: "success"
+  };
+}
 
 function fakeAdapter({ checksumOffset = 0, error, calls, staleWarmChecksum = false } = {}) {
   let coldChecksum;

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -252,10 +252,16 @@ test("webpack-compatible adapters build the loader benchmark fixture", async () 
       outputDir: join(workspace, "output"),
       cacheDir: join(workspace, "cache")
     });
-    assert.equal(rspackConfig.module.rules.length, 1);
-    assert.equal(rspackConfig.module.rules[0].test.test("src/index.js"), true);
-    assert.equal(rspackConfig.module.rules[0].test.test("src/rome.ts"), false);
-    assert.match(rspackConfig.module.rules[0].loader, /swc-loader/);
+    assert.equal(rspackConfig.module.rules.length, 2);
+    const [javascriptRule, typescriptRule] = rspackConfig.module.rules;
+    assert.equal(javascriptRule.test.test("src/index.js"), true);
+    assert.equal(javascriptRule.test.test("src/rome.ts"), false);
+    assert.match(javascriptRule.loader, /swc-loader/);
+    assert.equal(javascriptRule.options.jsc.parser.syntax, "ecmascript");
+    assert.equal(typescriptRule.test.test("src/index.js"), false);
+    assert.equal(typescriptRule.test.test("src/rome.ts"), true);
+    assert.match(typescriptRule.loader, /swc-loader/);
+    assert.equal(typescriptRule.options.jsc.parser.syntax, "typescript");
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@rspack/core':
         specifier: 2.1.1
         version: 2.1.1(@swc/helpers@0.5.23)
+      '@swc/core':
+        specifier: 1.15.43
+        version: 1.15.43(@swc/helpers@0.5.23)
       '@unpack-js/core':
         specifier: workspace:*
         version: link:../unpack
@@ -28,9 +31,12 @@ importers:
       rolldown:
         specifier: 1.1.3
         version: 1.1.3
+      swc-loader:
+        specifier: 0.2.7
+        version: 0.2.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(webpack@5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23)))
       webpack:
         specifier: 5.108.1
-        version: 5.108.1
+        version: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))
 
   packages/unpack:
     devDependencies:
@@ -1688,6 +1694,12 @@ packages:
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
+
+  swc-loader@0.2.7:
+    resolution: {integrity: sha512-nwYWw3Fh9ame3Rtm7StS9SBLpHRRnYcK7bnpF3UKZmesAK0gw2/ADvlURFAINmPvKtDLzp+GBiP9yLoEjg6S9w==}
+    peerDependencies:
+      '@swc/core': ^1.2.147
+      webpack: '>=2'
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
@@ -3523,6 +3535,16 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(webpack@5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.48.0
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))
+    optionalDependencies:
+      '@swc/core': 1.15.43(@swc/helpers@0.5.23)
+
   minimizer-webpack-plugin@5.6.1(webpack@5.108.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -3702,6 +3724,12 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  swc-loader@0.2.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(webpack@5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))):
+    dependencies:
+      '@swc/core': 1.15.43(@swc/helpers@0.5.23)
+      '@swc/counter': 0.1.3
+      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))
+
   tapable@2.3.3: {}
 
   term-size@2.2.1: {}
@@ -3774,6 +3802,44 @@ snapshots:
       loader-runner: 4.3.2
       mime-db: 1.54.0
       minimizer-webpack-plugin: 5.6.1(webpack@5.108.1)
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      watchpack: 2.5.2
+      webpack-sources: 3.5.0
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
+  webpack@5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23)):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
+      browserslist: 4.28.4
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.1
+      es-module-lexer: 2.1.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(webpack@5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23)))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3


### PR DESCRIPTION
## Summary

- Run every JavaScript module in the loader benchmark through `swc-loader` for webpack and Rspack.
- Run the fixture’s `rome.ts` entry through a separate TypeScript `swc-loader` rule.
- Reuse the large fixture module graph and checksum instead of adding synthetic `.benchdata` modules.
- Report adapters without webpack-compatible loader rules, including Unpack and Turbopack, as unsupported.

## Why

The previous loader fixture measured a custom loader over 300 additional synthetic modules. Using the same graph as the large fixture isolates the cost of applying real JavaScript and TypeScript transforms while preserving the existing JavaScript parser workload.

## Tests

- `pnpm --filter @unpack-js/benchmarks test`
- `pnpm test`