### PR TITLE
Align Rspack benchmark configuration with Unpack

### DIFF
--- a/docs/implementation/cross-bundler-benchmark.md
+++ b/docs/implementation/cross-bundler-benchmark.md
@@ -54,6 +54,33 @@ trace server with `pnpm next internal trace <trace.log>` or
 `cargo run --bin turbo-trace-server --release -- <trace.log>`, then open
 <https://trace.nextjs.org/>.
 
+## Rspack Configuration Alignment
+
+The Rspack adapter is constrained, where Rspack exposes a corresponding
+option, to Unpack's Implemented Webpack Surface. It uses the same `none` mode,
+Node/CommonJS output and require chunk loading, named module and chunk ids,
+resolver conditions and extensions, source-map setting, and loader rules. It
+also disables Node builtin externalization and emits without a whole-bundle
+IIFE or compare-before-write optimization.
+
+Rspack optimizations that Unpack does not implement are disabled: split-chunks
+extraction, generic duplicate-chunk merging, side-effect pruning, used-export
+analysis, inner-graph analysis, module concatenation, export mangling and
+inlining, minimization, and separate runtime chunks. Provided-export analysis
+remains enabled to match Unpack's minimal Exports Info, and empty-chunk removal
+remains enabled because Unpack avoids materializing Async Chunks whose targets
+are already available from their parent. CommonJS, AMD, `import.meta`, URL,
+worker, and async WebAssembly dependency surfaces are disabled where Rspack
+provides parser or output switches. Dynamic Import Dependencies with statically
+known specifiers remain enabled for Async Split Points; Rspack cannot reject
+only Context Modules without also disabling that implemented surface.
+
+For persistent-cache measurements, Rspack uses its own package root as the only
+managed path, mirroring the Unpack adapter instead of accepting Rspack's broader
+`node_modules` default. Warm builds keep that cache read-only, while no-cache
+builds set `cache: false`. These settings improve workload comparability; they
+do not make the benchmark a compatibility claim.
+
 ## Result Shape
 
 The runner emits a Markdown summary with the loader results in the first table and the results without loaders in a separate second table. It can also write the raw JSON report with `--output-json`.

--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -18,6 +18,7 @@ const DEFAULT_TURBOPACK_TRACING_FILTER = "turbo-tasks";
 const METRO_COMMONJS_TRANSFORMER = require.resolve("./metro-commonjs-transformer.cjs");
 const SWC_LOADER = require.resolve("swc-loader");
 const UNPACK_PACKAGE_ROOT = resolve(dirname(require.resolve("@unpack-js/core")), "..");
