### PR TITLE
Restore make phase parallelism

### DIFF
--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -52,8 +52,7 @@ impl CompilerOptions {
             infrastructure_logging: InfrastructureLoggingOptions::disabled(),
             module_rules: Vec::new(),
             loader_runner: None,
-      parallelism: std::thread::available_parallelism()
-        .map_or(16, |parallelism| (parallelism.get() * 4).clamp(16, 32)),
+            parallelism: 100,
             sourcemap: true,
         }
     }


### PR DESCRIPTION
## Summary

Restore the make phase's default parallelism to 100.

The CPU-derived 16–32 cap reduced the amount of concurrent factorization and module build work available during make. This change removes that cap while preserving the surrounding make contention and metrics improvements.
