### PR TITLE
Use typed identifiers in ModuleGraph

### DIFF
--- a/crates/unpack_core/src/chunk_graph.rs
+++ b/crates/unpack_core/src/chunk_graph.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-    CompilerOptions, ModuleGraph, ModuleId,
+    AsyncDependenciesBlockId, CompilerOptions, ModuleGraph, ModuleId,
     id_assignment::RenderId,
     runtime::{
         RuntimeModule, RuntimeRequirements, entry_startup_runtime_requirements,
@@ -178,7 +178,7 @@ pub enum ChunkGroupKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AsyncBlockOrigin {
     pub module: ModuleId,
-    pub block_index: usize,
+    pub block: AsyncDependenciesBlockId,
 }
 
 struct EntrypointAsyncPlan {
@@ -681,7 +681,7 @@ fn dynamic_import_origins(
             }
             let origin = AsyncBlockOrigin {
                 module,
-                block_index,
+                block: AsyncDependenciesBlockId::new(block_index),
             };
             if let Some(target) = import_block_target(module_graph, origin) {
                 origins.push((origin, target));
@@ -702,7 +702,7 @@ fn compare_async_origins(
     right: AsyncBlockOrigin,
 ) -> Ordering {
     compare_module_identities(module_graph, left.module, right.module)
-        .then(left.block_index.cmp(&right.block_index))
+        .then(left.block.cmp(&right.block))
 }
 
 fn compare_logical_groups(
@@ -762,7 +762,7 @@ fn import_block_target(module_graph: &ModuleGraph, origin: AsyncBlockOrigin) -> 
     module_graph
         .outgoing_connections(origin.module)
         .find(|connection| {
-            connection.origin_block == Some(origin.block_index)
+            connection.origin_block == Some(origin.block)
                 && connection.dependency.is_import_dependency()
         })
         .map(|connection| connection.module)

--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -7,8 +7,8 @@ use rspack_sources::{ConcatSource, OriginalSource, RawStringSource, ReplaceSourc
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AsyncBlockOrigin, Chunk, ChunkGraph, ChunkGroupKind, CompilerOptions, ConstDependency,
-    Dependency, Error, ExportsInfo, HarmonyExportExpressionDependency,
+    AsyncBlockOrigin, AsyncDependenciesBlockId, Chunk, ChunkGraph, ChunkGroupKind, CompilerOptions,
+    ConstDependency, Dependency, DependencyId, Error, ExportsInfo, HarmonyExportExpressionDependency,
     HarmonyExportHeaderDependency, HarmonyExportImportedSpecifierDependency,
     HarmonyExportSpecifierDependency, HarmonyImportSideEffectDependency,
     HarmonyImportSpecifierDependency, ImportDependency, Module, ModuleGraph, ModuleId, SourceRange,
@@ -82,7 +82,7 @@ fn code_generation_etag(input: &CodeGenerationInput<'_>) -> CacheETag {
 
     for dependency_id in 0..module.dependencies().len() {
         module_graph
-            .module_for_dependency(module.id(), None, dependency_id)
+            .module_for_dependency(module.id(), None, DependencyId::new(dependency_id))
             .and_then(|target| module_render_ids.get(&target))
             .hash(&mut hasher);
     }
@@ -90,14 +90,18 @@ fn code_generation_etag(input: &CodeGenerationInput<'_>) -> CacheETag {
     for (block_index, block) in module.blocks().iter().enumerate() {
         for dependency_id in 0..block.dependencies().len() {
             module_graph
-                .module_for_dependency(module.id(), Some(block_index), dependency_id)
+                .module_for_dependency(
+                    module.id(),
+                    Some(AsyncDependenciesBlockId::new(block_index)),
+                    DependencyId::new(dependency_id),
+                )
                 .and_then(|target| module_render_ids.get(&target))
                 .hash(&mut hasher);
         }
         chunk_graph
             .block_chunk_group(AsyncBlockOrigin {
                 module: module.id(),
-                block_index,
+                block: AsyncDependenciesBlockId::new(block_index),
             })
             .and_then(|group_id| {
                 chunk_graph.chunk_groups()[group_id.index()]
@@ -711,7 +715,7 @@ fn generate_module_code(
             dependency,
             module_id,
             None,
-            Some(dependency_id),
+            Some(DependencyId::new(dependency_id)),
             module_graph,
             chunk_graph,
             module.exports_info(),
@@ -726,8 +730,8 @@ fn generate_module_code(
             apply_dependency_template(
                 dependency,
                 module_id,
-                Some(block_index),
-                Some(dependency_id),
+                Some(AsyncDependenciesBlockId::new(block_index)),
+                Some(DependencyId::new(dependency_id)),
                 module_graph,
                 chunk_graph,
                 module.exports_info(),
@@ -797,8 +801,8 @@ fn push_init_fragment(
 fn apply_dependency_template(
     dependency: &Dependency,
     module_id: ModuleId,
-    origin_block: Option<usize>,
-    dependency_id: Option<usize>,
+    origin_block: Option<AsyncDependenciesBlockId>,
+    dependency_id: Option<DependencyId>,
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
     exports_info: &ExportsInfo,
@@ -905,7 +909,7 @@ fn apply_export_header_dependency(dep: &HarmonyExportHeaderDependency, source: &
 fn apply_harmony_import_side_effect_dependency(
     dep: &HarmonyImportSideEffectDependency,
     module_id: ModuleId,
-    dependency_id: Option<usize>,
+    dependency_id: Option<DependencyId>,
     module_graph: &ModuleGraph,
     module_render_ids: &HashMap<ModuleId, RenderId>,
     init_fragments: &mut Vec<InitFragment>,
@@ -926,7 +930,7 @@ fn apply_harmony_import_side_effect_dependency(
 fn apply_harmony_import_specifier_dependency(
     dep: &HarmonyImportSpecifierDependency,
     module_id: ModuleId,
-    dependency_id: Option<usize>,
+    dependency_id: Option<DependencyId>,
     module_graph: &ModuleGraph,
     module_render_ids: &HashMap<ModuleId, RenderId>,
     source: &mut ReplaceSource,
@@ -1003,7 +1007,7 @@ fn apply_harmony_export_expression_dependency(
 fn apply_harmony_export_imported_specifier_dependency(
     dep: &HarmonyExportImportedSpecifierDependency,
     module_id: ModuleId,
-    dependency_id: Option<usize>,
+    dependency_id: Option<DependencyId>,
     module_graph: &ModuleGraph,
     exports_info: &ExportsInfo,
     module_render_ids: &HashMap<ModuleId, RenderId>,
@@ -1040,8 +1044,8 @@ fn apply_harmony_export_imported_specifier_dependency(
 fn apply_import_dependency(
     dep: &ImportDependency,
     module_id: ModuleId,
-    origin_block: Option<usize>,
-    dependency_id: Option<usize>,
+    origin_block: Option<AsyncDependenciesBlockId>,
+    dependency_id: Option<DependencyId>,
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
     module_render_ids: &HashMap<ModuleId, RenderId>,
@@ -1056,7 +1060,7 @@ fn apply_import_dependency(
     let target_id = json_render_id(&module_render_ids[&target]);
     let origin = AsyncBlockOrigin {
         module: module_id,
-        block_index,
+        block: block_index,
     };
     let expression = if let Some(group_id) = chunk_graph.block_chunk_group(origin) {
         runtime_requirements.insert(RuntimeRequirement::EnsureChunk);

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -45,7 +45,9 @@ pub use exports_info::ExportsInfo;
 pub use loader::{LoaderFuture, LoaderRequest, LoaderRunner, MatchedLoader, ModuleRule};
 pub use logging::{InfrastructureLogEvent, InfrastructureLogLevel, InfrastructureLoggingOptions};
 pub use module::{Module, ModuleId, ModuleIdentity, ModuleType};
-pub use module_graph::{ModuleGraph, ModuleGraphConnection};
+pub use module_graph::{
+    AsyncDependenciesBlockId, DependencyId, ModuleGraph, ModuleGraphConnection,
+};
 pub use normal_module_factory::{FactorizedModule, NormalModuleFactory};
 pub use resolver::{ResolveOptions, ResolvedResource, UnpackResolver};
 pub use snapshot::{SnapshotOptions, SnapshotPathPattern, SnapshotStrategy};

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -16,7 +16,8 @@ use tokio::{
 
 use crate::{
     CompilerOptions, Dependency, DependencyKind, Error, FactorizedModule, LoaderRequest,
-    LoaderRunner, MatchedLoader, ModuleGraph, ModuleId, ModuleIdentity, NormalModuleFactory,
+    AsyncDependenciesBlockId, DependencyId, LoaderRunner, MatchedLoader, ModuleGraph, ModuleId,
+    ModuleIdentity, NormalModuleFactory,
     Result, SnapshotStrategy, UnpackResolver,
     build_cache::{BuildCache, ModuleBuildCache, ModuleBuildRecord},
     module::BuiltModuleContent,
@@ -151,8 +152,8 @@ struct ProcessDependenciesTask {
 #[derive(Debug, Clone)]
 struct QueuedDependency {
     entry_index: Option<usize>,
-    origin_block: Option<usize>,
-    origin_dependency_id: Option<usize>,
+    origin_block: Option<AsyncDependenciesBlockId>,
+    origin_dependency_id: Option<DependencyId>,
     dependency: Dependency,
 }
 
@@ -653,7 +654,7 @@ fn process_dependencies_task(
         .map(|(dependency_id, dependency)| QueuedDependency {
             entry_index: None,
             origin_block: None,
-            origin_dependency_id: Some(dependency_id),
+            origin_dependency_id: Some(DependencyId::new(dependency_id)),
             dependency,
         })
         .collect::<Vec<_>>();
@@ -662,8 +663,8 @@ fn process_dependencies_task(
         dependencies.extend(block.dependencies().iter().cloned().enumerate().map(
             |(dependency_id, dependency)| QueuedDependency {
                 entry_index: None,
-                origin_block: Some(block_index),
-                origin_dependency_id: Some(dependency_id),
+                origin_block: Some(AsyncDependenciesBlockId::new(block_index)),
+                origin_dependency_id: Some(DependencyId::new(dependency_id)),
                 dependency,
             },
         ));

--- a/crates/unpack_core/src/module_graph.rs
+++ b/crates/unpack_core/src/module_graph.rs
@@ -6,9 +6,48 @@ use crate::{Dependency, Module, ModuleId, ModuleIdentity};
 pub struct ModuleGraph {
     modules: Vec<Module>,
     connections: Vec<ModuleGraphConnection>,
-    outgoing: Vec<Vec<usize>>,
-    incoming: Vec<Vec<usize>>,
-    outgoing_by_location: Vec<HashMap<DependencyLocation, usize>>,
+    outgoing: Vec<Vec<ModuleGraphConnectionId>>,
+    incoming: Vec<Vec<ModuleGraphConnectionId>>,
+    outgoing_by_location: Vec<HashMap<DependencyLocation, ModuleGraphConnectionId>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+struct ModuleGraphConnectionId(usize);
+
+impl ModuleGraphConnectionId {
+    const fn new(index: usize) -> Self {
+        Self(index)
+    }
+
+    const fn index(self) -> usize {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DependencyId(usize);
+
+impl DependencyId {
+    pub const fn new(index: usize) -> Self {
+        Self(index)
+    }
+
+    pub const fn index(self) -> usize {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct AsyncDependenciesBlockId(usize);
+
+impl AsyncDependenciesBlockId {
+    pub const fn new(index: usize) -> Self {
+        Self(index)
+    }
+
+    pub const fn index(self) -> usize {
+        self.0
+    }
 }
 
 impl ModuleGraph {
@@ -28,12 +67,12 @@ impl ModuleGraph {
     pub(crate) fn connect(
         &mut self,
         origin_module: Option<ModuleId>,
-        origin_block: Option<usize>,
-        origin_dependency_id: Option<usize>,
+        origin_block: Option<AsyncDependenciesBlockId>,
+        origin_dependency_id: Option<DependencyId>,
         dependency: Dependency,
         module: ModuleId,
     ) {
-        let connection_id = self.connections.len();
+        let connection_id = ModuleGraphConnectionId::new(self.connections.len());
         self.connections.push(ModuleGraphConnection {
             origin_module,
             origin_block,
@@ -74,7 +113,7 @@ impl ModuleGraph {
     ) -> impl Iterator<Item = &ModuleGraphConnection> {
         self.outgoing[module.index()]
             .iter()
-            .map(|connection_id| &self.connections[*connection_id])
+            .map(|connection_id| &self.connections[connection_id.index()])
     }
 
     pub fn incoming_connections(
@@ -83,14 +122,14 @@ impl ModuleGraph {
     ) -> impl Iterator<Item = &ModuleGraphConnection> {
         self.incoming[module.index()]
             .iter()
-            .map(|connection_id| &self.connections[*connection_id])
+            .map(|connection_id| &self.connections[connection_id.index()])
     }
 
     pub fn module_for_dependency(
         &self,
         origin_module: ModuleId,
-        origin_block: Option<usize>,
-        dependency_id: usize,
+        origin_block: Option<AsyncDependenciesBlockId>,
+        dependency_id: DependencyId,
     ) -> Option<ModuleId> {
         let location = DependencyLocation {
             block: origin_block,
@@ -99,21 +138,21 @@ impl ModuleGraph {
         self.outgoing_by_location
             .get(origin_module.index())?
             .get(&location)
-            .map(|connection_id| self.connections[*connection_id].module)
+            .map(|connection_id| self.connections[connection_id.index()].module)
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct DependencyLocation {
-    block: Option<usize>,
-    dependency_id: usize,
+    block: Option<AsyncDependenciesBlockId>,
+    dependency_id: DependencyId,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModuleGraphConnection {
     pub origin_module: Option<ModuleId>,
-    pub origin_block: Option<usize>,
-    pub origin_dependency_id: Option<usize>,
+    pub origin_block: Option<AsyncDependenciesBlockId>,
+    pub origin_dependency_id: Option<DependencyId>,
     pub dependency: Dependency,
     pub module: ModuleId,
 }

--- a/crates/unpack_core/tests/codegen.rs
+++ b/crates/unpack_core/tests/codegen.rs
@@ -4,7 +4,9 @@ use std::{
     process::Command,
 };
 
-use unpack_core::{AsyncBlockOrigin, ChunkGroupKind, Compiler, CompilerOptions, Entry};
+use unpack_core::{
+    AsyncBlockOrigin, AsyncDependenciesBlockId, ChunkGroupKind, Compiler, CompilerOptions, Entry,
+};
 
 #[tokio::test]
 async fn seal_orchestrates_post_make_phases() -> Result<(), Box<dyn std::error::Error>> {
@@ -804,7 +806,7 @@ async fn nested_async_groups_terminate_and_collapse_available_back_edges()
     assert_eq!(
         chunk_graph.block_chunk_group(AsyncBlockOrigin {
             module: b_module.id(),
-            block_index: 0,
+            block: AsyncDependenciesBlockId::new(0),
         }),
         None,
         "B-to-A edge must collapse because A is already available on the loading path"
@@ -929,13 +931,13 @@ async fn nested_shared_parent_shrink_rescans_newly_required_modules()
     let c_from_p = chunk_graph
         .block_chunk_group(AsyncBlockOrigin {
             module: p,
-            block_index: 0,
+            block: AsyncDependenciesBlockId::new(0),
         })
         .expect("P-to-C must map to an Async Chunk Group");
     let c_from_q = chunk_graph
         .block_chunk_group(AsyncBlockOrigin {
             module: q,
-            block_index: 0,
+            block: AsyncDependenciesBlockId::new(0),
         })
         .expect("Q-to-C must reuse the Async Chunk Group");
     assert_eq!(c_from_p, c_from_q);
@@ -947,7 +949,7 @@ async fn nested_shared_parent_shrink_rescans_newly_required_modules()
     let y_group = chunk_graph
         .block_chunk_group(AsyncBlockOrigin {
             module: x,
-            block_index: 0,
+            block: AsyncDependenciesBlockId::new(0),
         })
         .expect("rescanning X must retain its nested Y split point");
     assert!(
@@ -986,7 +988,7 @@ fn chunk_group_topology(
                 format!(
                     "async:{}:{}",
                     module.identity().resource.display(),
-                    origin.block_index
+                    origin.block.index()
                 )
             }
         }

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -633,7 +633,7 @@ fn module_graph(graph: &unpack_core::ModuleGraph) -> NativeModuleGraph {
                 weak: dependency_is_weak(&connection.dependency),
                 parent_block_index: connection
                     .origin_dependency_id
-                    .and_then(|index| i32::try_from(index).ok())
+                    .and_then(|id| i32::try_from(id.index()).ok())
                     .unwrap_or(-1),
             })
             .collect(),


### PR DESCRIPTION
## Summary

- add `ModuleGraphConnectionId` for internal connection storage and adjacency indexes
- add `DependencyId` for dependency-to-connection lookup
- add `AsyncDependenciesBlockId` for async block origins
- carry the typed identifiers through make, ModuleGraph, chunk planning, code generation, tests, and native serialization

## Motivation

ModuleGraph previously represented connection, dependency, and async block identities with interchangeable `usize` values. That made it possible to pass the wrong kind of index through graph construction or lookup without a compiler error.

## Impact

The graph keeps the same storage layout and runtime behavior while Rust now rejects cross-domain ID mixups at compile time. JavaScript APIs are unchanged.

## Test coverage

- `cargo test -p unpack_core`: 112 passed, 0 failed
- `pnpm --filter @unpack-js/core test`: 107 passed, 1 platform-specific test skipped, 0 failed
