### PR TITLE
Back completed ModuleGraph with a native handle

### DIFF
--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -64,6 +64,10 @@ impl Compilation {
         &self.module_graph
     }
 
+    pub fn into_module_graph(self) -> ModuleGraph {
+        self.module_graph
+    }
+
     pub fn chunk_graph(&self) -> &ChunkGraph {
         &self.chunk_graph
     }

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -47,6 +47,7 @@ pub use logging::{InfrastructureLogEvent, InfrastructureLogLevel, Infrastructure
 pub use module::{Module, ModuleId, ModuleIdentity, ModuleType};
 pub use module_graph::{
     AsyncDependenciesBlockId, DependencyId, ModuleGraph, ModuleGraphConnection,
+    ModuleGraphConnectionId,
 };
 pub use normal_module_factory::{FactorizedModule, NormalModuleFactory};
 pub use resolver::{ResolveOptions, ResolvedResource, UnpackResolver};

--- a/crates/unpack_core/src/module_graph.rs
+++ b/crates/unpack_core/src/module_graph.rs
@@ -12,14 +12,14 @@ pub struct ModuleGraph {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-struct ModuleGraphConnectionId(usize);
+pub struct ModuleGraphConnectionId(usize);
 
 impl ModuleGraphConnectionId {
-    const fn new(index: usize) -> Self {
+    pub const fn new(index: usize) -> Self {
         Self(index)
     }
 
-    const fn index(self) -> usize {
+    pub const fn index(self) -> usize {
         self.0
     }
 }
@@ -74,6 +74,7 @@ impl ModuleGraph {
     ) {
         let connection_id = ModuleGraphConnectionId::new(self.connections.len());
         self.connections.push(ModuleGraphConnection {
+            id: connection_id,
             origin_module,
             origin_block,
             origin_dependency_id,
@@ -150,6 +151,7 @@ struct DependencyLocation {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModuleGraphConnection {
+    pub id: ModuleGraphConnectionId,
     pub origin_module: Option<ModuleId>,
     pub origin_block: Option<AsyncDependenciesBlockId>,
     pub origin_dependency_id: Option<DependencyId>,

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -174,14 +174,6 @@ pub struct NativeStatsJson {
     pub output_path: String,
     #[napi(js_name = "watchDependencies")]
     pub watch_dependencies: NativeWatchDependencies,
-    #[napi(js_name = "moduleGraph")]
-    pub module_graph: NativeModuleGraph,
-}
-
-#[napi(object)]
-pub struct NativeModuleGraph {
-    pub modules: Vec<NativeModule>,
-    pub connections: Vec<NativeModuleGraphConnection>,
 }
 
 #[napi(object)]
@@ -197,6 +189,7 @@ pub struct NativeModule {
 
 #[napi(object)]
 pub struct NativeModuleGraphConnection {
+    pub id: u32,
     #[napi(js_name = "originModule")]
     pub origin_module: Option<u32>,
     pub module: u32,
@@ -228,11 +221,53 @@ pub struct NativeInfrastructureLogEvent {
     pub message: String,
 }
 
-#[napi(object)]
+#[napi(object, object_from_js = false)]
 pub struct NativeRunResult {
     pub error: Option<NativeInfrastructureError>,
     pub stats: Option<NativeStatsJson>,
+    pub compilation: Option<NativeCompilation>,
     pub logs: Vec<NativeInfrastructureLogEvent>,
+}
+
+#[napi]
+pub struct NativeCompilation {
+    module_graph: Arc<unpack_core::ModuleGraph>,
+}
+
+#[napi]
+impl NativeCompilation {
+    #[napi]
+    pub fn modules(&self) -> Vec<NativeModule> {
+        self.module_graph
+            .modules()
+            .iter()
+            .map(native_module)
+            .collect()
+    }
+
+    #[napi(js_name = "incomingConnections")]
+    pub fn incoming_connections(&self, module_id: u32) -> Vec<NativeModuleGraphConnection> {
+        let module_id = unpack_core::ModuleId::new(module_id as usize);
+        if self.module_graph.module(module_id).is_none() {
+            return Vec::new();
+        }
+        self.module_graph
+            .incoming_connections(module_id)
+            .map(native_module_graph_connection)
+            .collect()
+    }
+
+    #[napi(js_name = "outgoingConnections")]
+    pub fn outgoing_connections(&self, module_id: u32) -> Vec<NativeModuleGraphConnection> {
+        let module_id = unpack_core::ModuleId::new(module_id as usize);
+        if self.module_graph.module(module_id).is_none() {
+            return Vec::new();
+        }
+        self.module_graph
+            .outgoing_connections(module_id)
+            .map(native_module_graph_connection)
+            .collect()
+    }
 }
 
 #[napi(object)]
@@ -604,39 +639,37 @@ async fn run_compiler_inner(
         return infrastructure_error_with_logs("OutputWriteError", error, logs);
     }
     let compilation = pending.finish();
+    let stats = NativeStatsJson {
+        errors: compilation.errors().iter().map(stats_error).collect(),
+        warnings: Vec::new(),
+        assets: compilation.assets().iter().map(asset_stats).collect(),
+        output_path: output_path.to_string_lossy().into_owned(),
+        watch_dependencies: watch_dependencies(compilation.watch_dependencies()),
+    };
+    let module_graph = Arc::new(compilation.into_module_graph());
 
     NativeRunResult {
         error: None,
-        stats: Some(NativeStatsJson {
-            errors: compilation.errors().iter().map(stats_error).collect(),
-            warnings: Vec::new(),
-            assets: compilation.assets().iter().map(asset_stats).collect(),
-            output_path: output_path.to_string_lossy().into_owned(),
-            watch_dependencies: watch_dependencies(compilation.watch_dependencies()),
-            module_graph: module_graph(compilation.module_graph()),
-        }),
+        stats: Some(stats),
+        compilation: Some(NativeCompilation { module_graph }),
         logs,
     }
 }
 
-fn module_graph(graph: &unpack_core::ModuleGraph) -> NativeModuleGraph {
-    NativeModuleGraph {
-        modules: graph.modules().iter().map(native_module).collect(),
-        connections: graph
-            .connections()
-            .iter()
-            .map(|connection| NativeModuleGraphConnection {
-                origin_module: connection.origin_module.map(native_module_id),
-                module: native_module_id(connection.module),
-                dependency_type: dependency_type(&connection.dependency).to_string(),
-                request: connection.dependency.request().map(str::to_string),
-                weak: dependency_is_weak(&connection.dependency),
-                parent_block_index: connection
-                    .origin_dependency_id
-                    .and_then(|id| i32::try_from(id.index()).ok())
-                    .unwrap_or(-1),
-            })
-            .collect(),
+fn native_module_graph_connection(
+    connection: &unpack_core::ModuleGraphConnection,
+) -> NativeModuleGraphConnection {
+    NativeModuleGraphConnection {
+        id: connection.id.index().try_into().unwrap_or(u32::MAX),
+        origin_module: connection.origin_module.map(native_module_id),
+        module: native_module_id(connection.module),
+        dependency_type: dependency_type(&connection.dependency).to_string(),
+        request: connection.dependency.request().map(str::to_string),
+        weak: dependency_is_weak(&connection.dependency),
+        parent_block_index: connection
+            .origin_dependency_id
+            .and_then(|id| i32::try_from(id.index()).ok())
+            .unwrap_or(-1),
     }
 }
 
@@ -746,6 +779,7 @@ fn infrastructure_error_with_logs(
             message: message.into(),
         }),
         stats: None,
+        compilation: None,
         logs,
     }
 }

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -381,13 +381,12 @@ interface NativeStatsJson {
   output_path?: string;
   watchDependencies?: WatchDependencySets;
   watch_dependencies?: WatchDependencySets;
-  moduleGraph?: NativeModuleGraph;
-  module_graph?: NativeModuleGraph;
 }
 
-interface NativeModuleGraph {
-  modules: NativeModule[];
-  connections: NativeModuleGraphConnection[];
+interface NativeCompilation {
+  modules(): NativeModule[];
+  incomingConnections(moduleId: number): NativeModuleGraphConnection[];
+  outgoingConnections(moduleId: number): NativeModuleGraphConnection[];
 }
 
 interface NativeModule {
@@ -399,6 +398,7 @@ interface NativeModule {
 }
 
 interface NativeModuleGraphConnection {
+  id: number;
   originModule?: number | null;
   origin_module?: number | null;
   module: number;
@@ -410,17 +410,13 @@ interface NativeModuleGraphConnection {
   parent_block_index?: number;
 }
 
-interface NormalizedNativeStats {
-  json: StatsJson;
-  moduleGraph: NativeModuleGraph;
-}
-
 interface NativeRunResult {
   error?: {
     name: string;
     message: string;
   } | null;
   stats?: NativeStatsJson | null;
+  compilation?: NativeCompilation | null;
   logs?: InfrastructureLogEvent[] | null;
 }
 
@@ -772,7 +768,10 @@ class CompilerImpl implements Compiler {
         );
         this.#hasCompletedFilesystemCompilation = true;
         this.#emitInfrastructureLog("info", "unpack.Compiler", "run completed");
-        const stats = new StatsImpl(normalizeNativeStats(result.stats));
+        const stats = new StatsImpl(
+          normalizeNativeStats(result.stats),
+          result.compilation
+        );
         void this.hooks.done.promise(stats).then(
           () => this.#deliverRunCallback(callback, null, stats),
           (error: unknown) =>
@@ -958,7 +957,10 @@ class CompilerImpl implements Compiler {
       );
       this.#hasCompletedFilesystemCompilation = true;
       this.#emitInfrastructureLog("info", "unpack.Watch", "watch compilation completed");
-      const stats = new StatsImpl(normalizeNativeStats(result.stats));
+      const stats = new StatsImpl(
+        normalizeNativeStats(result.stats),
+        result.compilation
+      );
       try {
         await this.hooks.done.promise(stats);
       } catch (error) {
@@ -1284,9 +1286,9 @@ class StatsImpl implements Stats {
   readonly compilation: Compilation;
   readonly #json: StatsJson;
 
-  constructor(stats: NormalizedNativeStats) {
-    this.#json = stats.json;
-    this.compilation = new CompilationImpl(stats.moduleGraph);
+  constructor(json: StatsJson, compilation: NativeCompilation | null | undefined) {
+    this.#json = json;
+    this.compilation = new CompilationImpl(compilation);
   }
 
   hasErrors(): boolean {
@@ -1305,10 +1307,12 @@ class StatsImpl implements Stats {
 }
 
 class ModuleImpl implements Module {
-  dependencies: readonly Dependency[] = [];
   readonly #identifier: string;
+  #moduleGraph: ModuleGraphImpl | undefined;
+  #dependencies: readonly Dependency[] | undefined;
 
   constructor(
+    readonly nativeId: number,
     readonly resource: string,
     readonly type: string,
     readonly providedExports: readonly string[],
@@ -1329,8 +1333,19 @@ class ModuleImpl implements Module {
     return this.resource;
   }
 
-  setDependencies(dependencies: readonly Dependency[]): void {
-    this.dependencies = dependencies;
+  get dependencies(): readonly Dependency[] {
+    if (!this.#dependencies) {
+      this.#dependencies = this.#moduleGraph
+        ? [...this.#moduleGraph.getOutgoingConnections(this)].map(
+            (connection) => connection.dependency
+          )
+        : [];
+    }
+    return this.#dependencies;
+  }
+
+  bindModuleGraph(moduleGraph: ModuleGraphImpl): void {
+    this.#moduleGraph = moduleGraph;
   }
 }
 
@@ -1429,6 +1444,9 @@ const EMPTY_OPTIMIZATION_BAILOUTS: readonly string[] = [];
 const EMPTY_EXPORTS_INFO = new ExportsInfoImpl([]);
 
 class ModuleGraphImpl implements ModuleGraph {
+  readonly #nativeCompilation: NativeCompilation | undefined;
+  readonly #modulesById: ReadonlyMap<number, ModuleImpl>;
+  readonly #connectionById = new Map<number, ModuleGraphConnectionImpl>();
   readonly #connectionByDependency = new Map<Dependency, ModuleGraphConnectionImpl>();
   readonly #incoming = new Map<Module, Set<ModuleGraphConnection>>();
   readonly #outgoing = new Map<Module, Set<ModuleGraphConnection>>();
@@ -1441,56 +1459,66 @@ class ModuleGraphImpl implements ModuleGraph {
     ReadonlyMap<Module, readonly ModuleGraphConnection[]>
   >();
   readonly #issuers = new Map<Module, Module | null>();
+  readonly #loadedIncoming = new Set<Module>();
+  readonly #loadedOutgoing = new Set<Module>();
   readonly #exports = new Map<Module, ExportsInfoImpl>();
 
   constructor(
-    modulesById: ReadonlyMap<number, ModuleImpl>,
-    connections: readonly NativeModuleGraphConnection[]
+    nativeCompilation: NativeCompilation | undefined,
+    modulesById: ReadonlyMap<number, ModuleImpl>
   ) {
+    this.#nativeCompilation = nativeCompilation;
+    this.#modulesById = modulesById;
     for (const module of modulesById.values()) {
       this.#exports.set(module, new ExportsInfoImpl(module.providedExports));
     }
-    for (const nativeConnection of connections) {
-      const target = modulesById.get(nativeConnection.module);
-      if (!target) continue;
-      const originId = nativeConnection.originModule ?? nativeConnection.origin_module;
-      const origin = originId == null ? null : modulesById.get(originId) ?? null;
-      const dependency = new DependencyImpl(
-        nativeConnection.dependencyType ?? nativeConnection.dependency_type ?? "unknown",
-        nativeConnection.request ?? undefined,
-        nativeConnection.weak,
-        nativeConnection.parentBlockIndex ?? nativeConnection.parent_block_index ?? -1
-      );
-      const connection = new ModuleGraphConnectionImpl(
-        origin,
-        dependency,
-        target,
-        nativeConnection.weak
-      );
-      this.#connectionByDependency.set(dependency, connection);
-      addToSetMap(this.#incoming, target, connection);
-      if (origin) addToSetMap(this.#outgoing, origin, connection);
+  }
+
+  #materializeConnection(
+    nativeConnection: NativeModuleGraphConnection
+  ): ModuleGraphConnectionImpl | undefined {
+    const existing = this.#connectionById.get(nativeConnection.id);
+    if (existing) return existing;
+    const target = this.#modulesById.get(nativeConnection.module);
+    if (!target) return undefined;
+    const originId = nativeConnection.originModule ?? nativeConnection.origin_module;
+    const origin = originId == null ? null : this.#modulesById.get(originId) ?? null;
+    const dependency = new DependencyImpl(
+      nativeConnection.dependencyType ?? nativeConnection.dependency_type ?? "unknown",
+      nativeConnection.request ?? undefined,
+      nativeConnection.weak,
+      nativeConnection.parentBlockIndex ?? nativeConnection.parent_block_index ?? -1
+    );
+    const connection = new ModuleGraphConnectionImpl(
+      origin,
+      dependency,
+      target,
+      nativeConnection.weak
+    );
+    this.#connectionById.set(nativeConnection.id, connection);
+    this.#connectionByDependency.set(dependency, connection);
+    addToSetMap(this.#incoming, target, connection);
+    if (origin) addToSetMap(this.#outgoing, origin, connection);
+    return connection;
+  }
+
+  #loadIncoming(module: Module): void {
+    if (this.#loadedIncoming.has(module)) return;
+    this.#loadedIncoming.add(module);
+    if (!(module instanceof ModuleImpl)) return;
+    for (const connection of
+      this.#nativeCompilation?.incomingConnections(module.nativeId) ?? []) {
+      this.#materializeConnection(connection);
     }
-    for (const module of modulesById.values()) {
-      const incoming = this.#incoming.get(module);
-      if (incoming) {
-        this.#incomingByOrigin.set(
-          module,
-          groupConnections(incoming, (connection) => connection.originModule)
-        );
-        this.#issuers.set(
-          module,
-          [...incoming].find((connection) => connection.originModule !== null)
-            ?.originModule ?? null
-        );
-      }
-      const outgoing = this.#outgoing.get(module);
-      if (outgoing) {
-        this.#outgoingByModule.set(
-          module,
-          groupConnections(outgoing, (connection) => connection.module)
-        );
-      }
+  }
+
+  #loadOutgoing(module: Module): void {
+    if (this.#loadedOutgoing.has(module)) return;
+    this.#loadedOutgoing.add(module);
+    if (!(module instanceof ModuleImpl)) return;
+    for (const connection of
+      this.#nativeCompilation?.outgoingConnections(module.nativeId) ?? []) {
+      this.#materializeConnection(connection);
     }
   }
 
@@ -1527,26 +1555,53 @@ class ModuleGraphImpl implements ModuleGraph {
   }
 
   getIncomingConnections(module: Module): ReadonlySet<ModuleGraphConnection> {
+    this.#loadIncoming(module);
     return this.#incoming.get(module) ?? EMPTY_CONNECTIONS;
   }
 
   getOutgoingConnections(module: Module): ReadonlySet<ModuleGraphConnection> {
+    this.#loadOutgoing(module);
     return this.#outgoing.get(module) ?? EMPTY_CONNECTIONS;
   }
 
   getIncomingConnectionsByOriginModule(
     module: Module
   ): ReadonlyMap<Module | null, readonly ModuleGraphConnection[]> {
-    return this.#incomingByOrigin.get(module) ?? EMPTY_INCOMING_CONNECTION_GROUPS;
+    let groups = this.#incomingByOrigin.get(module);
+    if (!groups) {
+      groups = groupConnections(
+        this.getIncomingConnections(module),
+        (connection) => connection.originModule
+      );
+      this.#incomingByOrigin.set(module, groups);
+    }
+    return groups ?? EMPTY_INCOMING_CONNECTION_GROUPS;
   }
 
   getOutgoingConnectionsByModule(
     module: Module
   ): ReadonlyMap<Module, readonly ModuleGraphConnection[]> | undefined {
-    return this.#outgoingByModule.get(module);
+    this.#loadOutgoing(module);
+    const outgoing = this.#outgoing.get(module);
+    if (!outgoing) return undefined;
+    let groups = this.#outgoingByModule.get(module);
+    if (!groups) {
+      groups = groupConnections(outgoing, (connection) => connection.module);
+      this.#outgoingByModule.set(module, groups);
+    }
+    return groups;
   }
 
   getIssuer(module: Module): Module | null | undefined {
+    if (!this.#issuers.has(module)) {
+      const incoming = this.getIncomingConnections(module);
+      if (incoming.size === 0) return undefined;
+      this.#issuers.set(
+        module,
+        [...incoming].find((connection) => connection.originModule !== null)
+          ?.originModule ?? null
+      );
+    }
     return this.#issuers.get(module);
   }
 
@@ -1593,11 +1648,12 @@ class CompilationImpl implements Compilation {
   readonly moduleGraph: ModuleGraph;
   readonly modules: ReadonlySet<Module>;
 
-  constructor(graph: NativeModuleGraph) {
+  constructor(compilation: NativeCompilation | null | undefined) {
     const modulesById = new Map(
-      graph.modules.map((module) => [
+      (compilation?.modules() ?? []).map((module) => [
         module.id,
         new ModuleImpl(
+          module.id,
           module.resource,
           module.type,
           module.providedExports,
@@ -1605,13 +1661,9 @@ class CompilationImpl implements Compilation {
         )
       ])
     );
-    const moduleGraph = new ModuleGraphImpl(modulesById, graph.connections);
+    const moduleGraph = new ModuleGraphImpl(compilation ?? undefined, modulesById);
     for (const module of modulesById.values()) {
-      module.setDependencies(
-        [...moduleGraph.getOutgoingConnections(module)].map(
-          (connection) => connection.dependency
-        )
-      );
+      module.bindModuleGraph(moduleGraph);
     }
     this.moduleGraph = moduleGraph;
     this.modules = new Set(modulesById.values());
@@ -2341,38 +2393,25 @@ function normalizeWatchPoll(value: unknown): number | undefined {
   throw new TypeError("watchOptions.poll must be true or a positive integer");
 }
 
-function normalizeNativeStats(
-  stats: NativeStatsJson | null | undefined
-): NormalizedNativeStats {
+function normalizeNativeStats(stats: NativeStatsJson | null | undefined): StatsJson {
   if (!stats) {
     return {
-      json: {
-        errors: [],
-        warnings: [],
-        assets: [],
-        outputPath: "",
-        watchDependencies: emptyWatchDependencies()
-      },
-      moduleGraph: emptyNativeModuleGraph()
+      errors: [],
+      warnings: [],
+      assets: [],
+      outputPath: "",
+      watchDependencies: emptyWatchDependencies()
     };
   }
   return {
-    json: {
-      errors: stats.errors.map(cloneStatsError),
-      warnings: (stats.warnings ?? []).map(cloneStatsError),
-      assets: stats.assets.map((asset) => ({ ...asset })),
-      outputPath: stats.outputPath ?? stats.output_path ?? "",
-      watchDependencies: cloneWatchDependencies(
-        stats.watchDependencies ?? stats.watch_dependencies ?? emptyWatchDependencies()
-      )
-    },
-    moduleGraph:
-      stats.moduleGraph ?? stats.module_graph ?? emptyNativeModuleGraph()
+    errors: stats.errors.map(cloneStatsError),
+    warnings: (stats.warnings ?? []).map(cloneStatsError),
+    assets: stats.assets.map((asset) => ({ ...asset })),
+    outputPath: stats.outputPath ?? stats.output_path ?? "",
+    watchDependencies: cloneWatchDependencies(
+      stats.watchDependencies ?? stats.watch_dependencies ?? emptyWatchDependencies()
+    )
   };
-}
-
-function emptyNativeModuleGraph(): NativeModuleGraph {
-  return { modules: [], connections: [] };
 }
 
 function cloneStatsError(error: StatsError): StatsError {


### PR DESCRIPTION
## Summary

- replace the serialized ModuleGraph JSON snapshot with a native completed-graph handle
- move the original completed Rust `ModuleGraph` into an `Arc` without cloning it
- lazily read module adjacency through `NativeCompilation` and materialize JavaScript connection wrappers by stable connection ID
- cache materialized connections, dependency mappings, grouped adjacency, issuers, and module dependencies for repeated access
- keep each run and watch rebuild bound to its own completed graph

## Motivation

`stats.compilation.moduleGraph` previously reconstructed the entire graph from a JSON-like native snapshot. That preserved query results but did not bind the JavaScript Compilation to native graph storage.

## Impact

The done-hook Compilation now owns a native-backed completed ModuleGraph. Initial module descriptors are loaded once, incoming and outgoing connections are fetched lazily, and repeated queries avoid additional native calls or regrouping. The handle owns only the completed graph, so it does not retain loader runners, cache services, or filesystem lifecycle state after compiler close.

This is the first read-only phase of live Compilation alignment. Compilation-phase graph mutation remains out of scope.

## Test coverage

- `cargo test -p unpack_core`: 112 passed, 0 failed
- `pnpm --filter @unpack-js/core test`: 107 passed, 1 platform-specific test skipped, 0 failed
