### PR TITLE
Support done hook and ModuleGraph APIs

### DIFF
--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -16,9 +16,10 @@ use napi_derive::napi;
 use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
 use unpack_core::{
     Asset, BuildDependency, CacheCompression, CacheIdleReason, CacheOptions, Compiler,
-    CompilerOptions, Entry, Error as CoreError, InfrastructureLogEvent, InfrastructureLogLevel,
-    InfrastructureLoggingOptions, LoaderFuture, LoaderRequest, LoaderRunner, ModuleRule,
-    SnapshotOptions, SnapshotPathPattern, SnapshotStrategy,
+    CompilerOptions, Dependency, Entry, Error as CoreError, InfrastructureLogEvent,
+    InfrastructureLogLevel, InfrastructureLoggingOptions, LoaderFuture, LoaderRequest,
+    LoaderRunner, Module, ModuleRule, ModuleType, SnapshotOptions, SnapshotPathPattern,
+    SnapshotStrategy,
 };
 
 #[global_allocator]
@@ -173,6 +174,38 @@ pub struct NativeStatsJson {
     pub output_path: String,
     #[napi(js_name = "watchDependencies")]
     pub watch_dependencies: NativeWatchDependencies,
+    #[napi(js_name = "moduleGraph")]
+    pub module_graph: NativeModuleGraph,
+}
+
+#[napi(object)]
+pub struct NativeModuleGraph {
+    pub modules: Vec<NativeModule>,
+    pub connections: Vec<NativeModuleGraphConnection>,
+}
+
+#[napi(object)]
+pub struct NativeModule {
+    pub id: u32,
+    pub identifier: String,
+    pub resource: String,
+    #[napi(js_name = "type")]
+    pub module_type: String,
+    #[napi(js_name = "providedExports")]
+    pub provided_exports: Vec<String>,
+}
+
+#[napi(object)]
+pub struct NativeModuleGraphConnection {
+    #[napi(js_name = "originModule")]
+    pub origin_module: Option<u32>,
+    pub module: u32,
+    #[napi(js_name = "dependencyType")]
+    pub dependency_type: String,
+    pub request: Option<String>,
+    pub weak: bool,
+    #[napi(js_name = "parentBlockIndex")]
+    pub parent_block_index: i32,
 }
 
 #[napi(object)]
@@ -580,8 +613,94 @@ async fn run_compiler_inner(
             assets: compilation.assets().iter().map(asset_stats).collect(),
             output_path: output_path.to_string_lossy().into_owned(),
             watch_dependencies: watch_dependencies(compilation.watch_dependencies()),
+            module_graph: module_graph(compilation.module_graph()),
         }),
         logs,
+    }
+}
+
+fn module_graph(graph: &unpack_core::ModuleGraph) -> NativeModuleGraph {
+    NativeModuleGraph {
+        modules: graph.modules().iter().map(native_module).collect(),
+        connections: graph
+            .connections()
+            .iter()
+            .map(|connection| NativeModuleGraphConnection {
+                origin_module: connection.origin_module.map(native_module_id),
+                module: native_module_id(connection.module),
+                dependency_type: dependency_type(&connection.dependency).to_string(),
+                request: connection.dependency.request().map(str::to_string),
+                weak: dependency_is_weak(&connection.dependency),
+                parent_block_index: connection
+                    .origin_dependency_id
+                    .and_then(|index| i32::try_from(index).ok())
+                    .unwrap_or(-1),
+            })
+            .collect(),
+    }
+}
+
+fn native_module(module: &Module) -> NativeModule {
+    let identity = module.identity();
+    let resource = format!(
+        "{}{}{}",
+        identity.resource.to_string_lossy(),
+        identity.query.as_deref().unwrap_or_default(),
+        identity.fragment.as_deref().unwrap_or_default()
+    );
+    let request = if identity.loaders.is_empty() {
+        resource.clone()
+    } else {
+        format!("{}!{resource}", identity.loaders.join("!"))
+    };
+    let module_type = match identity.module_type {
+        ModuleType::JavaScriptAuto => "javascript/auto",
+    };
+
+    NativeModule {
+        id: native_module_id(module.id()),
+        identifier: format!("{module_type}|{request}"),
+        resource,
+        module_type: module_type.to_string(),
+        provided_exports: module
+            .exports_info()
+            .provided_exports()
+            .map(str::to_string)
+            .collect(),
+    }
+}
+
+fn native_module_id(id: unpack_core::ModuleId) -> u32 {
+    id.index().try_into().unwrap_or(u32::MAX)
+}
+
+fn dependency_type(dependency: &Dependency) -> &'static str {
+    match dependency {
+        Dependency::Entry(_) => "entry",
+        Dependency::HarmonyImportSideEffect(_) => "harmony side effect evaluation",
+        Dependency::HarmonyImportSpecifier(_) => "harmony import specifier",
+        Dependency::HarmonyExportHeader(_) => "harmony export header",
+        Dependency::HarmonyExportSpecifier(_) => "harmony export specifier",
+        Dependency::HarmonyExportExpression(_) => "harmony export expression",
+        Dependency::HarmonyExportImportedSpecifier(_) => "harmony export imported specifier",
+        Dependency::Null(_) => "null",
+        Dependency::Const(_) => "const",
+        Dependency::Import(_) => "import()",
+    }
+}
+
+fn dependency_is_weak(dependency: &Dependency) -> bool {
+    match dependency {
+        Dependency::Entry(dependency) => dependency.module.weak,
+        Dependency::HarmonyImportSideEffect(dependency) => dependency.module.weak,
+        Dependency::HarmonyImportSpecifier(dependency) => dependency.module.weak,
+        Dependency::HarmonyExportImportedSpecifier(dependency) => dependency.module.weak,
+        Dependency::Import(dependency) => dependency.module.weak,
+        Dependency::HarmonyExportHeader(_)
+        | Dependency::HarmonyExportSpecifier(_)
+        | Dependency::HarmonyExportExpression(_)
+        | Dependency::Null(_)
+        | Dependency::Const(_) => false,
     }
 }
 

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -118,11 +118,121 @@ export interface WatchDependencySets {
 }
 
 export interface Stats {
+  readonly compilation: Compilation;
   hasErrors(): boolean;
   toJson(): StatsJson;
 }
 
