### PR TITLE
Compare cross-bundler benchmarks with main

### DIFF
--- a/.github/workflows/cross-bundler-benchmark.yml
+++ b/.github/workflows/cross-bundler-benchmark.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:
+      actions: read
       contents: read
       issues: write
       pull-requests: write
@@ -66,6 +67,40 @@ jobs:
           chmod +x .benchmark-tools/turbopack-cli/turbopack-cli
           .benchmark-tools/turbopack-cli/turbopack-cli --help >/dev/null
 
+      - name: Download latest main benchmark results
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          main_run_ids="$(
+            gh run list \
+              --workflow cross-bundler-benchmark.yml \
+              --branch main \
+              --event push \
+              --status success \
+              --limit 20 \
+              --json databaseId \
+              --jq '.[].databaseId'
+          )"
+          if [ -z "$main_run_ids" ]; then
+            echo "No successful main benchmark run was found; delta columns will be omitted."
+            exit 0
+          fi
+          while read -r main_run_id; do
+            rm -rf .benchmark-work/main
+            mkdir -p .benchmark-work/main
+            if gh run download "$main_run_id" \
+              --name cross-bundler-benchmark-results \
+              --dir .benchmark-work/main \
+              && find .benchmark-work/main -name results.json -type f -print -quit | grep -q .; then
+              echo "Using benchmark results from main workflow run $main_run_id."
+              exit 0
+            fi
+          done <<< "$main_run_ids"
+          rm -rf .benchmark-work/main
+          echo "No recent successful main run has a results artifact; delta columns will be omitted."
+
       - name: Run cross-bundler benchmark
         id: benchmark
         continue-on-error: true
@@ -100,6 +135,19 @@ jobs:
             --bundlers "$benchmark_bundlers" \
             "${turbopack_args[@]}" \
             2> >(tee .benchmark-work/ci/bundler-phase-timings.log | sed -E '/^\[(unpack|webpack) tracing\]/d; /(^| )TRACE .*: .*: close time\.busy=/d' >&2)
+
+      - name: Compare benchmark results with latest main
+        if: always() && github.event_name == 'pull_request'
+        run: |
+          baseline_results="$(find .benchmark-work/main -name results.json -type f -print -quit 2>/dev/null || true)"
+          if [ -f .benchmark-work/ci/results.json ] && [ -n "$baseline_results" ]; then
+            node packages/benchmarks/src/compare-summary.mjs \
+              .benchmark-work/ci/results.json \
+              "$baseline_results" \
+              .benchmark-work/ci/summary.md
+          else
+            echo "Current or main benchmark results are unavailable; keeping the unpaired summary."
+          fi
 
       - name: Format bundler phase timing summary
         if: always()

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -69,9 +69,10 @@ Important fields:
 
 On pull requests, the Markdown summary also compares each numeric measurement
 with the matching fixture and bundler from the latest successful `main` push.
-Delta columns use `(current - main) / main`, so a positive build-time delta is
-slower and a negative build-time delta is faster. If `main` has no matching
-result, the delta is shown as unavailable.
+Each delta is shown in parentheses after the current value and uses
+`(current - main) / main`, so a positive build-time delta is slower and a
+negative build-time delta is faster. If `main` has no matching result, only the
+current value is shown.
 
 Runtime verification is separate from build timing. A Bundle that builds but does not export the expected checksum is marked `runtime_failed` and should not be treated as a valid performance result.
 
@@ -79,6 +80,6 @@ Runtime verification is separate from build timing. A Bundle that builds but doe
 
 The `Cross-Bundler Benchmarks` workflow runs on pushes to `main`, pull requests, and manual dispatch. CI runs compare Unpack with webpack, Rspack, Rolldown, Metro, Parcel, and Turbopack across the `large` and `loader` fixtures by default. The workflow downloads the `turbopack-cli-main` release artifact from `hardfist/bundler-diff` and passes it to the benchmark runner with `--turbopack-binary`; manual dispatch can set `include_turbopack` to `false` when a non-Turbopack run is needed. Turbopack CI runs enable `TURBOPACK_TRACING=turbo-tasks`, copy raw trace files into `.benchmark-work/ci/turbopack-traces`, upload each trace log as a separate workflow artifact, and link those trace artifacts from the pull request timing comment. The workflow writes the benchmark table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, writes an Unpack and webpack phase timing summary for the `large` fixture to a new pull request issue comment, and uploads the JSON report, Markdown summary, timing summary, raw timing log, and Turbopack trace log artifacts.
 