+const RSPACK_PACKAGE_ROOT = resolve(dirname(require.resolve("@rspack/core")), "..");
 
 export const adapters = {
   unpack: {
@@ -460,8 +461,73 @@ export function createRspackBenchmarkConfig({
   persistentCache = true,
   cacheReadonly = false
 }) {
+  const baseConfig = webpackLikeConfig({ fixture, outputDir });
   return {
-    ...webpackLikeConfig({ fixture, outputDir }),
+    ...baseConfig,
+    resolve: rspackResolveConfig(),
+    externalsPresets: {
+      node: false
+    },
+    output: {
+      ...baseConfig.output,
+      module: false,
+      iife: false,
+      chunkFormat: "commonjs",
+      chunkLoading: "require",
+      workerChunkLoading: false,
+      wasmLoading: false,
+      workerWasmLoading: false,
+      asyncChunks: true,
+      pathinfo: false,
+      strictModuleErrorHandling: false,
+      compareBeforeEmit: false
+    },
+    module: {
+      ...(baseConfig.module ?? {}),
+      parser: {
+        javascript: {
+          commonjs: false,
+          commonjsMagicComments: false,
+          createRequire: false,
+          exportsPresence: false,
+          importDynamic: true,
+          importMeta: false,
+          importMetaResolve: false,
+          requireAlias: false,
+          requireAsExpression: false,
+          requireDynamic: false,
+          requireResolve: false,
+          url: false,
+          worker: false
+        }
+      }
+    },
+    amd: false,
+    node: false,
+    performance: false,
+    experiments: {
+      asyncWebAssembly: false
+    },
+    optimization: {
+      moduleIds: "named",
+      chunkIds: "named",
+      minimize: false,
+      mergeDuplicateChunks: false,
+      splitChunks: false,
+      runtimeChunk: false,
+      removeEmptyChunks: true,
+      realContentHash: false,
+      sideEffects: false,
+      providedExports: true,
+      concatenateModules: false,
+      innerGraph: false,
+      usedExports: false,
+      mangleExports: false,
+      inlineExports: false,
+      nodeEnv: false,
+      emitOnErrors: true,
+      avoidEntryIife: false
+    },
     cache: persistentCache
       ? {
           type: "persistent",
@@ -469,9 +535,29 @@ export function createRspackBenchmarkConfig({
             type: "filesystem",
             directory: cacheDir
           },
+          snapshot: {
+            managedPaths: [RSPACK_PACKAGE_ROOT]
+          },
           readonly: cacheReadonly
         }
       : false
+  };
+}
+
+function rspackResolveConfig() {
+  return {
+    ...unpackResolvePolicy(),
+    byDependency: {
+      esm: unpackResolvePolicy()
+    }
+  };
+}
+
+function unpackResolvePolicy() {
+  return {
+    conditionNames: [],
+    extensions: [".ts", ".tsx", ".js", ".jsx"],
+    mainFields: ["main"]
   };
 }
 

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
 
@@ -320,7 +320,7 @@ test("webpack-compatible adapters build the loader benchmark fixture", async () 
   }
 });
 
-test("rspack warm benchmark config enables readonly persistent cache", () => {
+test("rspack benchmark config aligns with Unpack's Implemented Webpack Surface", () => {
   const config = createRspackBenchmarkConfig({
     fixture: {
       context: "/benchmark/fixture",
@@ -332,14 +332,122 @@ test("rspack warm benchmark config enables readonly persistent cache", () => {
     cacheReadonly: true
   });
 
-  assert.deepEqual(config.cache, {
-    type: "persistent",
-    storage: {
-      type: "filesystem",
-      directory: "/benchmark/cache"
-    },
-    readonly: true
+  assert.equal(config.mode, "none");
+  assert.equal(config.target, "node");
+  assert.deepEqual(config.externalsPresets, {
+    node: false
   });
+  assert.deepEqual(config.entry, {
+    main: "/benchmark/fixture/src/index.js"
+  });
+  assert.deepEqual(config.output, {
+    path: "/benchmark/output",
+    filename: "main.js",
+    chunkFilename: "[name].js",
+    library: {
+      type: "commonjs2"
+    },
+    clean: false,
+    module: false,
+    iife: false,
+    chunkFormat: "commonjs",
+    chunkLoading: "require",
+    workerChunkLoading: false,
+    wasmLoading: false,
+    workerWasmLoading: false,
+    asyncChunks: true,
+    pathinfo: false,
+    strictModuleErrorHandling: false,
+    compareBeforeEmit: false
+  });
+  assert.equal(config.devtool, false);
+  assert.deepEqual(config.resolve, {
+    conditionNames: [],
+    extensions: [".ts", ".tsx", ".js", ".jsx"],
+    mainFields: ["main"],
+    byDependency: {
+      esm: {
+        conditionNames: [],
+        extensions: [".ts", ".tsx", ".js", ".jsx"],
+        mainFields: ["main"]
+      }
+    }
+  });
+  assert.deepEqual(config.module, {
+    parser: {
+      javascript: {
+        commonjs: false,
+        commonjsMagicComments: false,
+        createRequire: false,
+        exportsPresence: false,
+        importDynamic: true,
+        importMeta: false,
+        importMetaResolve: false,
+        requireAlias: false,
+        requireAsExpression: false,
+        requireDynamic: false,
+        requireResolve: false,
+        url: false,
+        worker: false
+      }
+    }
+  });
+  assert.equal(config.amd, false);
+  assert.equal(config.node, false);
+  assert.equal(config.performance, false);
+  assert.deepEqual(config.experiments, {
+    asyncWebAssembly: false
+  });
+  assert.deepEqual(config.optimization, {
+    moduleIds: "named",
+    chunkIds: "named",
+    minimize: false,
+    mergeDuplicateChunks: false,
+    splitChunks: false,
+    runtimeChunk: false,
+    removeEmptyChunks: true,
+    realContentHash: false,
+    sideEffects: false,
+    providedExports: true,
+    concatenateModules: false,
+    innerGraph: false,
+    usedExports: false,
+    mangleExports: false,
+    inlineExports: false,
+    nodeEnv: false,
+    emitOnErrors: true,
+    avoidEntryIife: false
+  });
+  assert.deepEqual(Object.keys(config.cache).sort(), [
+    "readonly",
+    "snapshot",
+    "storage",
+    "type"
+  ]);
+  assert.equal(config.cache.type, "persistent");
+  assert.deepEqual(config.cache.storage, {
+    type: "filesystem",
+    directory: "/benchmark/cache"
+  });
+  assert.equal(config.cache.readonly, true);
+  assert.deepEqual(Object.keys(config.cache.snapshot), ["managedPaths"]);
+  assert.equal(config.cache.snapshot.managedPaths.length, 1);
+  assert.equal(isAbsolute(config.cache.snapshot.managedPaths[0]), true);
+  assert.equal(
+    config.cache.snapshot.managedPaths[0].endsWith(join("@rspack", "core")),
+    true
+  );
+
+  const noCacheConfig = createRspackBenchmarkConfig({
+    fixture: {
+      context: "/benchmark/fixture",
+      entry: "./src/index.js"
+    },
+    outputDir: "/benchmark/output",
+    cacheDir: "/benchmark/cache",
+    persistentCache: false
+  });
+  assert.equal(noCacheConfig.cache, false);
 });
 
 test("non-loader adapters mark the loader benchmark fixture unsupported", async () => {


### PR DESCRIPTION
## Summary

- constrain the cross-bundler Rspack adapter to Unpack's Implemented Webpack Surface
- align resolver behavior, Node/CommonJS output, parser capabilities, named IDs, optimization settings, and persistent-cache Managed Paths
- add a configuration contract test and document the alignment boundary, including the Context Module limitation

## Why

Rspack 2.1.1 still enables several broader capabilities in `mode: "none"`, including split-chunks, side-effect analysis, natural IDs, Node builtin externalization, async WebAssembly, and compare-before-emit. Those defaults made the benchmark measure work and behavior that Unpack does not currently implement.

## Impact

Rspack benchmark rows now represent a closer workload comparison with Unpack. The intentional configuration shift changes the Rspack timing and output-size baseline without turning the benchmark into a compatibility claim.

## Checks

- `pnpm test`
- `pnpm --filter @unpack-js/benchmarks bench -- --fixtures large,loader --bundlers unpack,rspack --workspace .benchmark-work/rspack-alignment-reviewed --output-json .benchmark-work/rspack-alignment-reviewed/report.json --no-unpack-tracing`
- Standards and Spec reviews completed with no remaining findings
