### PR TITLE
Use sharded maps for concurrent caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,6 +1381,7 @@ version = "0.1.0"
 dependencies = [
  "brotli",
  "codspeed-divan-compat",
+ "dashmap",
  "filetime",
  "flate2",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/unpack-dev/unpack"
 
 [workspace.dependencies]
 brotli = "7.0.0"
+dashmap = "6.1.0"
 divan = { package = "codspeed-divan-compat", version = "5.0.1" }
 flate2 = "1.1.9"
 futures = "0.3.31"

--- a/crates/unpack_core/Cargo.toml
+++ b/crates/unpack_core/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 
 [dependencies]
 brotli = { workspace = true }
+dashmap = { workspace = true }
 flate2 = { workspace = true }
 futures = { workspace = true }
 regex = { workspace = true }

--- a/crates/unpack_core/src/normal_module_factory.rs
+++ b/crates/unpack_core/src/normal_module_factory.rs
@@ -1,8 +1,10 @@
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{BTreeSet, HashSet},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
+
+use dashmap::DashMap;
 use tokio::sync::OnceCell;
 
 use crate::{
@@ -25,8 +27,7 @@ pub struct NormalModuleFactory {
 
 // Per-compilation singleflight cache; separate from BuildCache so cache:false
 // still coalesces duplicate factory work within one make run.
-type RuntimeFactorizeCache =
-    Arc<Mutex<HashMap<ResolveRequest, Arc<OnceCell<Result<FactorizedModule>>>>>>;
+type RuntimeFactorizeCache = Arc<DashMap<ResolveRequest, Arc<OnceCell<Result<FactorizedModule>>>>>;
 
 impl NormalModuleFactory {
     pub(crate) fn new(
@@ -41,7 +42,7 @@ impl NormalModuleFactory {
             cache,
             file_system_info,
             resolve_snapshot_strategy,
-            runtime_factorize_cache: Arc::new(Mutex::new(HashMap::new())),
+            runtime_factorize_cache: Arc::new(DashMap::new()),
             snapshot_cache,
             module_rules: Vec::new(),
         }
@@ -85,16 +86,11 @@ impl NormalModuleFactory {
         request: &str,
         resolve_request: ResolveRequest,
     ) -> Result<FactorizedModule> {
-        let cell = {
-            let mut cache = self
-                .runtime_factorize_cache
-                .lock()
-                .expect("runtime factorize cache mutex should not be poisoned");
-            cache
-                .entry(resolve_request.clone())
-                .or_insert_with(|| Arc::new(OnceCell::new()))
-                .clone()
-        };
+        let cell = self
+            .runtime_factorize_cache
+            .entry(resolve_request.clone())
+            .or_insert_with(|| Arc::new(OnceCell::new()))
+            .clone();
 
         cell.get_or_init(|| async {
             self.factorize_uncached(context, request, resolve_request)
@@ -234,14 +230,7 @@ mod tests {
 
         assert_eq!(first, second);
         assert_eq!(build_cache.stats().resolve_entries, 0);
-        assert_eq!(
-            factory
-                .runtime_factorize_cache
-                .lock()
-                .expect("runtime factorize cache mutex should not be poisoned")
-                .len(),
-            1
-        );
+        assert_eq!(factory.runtime_factorize_cache.len(), 1);
 
         Ok(())
     }

--- a/crates/unpack_core/src/snapshot.rs
+++ b/crates/unpack_core/src/snapshot.rs
@@ -1,15 +1,15 @@
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet},
     fs, io,
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use std::collections::BTreeMap;
+use dashmap::DashMap;
+use regex::RegexBuilder;
 
 use crate::{Error, Result};
-use regex::RegexBuilder;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -121,19 +121,16 @@ pub(crate) struct FileSystemInfo {
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SnapshotCache {
-    file_snapshots: Arc<Mutex<HashMap<FileSnapshotCacheKey, FileSnapshot>>>,
-    context_timestamp_hashes: Arc<Mutex<HashMap<PathBuf, DirectoryTimestampHash>>>,
-    context_content_hashes: Arc<Mutex<HashMap<PathBuf, u64>>>,
-    managed_item_states: Arc<Mutex<HashMap<PathBuf, Option<ManagedItemState>>>>,
+    file_snapshots: Arc<DashMap<FileSnapshotCacheKey, FileSnapshot>>,
+    context_timestamp_hashes: Arc<DashMap<PathBuf, DirectoryTimestampHash>>,
+    context_content_hashes: Arc<DashMap<PathBuf, u64>>,
+    managed_item_states: Arc<DashMap<PathBuf, Option<ManagedItemState>>>,
 }
 
 impl SnapshotCache {
     fn managed_path_is_valid(&self, snapshot: &ManagedPathSnapshot) -> bool {
-        let mut states = self
+        let state = self
             .managed_item_states
-            .lock()
-            .expect("snapshot cache mutex should not be poisoned");
-        let state = states
             .entry(snapshot.root.clone())
             .or_insert_with(|| ManagedItemState::create(&snapshot.root));
         state.as_ref() == Some(&snapshot.state)
@@ -1002,20 +999,14 @@ impl FileSnapshot {
         };
         if let Some(snapshot) = cache
             .file_snapshots
-            .lock()
-            .expect("snapshot cache mutex should not be poisoned")
             .get(&key)
-            .cloned()
+            .map(|snapshot| snapshot.clone())
         {
             return Some(snapshot);
         }
 
         let snapshot = Self::create_from_path(path, strategy).await.ok()?;
-        cache
-            .file_snapshots
-            .lock()
-            .expect("snapshot cache mutex should not be poisoned")
-            .insert(key, snapshot.clone());
+        cache.file_snapshots.insert(key, snapshot.clone());
         Some(snapshot)
     }
 
@@ -1094,7 +1085,10 @@ impl ManagedPathSnapshot {
     }
 
     fn is_valid_with_cache(&self, cache: Option<&SnapshotCache>) -> bool {
-        cache.map_or_else(|| self.is_valid(), |cache| cache.managed_path_is_valid(self))
+        cache.map_or_else(
+            || self.is_valid(),
+            |cache| cache.managed_path_is_valid(self),
+        )
     }
 }
 
@@ -1161,13 +1155,7 @@ fn directory_timestamp_hash(
     cache: Option<&SnapshotCache>,
 ) -> Result<DirectoryTimestampHash> {
     if let Some(cache) = cache {
-        if let Some(hash) = cache
-            .context_timestamp_hashes
-            .lock()
-            .expect("snapshot cache mutex should not be poisoned")
-            .get(path)
-            .copied()
-        {
+        if let Some(hash) = cache.context_timestamp_hashes.get(path).map(|hash| *hash) {
             return Ok(hash);
         }
     }
@@ -1176,8 +1164,6 @@ fn directory_timestamp_hash(
     if let Some(cache) = cache {
         cache
             .context_timestamp_hashes
-            .lock()
-            .expect("snapshot cache mutex should not be poisoned")
             .insert(path.to_path_buf(), hash);
     }
     Ok(hash)
@@ -1244,13 +1230,7 @@ fn directory_content_hash(
     cache: Option<&SnapshotCache>,
 ) -> Result<u64> {
     if let Some(cache) = cache {
-        if let Some(hash) = cache
-            .context_content_hashes
-            .lock()
-            .expect("snapshot cache mutex should not be poisoned")
-            .get(path)
-            .copied()
-        {
+        if let Some(hash) = cache.context_content_hashes.get(path).map(|hash| *hash) {
             return Ok(hash);
         }
     }
@@ -1259,8 +1239,6 @@ fn directory_content_hash(
     if let Some(cache) = cache {
         cache
             .context_content_hashes
-            .lock()
-            .expect("snapshot cache mutex should not be poisoned")
             .insert(path.to_path_buf(), hash);
     }
     Ok(hash)


### PR DESCRIPTION
## Summary

- replace the runtime factorization cache global Mutex<HashMap> with DashMap
- replace the four snapshot cache maps with sharded DashMap storage
- split BuildCacheInner into cache-data and publication-state lock domains
- move generation and initial-store bookkeeping to atomics while preserving publication boundaries

## Impact

Concurrent make tasks avoid global map locks, and cache lifecycle queries no longer contend on the cache data mutex. Filesystem publication still holds the data lock intentionally so concurrent stores remain dirty for the next generation. Lock ordering is explicitly cache data before publication state.

The full workspace test suite passes (112 tests).