-The workflow builds the Unpack native addon with `UNPACK_NATIVE_PROFILE=release` so benchmark results compare optimized native builds. Pull request runs download the JSON artifact from the latest successful `main` push and show percentage deltas in the job summary and benchmark comment.
+The workflow builds the Unpack native addon with `UNPACK_NATIVE_PROFILE=release` so benchmark results compare optimized native builds. Pull request runs download the JSON artifact from the latest successful `main` push and show inline percentage deltas in the job summary and benchmark comment.
 
 The workflow is intentionally non-blocking. Benchmark setup failures, external toolchain failures, or runtime verification failures should be visible in the workflow output without blocking unrelated code from merging.

--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -67,12 +67,18 @@ Important fields:
 - `version_source`: the npm package version or fixed source commit used for the bundler.
 - `status`: `success`, `unsupported`, `setup_failed`, `build_failed`, `runtime_failed`, or a warm/no-cache build variant.
 
+On pull requests, the Markdown summary also compares each numeric measurement
+with the matching fixture and bundler from the latest successful `main` push.
+Delta columns use `(current - main) / main`, so a positive build-time delta is
+slower and a negative build-time delta is faster. If `main` has no matching
+result, the delta is shown as unavailable.
+
 Runtime verification is separate from build timing. A Bundle that builds but does not export the expected checksum is marked `runtime_failed` and should not be treated as a valid performance result.
 
 ## CI
 
 The `Cross-Bundler Benchmarks` workflow runs on pushes to `main`, pull requests, and manual dispatch. CI runs compare Unpack with webpack, Rspack, Rolldown, Metro, Parcel, and Turbopack across the `large` and `loader` fixtures by default. The workflow downloads the `turbopack-cli-main` release artifact from `hardfist/bundler-diff` and passes it to the benchmark runner with `--turbopack-binary`; manual dispatch can set `include_turbopack` to `false` when a non-Turbopack run is needed. Turbopack CI runs enable `TURBOPACK_TRACING=turbo-tasks`, copy raw trace files into `.benchmark-work/ci/turbopack-traces`, upload each trace log as a separate workflow artifact, and link those trace artifacts from the pull request timing comment. The workflow writes the benchmark table to the GitHub Actions job summary, creates or updates a benchmark summary comment on pull requests, writes an Unpack and webpack phase timing summary for the `large` fixture to a new pull request issue comment, and uploads the JSON report, Markdown summary, timing summary, raw timing log, and Turbopack trace log artifacts.
 
-The workflow builds the Unpack native addon with `UNPACK_NATIVE_PROFILE=release` so benchmark results compare optimized native builds.
+The workflow builds the Unpack native addon with `UNPACK_NATIVE_PROFILE=release` so benchmark results compare optimized native builds. Pull request runs download the JSON artifact from the latest successful `main` push and show percentage deltas in the job summary and benchmark comment.
 
 The workflow is intentionally non-blocking. Benchmark setup failures, external toolchain failures, or runtime verification failures should be visible in the workflow output without blocking unrelated code from merging.

--- a/packages/benchmarks/src/compare-summary.mjs
+++ b/packages/benchmarks/src/compare-summary.mjs
@@ -1,0 +1,22 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+import { toSummaryMarkdown } from "./runner.mjs";
+
+const [currentPath, baselinePath, outputPath] = process.argv.slice(2);
+
+if (!currentPath || !baselinePath || !outputPath) {
+  process.stderr.write(
+    "Usage: node src/compare-summary.mjs <current.json> <main.json> <output.md>\n"
+  );
+  process.exitCode = 1;
+} else {
+  const [current, baseline] = await Promise.all([
+    readReport(currentPath),
+    readReport(baselinePath)
+  ]);
+  await writeFile(outputPath, toSummaryMarkdown(current, baseline));
+}
+
+async function readReport(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}