+export interface Compilation {
+  readonly moduleGraph: ModuleGraph;
+  readonly modules: ReadonlySet<Module>;
+}
+
+export interface Module {
+  readonly resource: string;
+  readonly type: string;
+  readonly dependencies: readonly Dependency[];
+  identifier(): string;
+  readableIdentifier(): string;
+  nameForCondition(): string;
+}
+
+export interface Dependency {
+  readonly type: string;
+  readonly request?: string;
+  readonly weak: boolean;
+  getResourceIdentifier(): string | null;
+}
+
+export interface ModuleGraphConnection {
+  readonly originModule: Module | null;
+  readonly resolvedOriginModule: Module | null;
+  readonly dependency: Dependency;
+  readonly module: Module;
+  readonly resolvedModule: Module;
+  readonly weak: boolean;
+  readonly conditional: false;
+  readonly active: boolean;
+  readonly explanations: ReadonlySet<string>;
+  getActiveState(runtime?: unknown): boolean;
+  isActive(runtime?: unknown): boolean;
+  isTargetActive(runtime?: unknown): boolean;
+}
+
+export interface ExportInfo {
+  readonly name: string;
+  readonly provided: boolean;
+  getUsedName(): string;
+}
+
+export interface ExportsInfo {
+  getProvidedExports(): string[];
+  isExportProvided(exportName: string | readonly string[]): boolean;
+  getExportInfo(exportName: string): ExportInfo;
+  getReadOnlyExportInfo(exportName: string): ExportInfo;
+  getUsedExports(runtime?: unknown): null;
+}
+
+export interface ModuleGraph {
+  getResolvedModule(dependency: Dependency): Module | null;
+  getConnection(dependency: Dependency): ModuleGraphConnection | undefined;
+  getModule(dependency: Dependency): Module | null;
+  getOrigin(dependency: Dependency): Module | null;
+  getResolvedOrigin(dependency: Dependency): Module | null;
+  getParentModule(dependency: Dependency): Module | undefined;
+  getParentBlock(dependency: Dependency): undefined;
+  getParentBlockIndex(dependency: Dependency): number;
+  getIncomingConnections(module: Module): ReadonlySet<ModuleGraphConnection>;
+  getOutgoingConnections(module: Module): ReadonlySet<ModuleGraphConnection>;
+  getIncomingConnectionsByOriginModule(
+    module: Module
+  ): ReadonlyMap<Module | null, readonly ModuleGraphConnection[]>;
+  getOutgoingConnectionsByModule(
+    module: Module
+  ): ReadonlyMap<Module, readonly ModuleGraphConnection[]> | undefined;
+  getIssuer(module: Module): Module | null | undefined;
+  getOptimizationBailout(module: Module): readonly string[];
+  getProvidedExports(module: Module): string[];
+  isExportProvided(
+    module: Module,
+    exportName: string | readonly string[]
+  ): boolean;
+  getExportsInfo(module: Module): ExportsInfo;
+  getExportInfo(module: Module, exportName: string): ExportInfo;
+  getReadOnlyExportInfo(module: Module, exportName: string): ExportInfo;
+  getUsedExports(module: Module, runtime?: unknown): null;
+  cached<TArgs extends unknown[], TResult>(
+    fn: (moduleGraph: ModuleGraph, ...args: TArgs) => TResult,
+    ...args: TArgs
+  ): TResult;
+}
+
+export interface TapOptions {
+  name: string;
+  stage?: number;
+  before?: string | string[];
+}
+
+export interface DoneHook {
+  tap(options: string | TapOptions, callback: (stats: Stats) => void): void;
+  tapAsync(
+    options: string | TapOptions,
+    callback: (stats: Stats, done: (error?: Error | null) => void) => void
+  ): void;
+  tapPromise(
+    options: string | TapOptions,
+    callback: (stats: Stats) => PromiseLike<void>
+  ): void;
+  callAsync(stats: Stats, callback: (error?: Error | null) => void): void;
+  promise(stats: Stats): Promise<void>;
+}
+
+export interface CompilerHooks {
+  readonly done: DoneHook;
+}
+
 export interface Compiler {
+  readonly hooks: CompilerHooks;
   run(callback: RunCallback): void;
   watch(watchOptions: WatchOptions, handler: WatchHandler): Watching;
   close(callback: CloseCallback): void;
@@ -271,6 +381,38 @@ interface NativeStatsJson {
   output_path?: string;
   watchDependencies?: WatchDependencySets;
   watch_dependencies?: WatchDependencySets;
+  moduleGraph?: NativeModuleGraph;
+  module_graph?: NativeModuleGraph;
+}
+
+interface NativeModuleGraph {
+  modules: NativeModule[];
+  connections: NativeModuleGraphConnection[];
+}
+
+interface NativeModule {
+  id: number;
+  identifier: string;
+  resource: string;
+  type: string;
+  providedExports: string[];
+}
+
+interface NativeModuleGraphConnection {
+  originModule?: number | null;
+  origin_module?: number | null;
+  module: number;
+  dependencyType?: string;
+  dependency_type?: string;
+  request?: string | null;
+  weak: boolean;
+  parentBlockIndex?: number;
+  parent_block_index?: number;
+}
+
+interface NormalizedNativeStats {
+  json: StatsJson;
+  moduleGraph: NativeModuleGraph;
 }
 
 interface NativeRunResult {
@@ -423,12 +565,125 @@ class LoaderRuntime {
   };
 }
 
+interface DoneTap {
+  name: string;
+  stage: number;
+  before: Set<string>;
+  run(stats: Stats): Promise<void>;
+}
+
+class DoneHookImpl implements DoneHook {
+  readonly #taps: DoneTap[] = [];
+
+  tap(options: string | TapOptions, callback: (stats: Stats) => void): void {
+    assertFunction(callback, "callback");
+    this.#insert(options, async (stats) => {
+      callback(stats);
+    });
+  }
+
+  tapAsync(
+    options: string | TapOptions,
+    callback: (stats: Stats, done: (error?: Error | null) => void) => void
+  ): void {
+    assertFunction(callback, "callback");
+    this.#insert(
+      options,
+      (stats) =>
+        new Promise<void>((resolve, reject) => {
+          let completed = false;
+          const done = (error?: Error | null): void => {
+            if (completed) return;
+            completed = true;
+            if (error) reject(error);
+            else resolve();
+          };
+          try {
+            callback(stats, done);
+          } catch (error) {
+            done(toError(error, "HookError"));
+          }
+        })
+    );
+  }
+
+  tapPromise(
+    options: string | TapOptions,
+    callback: (stats: Stats) => PromiseLike<void>
+  ): void {
+    assertFunction(callback, "callback");
+    this.#insert(options, async (stats) => {
+      await callback(stats);
+    });
+  }
+
+  callAsync(stats: Stats, callback: (error?: Error | null) => void): void {
+    assertFunction(callback, "callback");
+    void this.promise(stats).then(
+      () => callback(),
+      (error: unknown) => callback(toError(error, "HookError"))
+    );
+  }
+
+  async promise(stats: Stats): Promise<void> {
+    for (const tap of this.#taps) {
+      await tap.run(stats);
+    }
+  }
+
+  #insert(
+    options: string | TapOptions,
+    run: (stats: Stats) => Promise<void>
+  ): void {
+    const normalized = normalizeTapOptions(options);
+    const tap: DoneTap = { ...normalized, run };
+    const before = new Set(tap.before);
+    let index = this.#taps.length;
+    while (index > 0) {
+      const current = this.#taps[index - 1];
+      if (before.has(current.name)) {
+        before.delete(current.name);
+        index -= 1;
+        continue;
+      }
+      if (before.size > 0 || current.stage > tap.stage) {
+        index -= 1;
+        continue;
+      }
+      break;
+    }
+    this.#taps.splice(index, 0, tap);
+  }
+}
+
+function normalizeTapOptions(options: string | TapOptions): Omit<DoneTap, "run"> {
+  if (typeof options === "string") {
+    return { name: assertNonEmptyString(options, "options"), stage: 0, before: new Set() };
+  }
+  assertPlainObject(options, "options");
+  const name = assertNonEmptyString(options.name, "options.name");
+  const stage = options.stage === undefined ? 0 : options.stage;
+  if (typeof stage !== "number" || !Number.isFinite(stage)) {
+    throw new TypeError("options.stage must be a finite number");
+  }
+  const before = options.before === undefined
+    ? []
+    : typeof options.before === "string"
+      ? [options.before]
+      : options.before;
+  if (!Array.isArray(before) || before.some((item) => typeof item !== "string")) {
+    throw new TypeError("options.before must be a string or an array of strings");
+  }
+  return { name, stage, before: new Set(before) };
+}
+
 type CompilerLifecycle =
   | { kind: "open" }
   | { kind: "closing"; operation: Promise<Error | null> }
   | { kind: "closed" };
 
 class CompilerImpl implements Compiler {
+  readonly hooks: CompilerHooks = { done: new DoneHookImpl() };
   #lifecycle: CompilerLifecycle = { kind: "open" };
   #running = false;
   #watching: WatchingImpl | undefined;
@@ -517,10 +772,11 @@ class CompilerImpl implements Compiler {
         );
         this.#hasCompletedFilesystemCompilation = true;
         this.#emitInfrastructureLog("info", "unpack.Compiler", "run completed");
-        this.#deliverRunCallback(
-          callback,
-          null,
-          new StatsImpl(normalizeNativeStats(result.stats))
+        const stats = new StatsImpl(normalizeNativeStats(result.stats));
+        void this.hooks.done.promise(stats).then(
+          () => this.#deliverRunCallback(callback, null, stats),
+          (error: unknown) =>
+            this.#deliverRunCallback(callback, toError(error, "HookError"))
         );
       },
       (error: unknown) => {
@@ -702,7 +958,14 @@ class CompilerImpl implements Compiler {
       );
       this.#hasCompletedFilesystemCompilation = true;
       this.#emitInfrastructureLog("info", "unpack.Watch", "watch compilation completed");
-      handler(null, new StatsImpl(normalizeNativeStats(result.stats)));
+      const stats = new StatsImpl(normalizeNativeStats(result.stats));
+      try {
+        await this.hooks.done.promise(stats);
+      } catch (error) {
+        handler(toError(error, "HookError"));
+        return;
+      }
+      handler(null, stats);
     } catch (error) {
       const infrastructureError = toError(error, "InfrastructureError");
       this.#emitInfrastructureLog("error", "unpack.Watch", infrastructureError.message);
@@ -1018,21 +1281,338 @@ class WatchingImpl implements Watching {
 }
 
 class StatsImpl implements Stats {
-  constructor(private readonly json: StatsJson) {}
+  readonly compilation: Compilation;
+  readonly #json: StatsJson;
+
+  constructor(stats: NormalizedNativeStats) {
+    this.#json = stats.json;
+    this.compilation = new CompilationImpl(stats.moduleGraph);
+  }
 
   hasErrors(): boolean {
-    return this.json.errors.length > 0;
+    return this.#json.errors.length > 0;
   }
 
   toJson(): StatsJson {
     return {
-      errors: this.json.errors.map(cloneStatsError),
-      warnings: this.json.warnings.map(cloneStatsError),
-      assets: this.json.assets.map((asset) => ({ ...asset })),
-      outputPath: this.json.outputPath,
-      watchDependencies: cloneWatchDependencies(this.json.watchDependencies)
+      errors: this.#json.errors.map(cloneStatsError),
+      warnings: this.#json.warnings.map(cloneStatsError),
+      assets: this.#json.assets.map((asset) => ({ ...asset })),
+      outputPath: this.#json.outputPath,
+      watchDependencies: cloneWatchDependencies(this.#json.watchDependencies)
     };
   }
+}
+
+class ModuleImpl implements Module {
+  dependencies: readonly Dependency[] = [];
+
+  constructor(
+    readonly resource: string,
+    readonly type: string,
+    readonly providedExports: readonly string[],
+    readonly #identifier: string
+  ) {}
+
+  identifier(): string {
+    return this.#identifier;
+  }
+
+  readableIdentifier(): string {
+    return this.#identifier;
+  }
+
+  nameForCondition(): string {
+    return this.resource;
+  }
+
+  setDependencies(dependencies: readonly Dependency[]): void {
+    this.dependencies = dependencies;
+  }
+}
+
+class DependencyImpl implements Dependency {
+  constructor(
+    readonly type: string,
+    readonly request: string | undefined,
+    readonly weak: boolean,
+    readonly parentBlockIndex: number
+  ) {}
+
+  getResourceIdentifier(): string | null {
+    return this.request === undefined ? null : `context|module${this.request}`;
+  }
+}
+
+class ModuleGraphConnectionImpl implements ModuleGraphConnection {
+  readonly resolvedOriginModule: Module | null;
+  readonly resolvedModule: Module;
+  readonly conditional = false as const;
+  readonly active = true;
+  readonly explanations: ReadonlySet<string> = new Set();
+
+  constructor(
+    readonly originModule: Module | null,
+    readonly dependency: Dependency,
+    readonly module: Module,
+    readonly weak: boolean
+  ) {
+    this.resolvedOriginModule = originModule;
+    this.resolvedModule = module;
+  }
+
+  getActiveState(_runtime?: unknown): boolean {
+    return true;
+  }
+
+  isActive(_runtime?: unknown): boolean {
+    return true;
+  }
+
+  isTargetActive(_runtime?: unknown): boolean {
+    return true;
+  }
+}
+
+class ExportInfoImpl implements ExportInfo {
+  constructor(readonly name: string, readonly provided: boolean) {}
+
+  getUsedName(): string {
+    return this.name;
+  }
+}
+
+class ExportsInfoImpl implements ExportsInfo {
+  readonly #provided: Set<string>;
+  readonly #exports = new Map<string, ExportInfo>();
+
+  constructor(providedExports: readonly string[]) {
+    this.#provided = new Set(providedExports);
+  }
+
+  getProvidedExports(): string[] {
+    return [...this.#provided];
+  }
+
+  isExportProvided(exportName: string | readonly string[]): boolean {
+    const name = typeof exportName === "string" ? exportName : exportName[0];
+    return name !== undefined && this.#provided.has(name);
+  }
+
+  getExportInfo(exportName: string): ExportInfo {
+    let info = this.#exports.get(exportName);
+    if (!info) {
+      info = new ExportInfoImpl(exportName, this.#provided.has(exportName));
+      this.#exports.set(exportName, info);
+    }
+    return info;
+  }
+
+  getReadOnlyExportInfo(exportName: string): ExportInfo {
+    return this.getExportInfo(exportName);
+  }
+
+  getUsedExports(_runtime?: unknown): null {
+    return null;
+  }
+}
+
+const EMPTY_CONNECTIONS: ReadonlySet<ModuleGraphConnection> = new Set();
+
+class ModuleGraphImpl implements ModuleGraph {
+  readonly #connectionByDependency = new Map<Dependency, ModuleGraphConnectionImpl>();
+  readonly #incoming = new Map<Module, Set<ModuleGraphConnection>>();
+  readonly #outgoing = new Map<Module, Set<ModuleGraphConnection>>();
+  readonly #exports = new Map<Module, ExportsInfoImpl>();
+
+  constructor(
+    modulesById: ReadonlyMap<number, ModuleImpl>,
+    connections: readonly NativeModuleGraphConnection[]
+  ) {
+    for (const module of modulesById.values()) {
+      this.#exports.set(module, new ExportsInfoImpl(module.providedExports));
+    }
+    for (const nativeConnection of connections) {
+      const target = modulesById.get(nativeConnection.module);
+      if (!target) continue;
+      const originId = nativeConnection.originModule ?? nativeConnection.origin_module;
+      const origin = originId == null ? null : modulesById.get(originId) ?? null;
+      const dependency = new DependencyImpl(
+        nativeConnection.dependencyType ?? nativeConnection.dependency_type ?? "unknown",
+        nativeConnection.request ?? undefined,
+        nativeConnection.weak,
+        nativeConnection.parentBlockIndex ?? nativeConnection.parent_block_index ?? -1
+      );
+      const connection = new ModuleGraphConnectionImpl(
+        origin,
+        dependency,
+        target,
+        nativeConnection.weak
+      );
+      this.#connectionByDependency.set(dependency, connection);
+      addToSetMap(this.#incoming, target, connection);
+      if (origin) addToSetMap(this.#outgoing, origin, connection);
+    }
+  }
+
+  getResolvedModule(dependency: Dependency): Module | null {
+    return this.getConnection(dependency)?.resolvedModule ?? null;
+  }
+
+  getConnection(dependency: Dependency): ModuleGraphConnectionImpl | undefined {
+    return this.#connectionByDependency.get(dependency);
+  }
+
+  getModule(dependency: Dependency): Module | null {
+    return this.getConnection(dependency)?.module ?? null;
+  }
+
+  getOrigin(dependency: Dependency): Module | null {
+    return this.getConnection(dependency)?.originModule ?? null;
+  }
+
+  getResolvedOrigin(dependency: Dependency): Module | null {
+    return this.getConnection(dependency)?.resolvedOriginModule ?? null;
+  }
+
+  getParentModule(dependency: Dependency): Module | undefined {
+    return this.getConnection(dependency)?.originModule ?? undefined;
+  }
+
+  getParentBlock(_dependency: Dependency): undefined {
+    return undefined;
+  }
+
+  getParentBlockIndex(dependency: Dependency): number {
+    return dependency instanceof DependencyImpl ? dependency.parentBlockIndex : -1;
+  }
+
+  getIncomingConnections(module: Module): ReadonlySet<ModuleGraphConnection> {
+    return this.#incoming.get(module) ?? EMPTY_CONNECTIONS;
+  }
+
+  getOutgoingConnections(module: Module): ReadonlySet<ModuleGraphConnection> {
+    return this.#outgoing.get(module) ?? EMPTY_CONNECTIONS;
+  }
+
+  getIncomingConnectionsByOriginModule(
+    module: Module
+  ): ReadonlyMap<Module | null, readonly ModuleGraphConnection[]> {
+    return groupConnections(this.getIncomingConnections(module), (connection) =>
+      connection.originModule
+    );
+  }
+
+  getOutgoingConnectionsByModule(
+    module: Module
+  ): ReadonlyMap<Module, readonly ModuleGraphConnection[]> | undefined {
+    const connections = this.#outgoing.get(module);
+    if (!connections) return undefined;
+    return groupConnections(connections, (connection) => connection.module);
+  }
+
+  getIssuer(module: Module): Module | null | undefined {
+    const incoming = this.#incoming.get(module);
+    if (!incoming) return undefined;
+    for (const connection of incoming) {
+      if (connection.originModule) return connection.originModule;
+    }
+    return null;
+  }
+
+  getOptimizationBailout(_module: Module): readonly string[] {
+    return [];
+  }
+
+  getProvidedExports(module: Module): string[] {
+    return this.getExportsInfo(module).getProvidedExports();
+  }
+
+  isExportProvided(
+    module: Module,
+    exportName: string | readonly string[]
+  ): boolean {
+    return this.getExportsInfo(module).isExportProvided(exportName);
+  }
+
+  getExportsInfo(module: Module): ExportsInfoImpl {
+    return this.#exports.get(module) ?? new ExportsInfoImpl([]);
+  }
+
+  getExportInfo(module: Module, exportName: string): ExportInfo {
+    return this.getExportsInfo(module).getExportInfo(exportName);
+  }
+
+  getReadOnlyExportInfo(module: Module, exportName: string): ExportInfo {
+    return this.getExportsInfo(module).getReadOnlyExportInfo(exportName);
+  }
+
+  getUsedExports(module: Module, runtime?: unknown): null {
+    return this.getExportsInfo(module).getUsedExports(runtime);
+  }
+
+  cached<TArgs extends unknown[], TResult>(
+    fn: (moduleGraph: ModuleGraph, ...args: TArgs) => TResult,
+    ...args: TArgs
+  ): TResult {
+    return fn(this, ...args);
+  }
+}
+
+class CompilationImpl implements Compilation {
+  readonly moduleGraph: ModuleGraph;
+  readonly modules: ReadonlySet<Module>;
+
+  constructor(graph: NativeModuleGraph) {
+    const modulesById = new Map(
+      graph.modules.map((module) => [
+        module.id,
+        new ModuleImpl(
+          module.resource,
+          module.type,
+          module.providedExports,
+          module.identifier
+        )
+      ])
+    );
+    const moduleGraph = new ModuleGraphImpl(modulesById, graph.connections);
+    for (const module of modulesById.values()) {
+      module.setDependencies(
+        [...moduleGraph.getOutgoingConnections(module)].map(
+          (connection) => connection.dependency
+        )
+      );
+    }
+    this.moduleGraph = moduleGraph;
+    this.modules = new Set(modulesById.values());
+  }
+}
+
+function addToSetMap<TKey, TValue>(
+  map: Map<TKey, Set<TValue>>,
+  key: TKey,
+  value: TValue
+): void {
+  let values = map.get(key);
+  if (!values) {
+    values = new Set();
+    map.set(key, values);
+  }
+  values.add(value);
+}
+
+function groupConnections<TKey>(
+  connections: Iterable<ModuleGraphConnection>,
+  getKey: (connection: ModuleGraphConnection) => TKey
+): ReadonlyMap<TKey, readonly ModuleGraphConnection[]> {
+  const groups = new Map<TKey, ModuleGraphConnection[]>();
+  for (const connection of connections) {
+    const key = getKey(connection);
+    const group = groups.get(key);
+    if (group) group.push(connection);
+    else groups.set(key, [connection]);
+  }
+  return groups;
 }
 
 export default function unpack(
@@ -1731,25 +2311,38 @@ function normalizeWatchPoll(value: unknown): number | undefined {
   throw new TypeError("watchOptions.poll must be true or a positive integer");
 }
 
-function normalizeNativeStats(stats: NativeStatsJson | null | undefined): StatsJson {
+function normalizeNativeStats(
+  stats: NativeStatsJson | null | undefined
+): NormalizedNativeStats {
   if (!stats) {
     return {
-      errors: [],
-      warnings: [],
-      assets: [],
-      outputPath: "",
-      watchDependencies: emptyWatchDependencies()
+      json: {
+        errors: [],
+        warnings: [],
+        assets: [],
+        outputPath: "",
+        watchDependencies: emptyWatchDependencies()
+      },
+      moduleGraph: emptyNativeModuleGraph()
     };
   }
   return {
-    errors: stats.errors.map(cloneStatsError),
-    warnings: (stats.warnings ?? []).map(cloneStatsError),
-    assets: stats.assets.map((asset) => ({ ...asset })),
-    outputPath: stats.outputPath ?? stats.output_path ?? "",
-    watchDependencies: cloneWatchDependencies(
-      stats.watchDependencies ?? stats.watch_dependencies ?? emptyWatchDependencies()
-    )
+    json: {
+      errors: stats.errors.map(cloneStatsError),
+      warnings: (stats.warnings ?? []).map(cloneStatsError),
+      assets: stats.assets.map((asset) => ({ ...asset })),
+      outputPath: stats.outputPath ?? stats.output_path ?? "",
+      watchDependencies: cloneWatchDependencies(
+        stats.watchDependencies ?? stats.watch_dependencies ?? emptyWatchDependencies()
+      )
+    },
+    moduleGraph:
+      stats.moduleGraph ?? stats.module_graph ?? emptyNativeModuleGraph()
   };
+}
+
+function emptyNativeModuleGraph(): NativeModuleGraph {
+  return { modules: [], connections: [] };
 }
 
 function cloneStatsError(error: StatsError): StatsError {

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -1306,13 +1306,16 @@ class StatsImpl implements Stats {
 
 class ModuleImpl implements Module {
   dependencies: readonly Dependency[] = [];
+  readonly #identifier: string;
 
   constructor(
     readonly resource: string,
     readonly type: string,
     readonly providedExports: readonly string[],
-    readonly #identifier: string
-  ) {}
+    identifier: string
+  ) {
+    this.#identifier = identifier;
+  }
 
   identifier(): string {
     return this.#identifier;
@@ -1418,11 +1421,26 @@ class ExportsInfoImpl implements ExportsInfo {
 }
 
 const EMPTY_CONNECTIONS: ReadonlySet<ModuleGraphConnection> = new Set();
+const EMPTY_INCOMING_CONNECTION_GROUPS: ReadonlyMap<
+  Module | null,
+  readonly ModuleGraphConnection[]
+> = new Map();
+const EMPTY_OPTIMIZATION_BAILOUTS: readonly string[] = [];
+const EMPTY_EXPORTS_INFO = new ExportsInfoImpl([]);
 
 class ModuleGraphImpl implements ModuleGraph {
   readonly #connectionByDependency = new Map<Dependency, ModuleGraphConnectionImpl>();
   readonly #incoming = new Map<Module, Set<ModuleGraphConnection>>();
   readonly #outgoing = new Map<Module, Set<ModuleGraphConnection>>();
+  readonly #incomingByOrigin = new Map<
+    Module,
+    ReadonlyMap<Module | null, readonly ModuleGraphConnection[]>
+  >();
+  readonly #outgoingByModule = new Map<
+    Module,
+    ReadonlyMap<Module, readonly ModuleGraphConnection[]>
+  >();
+  readonly #issuers = new Map<Module, Module | null>();
   readonly #exports = new Map<Module, ExportsInfoImpl>();
 
   constructor(
@@ -1452,6 +1470,27 @@ class ModuleGraphImpl implements ModuleGraph {
       this.#connectionByDependency.set(dependency, connection);
       addToSetMap(this.#incoming, target, connection);
       if (origin) addToSetMap(this.#outgoing, origin, connection);
+    }
+    for (const module of modulesById.values()) {
+      const incoming = this.#incoming.get(module);
+      if (incoming) {
+        this.#incomingByOrigin.set(
+          module,
+          groupConnections(incoming, (connection) => connection.originModule)
+        );
+        this.#issuers.set(
+          module,
+          [...incoming].find((connection) => connection.originModule !== null)
+            ?.originModule ?? null
+        );
+      }
+      const outgoing = this.#outgoing.get(module);
+      if (outgoing) {
+        this.#outgoingByModule.set(
+          module,
+          groupConnections(outgoing, (connection) => connection.module)
+        );
+      }
     }
   }
 
@@ -1498,30 +1537,21 @@ class ModuleGraphImpl implements ModuleGraph {
   getIncomingConnectionsByOriginModule(
     module: Module
   ): ReadonlyMap<Module | null, readonly ModuleGraphConnection[]> {
-    return groupConnections(this.getIncomingConnections(module), (connection) =>
-      connection.originModule
-    );
+    return this.#incomingByOrigin.get(module) ?? EMPTY_INCOMING_CONNECTION_GROUPS;
   }
 
   getOutgoingConnectionsByModule(
     module: Module
   ): ReadonlyMap<Module, readonly ModuleGraphConnection[]> | undefined {
-    const connections = this.#outgoing.get(module);
-    if (!connections) return undefined;
-    return groupConnections(connections, (connection) => connection.module);
+    return this.#outgoingByModule.get(module);
   }
 
   getIssuer(module: Module): Module | null | undefined {
-    const incoming = this.#incoming.get(module);
-    if (!incoming) return undefined;
-    for (const connection of incoming) {
-      if (connection.originModule) return connection.originModule;
-    }
-    return null;
+    return this.#issuers.get(module);
   }
 
   getOptimizationBailout(_module: Module): readonly string[] {
-    return [];
+    return EMPTY_OPTIMIZATION_BAILOUTS;
   }
 
   getProvidedExports(module: Module): string[] {
@@ -1536,7 +1566,7 @@ class ModuleGraphImpl implements ModuleGraph {
   }
 
   getExportsInfo(module: Module): ExportsInfoImpl {
-    return this.#exports.get(module) ?? new ExportsInfoImpl([]);
+    return this.#exports.get(module) ?? EMPTY_EXPORTS_INFO;
   }
 
   getExportInfo(module: Module, exportName: string): ExportInfo {

--- a/packages/unpack/test/done-hook-module-graph.test.ts
+++ b/packages/unpack/test/done-hook-module-graph.test.ts
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import unpack from "@unpack-js/core";
+import type {
+  Compiler,
+  Module,
+  ModuleGraphConnection,
+  Stats
+} from "@unpack-js/core";
+
+// Ported from webpack's Compiler hook integration coverage: done is an
+// AsyncSeriesHook and the final run callback observes it as completed.
+test("done taps run serially before the run callback", async () => {
+  const fixture = await createGraphFixture();
+  const compiler = createCompiler(fixture);
+  const events: string[] = [];
+  const seenStats: Stats[] = [];
+
+  compiler.hooks.done.tap({ name: "last", stage: 10 }, (stats) => {
+    seenStats.push(stats);
+    events.push("sync");
+  });
+  compiler.hooks.done.tapPromise(
+    { name: "promise", before: "last" },
+    async (stats) => {
+      seenStats.push(stats);
+      events.push("promise:start");
+      await delay(5);
+      events.push("promise:end");
+    }
+  );
+  compiler.hooks.done.tapAsync(
+    { name: "callback", before: "promise" },
+    (stats, done) => {
+      seenStats.push(stats);
+      events.push("callback:start");
+      setTimeout(() => {
+        events.push("callback:end");
+        done();
+      }, 5);
+    }
+  );
+
+  try {
+    const stats = await runCompiler(compiler, () => events.push("run:callback"));
+    assert.deepEqual(events, [
+      "callback:start",
+      "callback:end",
+      "promise:start",
+      "promise:end",
+      "sync",
+      "run:callback"
+    ]);
+    assert.equal(seenStats.length, 3);
+    assert.equal(seenStats.every((seen) => seen === stats), true);
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+// Ported from webpack's Compiler.run behavior: errors from done abort the
+// successful callback path and do not provide Stats to the final callback.
+test("done errors are delivered as run errors without Stats", async () => {
+  const fixture = await createGraphFixture();
+  const compiler = createCompiler(fixture);
+  const expected = new Error("done failed");
+  compiler.hooks.done.tap("failure", () => {
+    throw expected;
+  });
+
+  try {
+    const observation = await observeCompilerRun(compiler);
+    assert.equal(observation.error, expected);
+    assert.equal(observation.stats, undefined);
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+// Ported from webpack ModuleGraph's public query contract. The assertions use
+// a completed real compilation, as webpack plugins do, rather than a mock graph.
+test("done exposes webpack-shaped ModuleGraph queries with cached grouping", async () => {
+  const fixture = await createGraphFixture();
+  const compiler = createCompiler(fixture);
+  let inspected = false;
+
+  compiler.hooks.done.tap("inspect module graph", (stats) => {
+    const { moduleGraph, modules } = stats.compilation;
+    assert.equal(modules.size, 4);
+
+    const entry = findModule(modules, "/src/index.js");
+    const left = findModule(modules, "/src/left.js");
+    const right = findModule(modules, "/src/right.js");
+    const shared = findModule(modules, "/src/shared.js");
+
+    const entryOutgoing = moduleGraph.getOutgoingConnections(entry);
+    assert.equal(entryOutgoing.size > 0, true);
+    for (const connection of entryOutgoing) {
+      assertConnection(connection);
+      assert.equal(connection.originModule, entry);
+      assert.equal(moduleGraph.getConnection(connection.dependency), connection);
+      assert.equal(moduleGraph.getModule(connection.dependency), connection.module);
+      assert.equal(moduleGraph.getResolvedModule(connection.dependency), connection.module);
+      assert.equal(moduleGraph.getOrigin(connection.dependency), entry);
+      assert.equal(moduleGraph.getResolvedOrigin(connection.dependency), entry);
+      assert.equal(moduleGraph.getParentModule(connection.dependency), entry);
+    }
+
+    const outgoingByModule = moduleGraph.getOutgoingConnectionsByModule(entry);
+    assert.ok(outgoingByModule);
+    assert.equal(outgoingByModule, moduleGraph.getOutgoingConnectionsByModule(entry));
+    assert.equal(outgoingByModule.has(left), true);
+    assert.equal(outgoingByModule.has(right), true);
+
+    const sharedIncoming = moduleGraph.getIncomingConnections(shared);
+    const incomingOrigins = new Set(
+      [...sharedIncoming].map((connection) => connection.originModule)
+    );
+    assert.equal(incomingOrigins.has(left), true);
+    assert.equal(incomingOrigins.has(right), true);
+
+    const incomingByOrigin = moduleGraph.getIncomingConnectionsByOriginModule(shared);
+    assert.equal(
+      incomingByOrigin,
+      moduleGraph.getIncomingConnectionsByOriginModule(shared)
+    );
+    assert.equal(incomingByOrigin.has(left), true);
+    assert.equal(incomingByOrigin.has(right), true);
+    assert.equal(incomingOrigins.has(moduleGraph.getIssuer(shared) ?? null), true);
+
+    assert.deepEqual(moduleGraph.getProvidedExports(shared), ["shared"]);
+    assert.equal(moduleGraph.isExportProvided(shared, "shared"), true);
+    assert.equal(moduleGraph.isExportProvided(shared, "missing"), false);
+    assert.equal(
+      moduleGraph.getExportsInfo(shared),
+      moduleGraph.getExportsInfo(shared)
+    );
+    assert.equal(
+      moduleGraph.getExportInfo(shared, "shared"),
+      moduleGraph.getReadOnlyExportInfo(shared, "shared")
+    );
+    assert.equal(moduleGraph.getExportInfo(shared, "shared").provided, true);
+    assert.equal(moduleGraph.getUsedExports(shared), null);
+    inspected = true;
+  });
+
+  try {
+    const stats = await runCompiler(compiler);
+    assert.equal(stats.hasErrors(), false);
+    assert.equal(inspected, true);
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+function assertConnection(connection: ModuleGraphConnection): void {
+  assert.equal(connection.resolvedOriginModule, connection.originModule);
+  assert.equal(connection.resolvedModule, connection.module);
+  assert.equal(connection.active, true);
+  assert.equal(connection.getActiveState(), true);
+  assert.equal(connection.isActive(), true);
+  assert.equal(connection.isTargetActive(), true);
+}
+
+function findModule(modules: ReadonlySet<Module>, suffix: string): Module {
+  const normalizedSuffix = suffix.replaceAll("/", join("/"));
+  const module = [...modules].find((candidate) =>
+    candidate.resource.endsWith(normalizedSuffix)
+  );
+  assert.ok(module, `expected module ending in ${suffix}`);
+  return module;
+}
+
+function createCompiler(context: string): Compiler {
+  return unpack({
+    context,
+    entry: "./src/index.js",
+    output: { path: join(context, "dist") },
+    sourcemap: false
+  });
+}
+
+async function createGraphFixture(): Promise<string> {
+  const fixture = await mkdtemp(join(tmpdir(), "unpack-module-graph-"));
+  await writeFixtureFile(
+    join(fixture, "src/index.js"),
+    'export { left } from "./left.js";\nexport { right } from "./right.js";\n'
+  );
+  await writeFixtureFile(
+    join(fixture, "src/left.js"),
+    'import { shared } from "./shared.js";\nexport const left = shared;\n'
+  );
+  await writeFixtureFile(
+    join(fixture, "src/right.js"),
+    'import { shared } from "./shared.js";\nexport const right = shared;\n'
+  );
+  await writeFixtureFile(
+    join(fixture, "src/shared.js"),
+    'export const shared = "shared";\n'
+  );
+  return fixture;
+}
+
+async function writeFixtureFile(path: string, contents: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, contents);
+}
+
+function runCompiler(compiler: Compiler, onCallback?: () => void): Promise<Stats> {
+  return new Promise((resolve, reject) => {
+    compiler.run((error, stats) => {
+      onCallback?.();
+      if (error) reject(error);
+      else if (!stats) reject(new Error("compiler completed without Stats"));
+      else resolve(stats);
+    });
+  });
+}
+
+function observeCompilerRun(
+  compiler: Compiler
+): Promise<{ error: Error | null; stats: Stats | undefined }> {
+  return new Promise((resolve) => {
+    compiler.run((error, stats) => resolve({ error, stats }));
+  });
+}
+
+function closeCompiler(compiler: Compiler): Promise<void> {
+  return new Promise((resolve, reject) => {
+    compiler.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}


### PR DESCRIPTION
## Summary

- add a webpack-shaped `compiler.hooks.done` async series hook with sync, callback, and promise taps
- expose `stats.compilation.moduleGraph` and `stats.compilation.modules`
- serialize completed module graph data across the native boundary
- provide the primary dependency, connection, issuer, and exports lookup APIs with stable JavaScript object identity
- precompute connection grouping and issuer indexes so repeated graph API access avoids traversal and allocation
- replace raw ModuleGraph indexes with `ModuleGraphConnectionId`, `DependencyId`, and `AsyncDependenciesBlockId`
- port webpack-shaped Compiler hook and ModuleGraph behavior coverage to JavaScript API tests

## Motivation

Plugins need access to the completed compilation graph from the `done` hook. This adds the model-backed surface without placing graph data in `stats.toJson()` or exposing unsupported graph mutation operations.

Module graph identities now remain distinct across make, graph lookup, chunk planning, code generation, and native serialization instead of sharing interchangeable `usize` values.

## Impact

JavaScript integrations can inspect modules and traverse incoming or outgoing connections after run and watch compilations using webpack-shaped APIs. Repeated grouped connection queries reuse their completed-compilation indexes.

## Test coverage

- `cargo test -p unpack_core`: 112 passed, 0 failed
- `pnpm --filter @unpack-js/core test`: 107 passed, 1 platform-specific test skipped, 0 failed