--- a/packages/benchmarks/src/runner.mjs
+++ b/packages/benchmarks/src/runner.mjs
@@ -82,7 +82,7 @@ export function toSummaryMarkdown(report, baselineReport) {
     .map(([heading, results]) => `${heading}\n\n${toSummaryTable(results, baselines)}`)
     .join("\n\n");
   const comparisonNote = baselineReport
-    ? "\n\n> Delta is `(current - main) / main`. Positive timing deltas mean slower than the latest main result; negative timing deltas mean faster."
+    ? "\n\n> Delta vs main: `+` means slower or larger; `−` means faster or smaller. Calculated as `(current - main) / main`."
     : "";
 
   return `${summary}${comparisonNote}\n`;

--- a/packages/benchmarks/src/runner.mjs
+++ b/packages/benchmarks/src/runner.mjs
@@ -79,7 +79,7 @@ export function toSummaryMarkdown(report, baselineReport) {
   ].filter(([, results]) => results.length > 0);
 
   const summary = groups
-    .map(([heading, results]) => `${heading}\n\n${toSummaryTable(results, baselines, baselineReport)}`)
+    .map(([heading, results]) => `${heading}\n\n${toSummaryTable(results, baselines)}`)
     .join("\n\n");
   const comparisonNote = baselineReport
     ? "\n\n> Delta is `(current - main) / main`. Positive timing deltas mean slower than the latest main result; negative timing deltas mean faster."
@@ -88,16 +88,11 @@ export function toSummaryMarkdown(report, baselineReport) {
   return `${summary}${comparisonNote}\n`;
 }
 
-function toSummaryTable(results, baselines, baselineReport) {
-  const lines = baselineReport
-    ? [
-        "| fixture | bundler | version/source | cold_build_ms | warm_build_ms | no_cache_build_ms | output_bytes | cold_delta_vs_main | warm_delta_vs_main | no_cache_delta_vs_main | output_delta_vs_main | status |",
-        "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |"
-      ]
-    : [
-        "| fixture | bundler | version/source | cold_build_ms | warm_build_ms | no_cache_build_ms | output_bytes | status |",
-        "| --- | --- | --- | ---: | ---: | ---: | ---: | --- |"
-      ];
+function toSummaryTable(results, baselines) {
+  const lines = [
+    "| fixture | bundler | version/source | cold_build_ms | warm_build_ms | no_cache_build_ms | output_bytes | status |",
+    "| --- | --- | --- | ---: | ---: | ---: | ---: | --- |"
+  ];
 
   for (const result of results) {
     const baseline = baselines.get(resultKey(result));
@@ -106,18 +101,10 @@ function toSummaryTable(results, baselines, baselineReport) {
         result.fixture,
         result.bundler,
         result.version_source ?? "",
-        formatNumber(result.cold_build_ms),
-        formatNumber(result.warm_build_ms),
-        formatNumber(result.no_cache_build_ms),
-        formatNumber(result.output_bytes, 0),
-        ...(baselineReport
-          ? [
-              formatDelta(result.cold_build_ms, baseline?.cold_build_ms),
-              formatDelta(result.warm_build_ms, baseline?.warm_build_ms),
-              formatDelta(result.no_cache_build_ms, baseline?.no_cache_build_ms),
-              formatDelta(result.output_bytes, baseline?.output_bytes)
-            ]
-          : []),
+        formatMeasurement(result.cold_build_ms, baseline?.cold_build_ms),
+        formatMeasurement(result.warm_build_ms, baseline?.warm_build_ms),
+        formatMeasurement(result.no_cache_build_ms, baseline?.no_cache_build_ms),
+        formatMeasurement(result.output_bytes, baseline?.output_bytes, 0),
         result.status
       ].join(" | ").replace(/^/, "| ").replace(/$/, " |")
     );
@@ -130,12 +117,14 @@ function resultKey(result) {
   return `${result.fixture}\0${result.bundler}`;
 }
 
-function formatDelta(current, baseline) {
+function formatMeasurement(current, baseline, digits = 1) {
+  const value = formatNumber(current, digits);
   if (!Number.isFinite(current) || !Number.isFinite(baseline) || baseline === 0) {
-    return "—";
+    return value;
   }
   const percentage = ((current - baseline) / baseline) * 100;
-  return `${percentage >= 0 ? "+" : ""}${percentage.toFixed(1)}%`;
+  const delta = `${percentage >= 0 ? "+" : ""}${percentage.toFixed(1)}%`;
+  return `${value} (${delta})`;
 }
 
 async function runBundlerBenchmark({ adapter, bundler, fixture, workspaceDir, options }) {

--- a/packages/benchmarks/src/runner.mjs
+++ b/packages/benchmarks/src/runner.mjs
@@ -66,7 +66,10 @@ export async function runBenchmark(options = {}) {
   };
 }
 
-export function toSummaryMarkdown(report) {
+export function toSummaryMarkdown(report, baselineReport) {
+  const baselines = new Map(
+    (baselineReport?.results ?? []).map((result) => [resultKey(result), result])
+  );
   const groups = [
     ["### Loader Benchmarks", report.results.filter((result) => result.fixture === "loader")],
     [
@@ -75,18 +78,29 @@ export function toSummaryMarkdown(report) {
     ]
   ].filter(([, results]) => results.length > 0);
 
-  return `${groups
-    .map(([heading, results]) => `${heading}\n\n${toSummaryTable(results)}`)
-    .join("\n\n")}\n`;
+  const summary = groups
+    .map(([heading, results]) => `${heading}\n\n${toSummaryTable(results, baselines, baselineReport)}`)
+    .join("\n\n");
+  const comparisonNote = baselineReport
+    ? "\n\n> Delta is `(current - main) / main`. Positive timing deltas mean slower than the latest main result; negative timing deltas mean faster."
+    : "";
+
+  return `${summary}${comparisonNote}\n`;
 }
 
-function toSummaryTable(results) {
-  const lines = [
-    "| fixture | bundler | version/source | cold_build_ms | warm_build_ms | no_cache_build_ms | output_bytes | status |",
-    "| --- | --- | --- | ---: | ---: | ---: | ---: | --- |"
-  ];
+function toSummaryTable(results, baselines, baselineReport) {
+  const lines = baselineReport
+    ? [
+        "| fixture | bundler | version/source | cold_build_ms | warm_build_ms | no_cache_build_ms | output_bytes | cold_delta_vs_main | warm_delta_vs_main | no_cache_delta_vs_main | output_delta_vs_main | status |",
+        "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |"
+      ]
+    : [
+        "| fixture | bundler | version/source | cold_build_ms | warm_build_ms | no_cache_build_ms | output_bytes | status |",
+        "| --- | --- | --- | ---: | ---: | ---: | ---: | --- |"
+      ];
 
   for (const result of results) {
+    const baseline = baselines.get(resultKey(result));
     lines.push(
       [
         result.fixture,
@@ -96,12 +110,32 @@ function toSummaryTable(results) {
         formatNumber(result.warm_build_ms),
         formatNumber(result.no_cache_build_ms),
         formatNumber(result.output_bytes, 0),
+        ...(baselineReport
+          ? [
+              formatDelta(result.cold_build_ms, baseline?.cold_build_ms),
+              formatDelta(result.warm_build_ms, baseline?.warm_build_ms),
+              formatDelta(result.no_cache_build_ms, baseline?.no_cache_build_ms),
+              formatDelta(result.output_bytes, baseline?.output_bytes)
+            ]
+          : []),
         result.status
       ].join(" | ").replace(/^/, "| ").replace(/$/, " |")
     );
   }
 
   return lines.join("\n");
+}
+
+function resultKey(result) {
+  return `${result.fixture}\0${result.bundler}`;
+}
+
+function formatDelta(current, baseline) {
+  if (!Number.isFinite(current) || !Number.isFinite(baseline) || baseline === 0) {
+    return "—";
+  }
+  const percentage = ((current - baseline) / baseline) * 100;
+  return `${percentage >= 0 ? "+" : ""}${percentage.toFixed(1)}%`;
 }
 
 async function runBundlerBenchmark({ adapter, bundler, fixture, workspaceDir, options }) {

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -52,21 +52,22 @@ test("summary compares measurements with matching latest main results", () => {
     { results: [baseline] }
   );
 
-  assert.match(summary, /cold_delta_vs_main/);
-  assert.match(summary, /warm_delta_vs_main/);
-  assert.match(summary, /no_cache_delta_vs_main/);
-  assert.match(summary, /output_delta_vs_main/);
-  assert.match(summary, /\| \+25\.0% \| \+100\.0% \| -20\.0% \| -50\.0% \| success \|/);
+  assert.doesNotMatch(summary, /delta_vs_main/);
+  assert.match(
+    summary,
+    /\| 10\.0 \(\+25\.0%\) \| 5\.0 \(\+100\.0%\) \| 8\.0 \(-20\.0%\) \| 100 \(-50\.0%\) \| success \|/
+  );
   assert.match(summary, /Positive timing deltas mean slower than the latest main result/);
 });
 
-test("summary displays unavailable deltas when main has no matching result", () => {
+test("summary omits inline deltas when main has no matching result", () => {
   const summary = toSummaryMarkdown(
     { results: [summaryResult({ fixture: "large", bundler: "unpack" })] },
     { results: [summaryResult({ fixture: "loader", bundler: "unpack" })] }
   );
 
-  assert.match(summary, /\| — \| — \| — \| — \| success \|/);
+  assert.match(summary, /\| 10\.0 \| 5\.0 \| 8\.0 \| 100 \| success \|/);
+  assert.doesNotMatch(summary, /\([+-][\d.]+%\)/);
 });
 
 test("runner emits persistent-cache and no-cache measurements for a verified bundle", async () => {

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -38,6 +38,37 @@ test("summary renders loader results before a separate non-loader table", () => 
   assert.doesNotMatch(summary.slice(nonLoaderHeading), /\| loader \|/);
 });
 
+test("summary compares measurements with matching latest main results", () => {
+  const current = summaryResult({ fixture: "large", bundler: "unpack" });
+  const baseline = {
+    ...current,
+    cold_build_ms: 8,
+    warm_build_ms: 2.5,
+    no_cache_build_ms: 10,
+    output_bytes: 200
+  };
+  const summary = toSummaryMarkdown(
+    { results: [current] },
+    { results: [baseline] }
+  );
+
+  assert.match(summary, /cold_delta_vs_main/);
+  assert.match(summary, /warm_delta_vs_main/);
+  assert.match(summary, /no_cache_delta_vs_main/);
+  assert.match(summary, /output_delta_vs_main/);
+  assert.match(summary, /\| \+25\.0% \| \+100\.0% \| -20\.0% \| -50\.0% \| success \|/);
+  assert.match(summary, /Positive timing deltas mean slower than the latest main result/);
+});
+
+test("summary displays unavailable deltas when main has no matching result", () => {
+  const summary = toSummaryMarkdown(
+    { results: [summaryResult({ fixture: "large", bundler: "unpack" })] },
+    { results: [summaryResult({ fixture: "loader", bundler: "unpack" })] }
+  );
+
+  assert.match(summary, /\| — \| — \| — \| — \| success \|/);
+});
+
 test("runner emits persistent-cache and no-cache measurements for a verified bundle", async () => {
   const workspace = await mkdtemp(join(tmpdir(), "unpack-benchmarks-"));
   const calls = [];

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -57,7 +57,7 @@ test("summary compares measurements with matching latest main results", () => {
     summary,
     /\| 10\.0 \(\+25\.0%\) \| 5\.0 \(\+100\.0%\) \| 8\.0 \(-20\.0%\) \| 100 \(-50\.0%\) \| success \|/
   );
-  assert.match(summary, /Positive timing deltas mean slower than the latest main result/);
+  assert.match(summary, /`\+` means slower or larger; `−` means faster or smaller/);
 });
 
 test("summary omits inline deltas when main has no matching result", () => {


### PR DESCRIPTION
## Summary

- download the latest available cross-bundler benchmark results from `main` for pull request runs
- compare matching fixture and bundler measurements for cold, warm, no-cache, and output size
- show percentage deltas in the job summary and pull request benchmark comment
- fall back cleanly when recent `main` runs do not contain usable result artifacts

## Impact

Benchmark results on pull requests now show whether each measurement improved or regressed relative to `main`, while keeping the workflow diagnostic and non-blocking.
