### PR TITLE
Support the finishModules compilation hook

### DIFF
--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 use crate::{
-    CacheOptions, Compilation, InfrastructureLoggingOptions, LoaderRunner, ModuleRule,
-    ResolveOptions, Result, SnapshotOptions, UnpackResolver, build_cache::BuildCache,
+    CacheOptions, Compilation, CompilationHooks, InfrastructureLoggingOptions, LoaderRunner,
+    ModuleRule, ResolveOptions, Result, SnapshotOptions, UnpackResolver, build_cache::BuildCache,
 };
 use tracing::Instrument;
 
@@ -37,6 +37,7 @@ pub struct CompilerOptions {
     pub infrastructure_logging: InfrastructureLoggingOptions,
     pub module_rules: Vec<ModuleRule>,
     pub loader_runner: Option<Arc<dyn LoaderRunner>>,
+    pub compilation_hooks: Option<Arc<dyn CompilationHooks>>,
     pub parallelism: usize,
     pub sourcemap: bool,
 }
@@ -52,6 +53,7 @@ impl CompilerOptions {
             infrastructure_logging: InfrastructureLoggingOptions::disabled(),
             module_rules: Vec::new(),
             loader_runner: None,
+            compilation_hooks: None,
             parallelism: 100,
             sourcemap: true,
         }
@@ -678,7 +680,13 @@ impl Compiler {
         let cache_activity = self.cache_lifecycle.end_idle(idle_reason)?;
         let result = async {
             let mut compilation = self.create_compilation();
+            if let Some(hooks) = &self.options.compilation_hooks {
+                hooks.compilation(&compilation).await?;
+            }
             compilation.make().await?;
+            if let Some(hooks) = &self.options.compilation_hooks {
+                hooks.finish_modules(&compilation).await?;
+            }
             compilation.seal();
             Ok(compilation)
         }

--- a/crates/unpack_core/src/error.rs
+++ b/crates/unpack_core/src/error.rs
@@ -44,6 +44,9 @@ pub enum Error {
     #[error("make task failed: {message}")]
     MakeTask { message: String },
 
+    #[error("compilation hook failed: {message}")]
+    Hook { message: String },
+
     #[error("module graph is missing module {0:?}")]
     MissingModule(ModuleHandle),
 

--- a/crates/unpack_core/src/hooks.rs
+++ b/crates/unpack_core/src/hooks.rs
@@ -1,0 +1,11 @@
+use std::{fmt::Debug, future::Future, pin::Pin};
+
+use crate::{Compilation, Result};
+
+pub type HookFuture<'a> = Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+
+/// Host callbacks invoked at webpack-compatible compilation boundaries.
+pub trait CompilationHooks: Debug + Send + Sync {
+    fn compilation<'a>(&'a self, compilation: &'a Compilation) -> HookFuture<'a>;
+    fn finish_modules<'a>(&'a self, compilation: &'a Compilation) -> HookFuture<'a>;
+}

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -11,6 +11,7 @@ mod compiler;
 mod dependency;
 mod error;
 mod exports_info;
+mod hooks;
 mod id_assignment;
 mod loader;
 mod logging;
@@ -45,6 +46,7 @@ pub use dependency::{
 };
 pub use error::{Error, Result};
 pub use exports_info::ExportsInfo;
+pub use hooks::{CompilationHooks, HookFuture};
 pub use loader::{LoaderFuture, LoaderRequest, LoaderRunner, MatchedLoader, ModuleRule};
 pub use logging::{InfrastructureLogEvent, InfrastructureLogLevel, InfrastructureLoggingOptions};
 pub use module::{Module, ModuleHandle, ModuleIdentity, ModuleType};

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -15,11 +15,11 @@ use napi::{
 use napi_derive::napi;
 use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
 use unpack_core::{
-    Asset, BuildDependency, CacheCompression, CacheIdleReason, CacheOptions, Compiler,
-    CompilerOptions, Dependency, Entry, Error as CoreError, InfrastructureLogEvent,
-    InfrastructureLogLevel, InfrastructureLoggingOptions, LoaderFuture, LoaderRequest,
-    LoaderRunner, Module, ModuleRule, ModuleType, SnapshotOptions, SnapshotPathPattern,
-    SnapshotStrategy,
+    Asset, BuildDependency, CacheCompression, CacheIdleReason, CacheOptions, CompilationHooks,
+    Compiler, CompilerOptions, Dependency, Entry, Error as CoreError, HookFuture,
+    InfrastructureLogEvent, InfrastructureLogLevel, InfrastructureLoggingOptions, LoaderFuture,
+    LoaderRequest, LoaderRunner, Module, ModuleRule, ModuleType, SnapshotOptions,
+    SnapshotPathPattern, SnapshotStrategy,
 };
 
 #[global_allocator]
@@ -344,9 +344,16 @@ pub fn create_compiler(
     loader_callback: Option<
         Function<'_, FnArgs<(String, String, String, String)>, Promise<String>>,
     >,
+    compilation_callback: Option<Function<'_, NativeCompilation, Promise<()>>>,
+    finish_modules_callback: Option<Function<'_, NativeCompilation, Promise<()>>>,
 ) -> Result<NativeCompiler> {
     init_internal_tracing_from_env();
-    NativeCompiler::new(options, loader_callback)
+    NativeCompiler::new(
+        options,
+        loader_callback,
+        compilation_callback,
+        finish_modules_callback,
+    )
 }
 
 type NativeLoaderCallback = ThreadsafeFunction<
@@ -393,6 +400,51 @@ impl LoaderRunner for NativeLoaderRunner {
             })
         })
     }
+}
+
+type NativeFinishModulesCallback =
+    ThreadsafeFunction<NativeCompilation, Promise<()>, NativeCompilation, Status, false, true>;
+
+struct NativeCompilationHooks {
+    compilation: Arc<NativeFinishModulesCallback>,
+    finish_modules: Arc<NativeFinishModulesCallback>,
+}
+
+impl std::fmt::Debug for NativeCompilationHooks {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("NativeCompilationHooks")
+    }
+}
+
+impl CompilationHooks for NativeCompilationHooks {
+    fn compilation<'a>(&'a self, compilation: &'a unpack_core::Compilation) -> HookFuture<'a> {
+        call_compilation_hook(Arc::clone(&self.compilation), compilation)
+    }
+
+    fn finish_modules<'a>(&'a self, compilation: &'a unpack_core::Compilation) -> HookFuture<'a> {
+        call_compilation_hook(Arc::clone(&self.finish_modules), compilation)
+    }
+}
+
+fn call_compilation_hook<'a>(
+    callback: Arc<NativeFinishModulesCallback>,
+    compilation: &'a unpack_core::Compilation,
+) -> HookFuture<'a> {
+    let native_compilation = NativeCompilation {
+        module_graph: Arc::new(compilation.module_graph().clone()),
+        chunk_graph: Arc::new(unpack_core::ChunkGraph::default()),
+    };
+    Box::pin(async move {
+        let promise = callback
+            .call_async_catch(native_compilation)
+            .await
+            .map_err(|error| CoreError::Hook {
+                message: error.to_string(),
+            })?;
+        promise.await.map_err(|error| CoreError::Hook {
+            message: error.to_string(),
+        })
+    })
 }
 
 #[napi]
@@ -480,6 +532,8 @@ impl NativeCompiler {
         loader_callback: Option<
             Function<'_, FnArgs<(String, String, String, String)>, Promise<String>>,
         >,
+        compilation_callback: Option<Function<'_, NativeCompilation, Promise<()>>>,
+        finish_modules_callback: Option<Function<'_, NativeCompilation, Promise<()>>>,
     ) -> Result<Self> {
         let context = PathBuf::from(&options.context);
         let output_path = PathBuf::from(&options.output_path);
@@ -511,6 +565,25 @@ impl NativeCompiler {
                     .build()?;
                 Ok::<Arc<dyn LoaderRunner>, napi::Error>(Arc::new(NativeLoaderRunner {
                     callback: Arc::new(callback),
+                }))
+            })
+            .transpose()?;
+        compiler_options.compilation_hooks = compilation_callback
+            .zip(finish_modules_callback)
+            .map(|(compilation_callback, finish_modules_callback)| {
+                let compilation: NativeFinishModulesCallback = compilation_callback
+                    .build_threadsafe_function()
+                    .callee_handled::<false>()
+                    .weak::<true>()
+                    .build()?;
+                let finish_modules: NativeFinishModulesCallback = finish_modules_callback
+                    .build_threadsafe_function()
+                    .callee_handled::<false>()
+                    .weak::<true>()
+                    .build()?;
+                Ok::<Arc<dyn CompilationHooks>, napi::Error>(Arc::new(NativeCompilationHooks {
+                    compilation: Arc::new(compilation),
+                    finish_modules: Arc::new(finish_modules),
                 }))
             })
             .transpose()?;
@@ -899,7 +972,7 @@ fn stats_error(error: &CoreError) -> NativeStatsError {
             issuer: None,
             stack: None,
         },
-        CoreError::MakeTask { message } => NativeStatsError {
+        CoreError::MakeTask { message } | CoreError::Hook { message } => NativeStatsError {
             message: error.to_string(),
             path: None,
             request: None,

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -124,6 +124,7 @@ export interface Stats {
 }
 
 export interface Compilation {
+  readonly hooks: CompilationHooks;
   readonly moduleGraph: ModuleGraph;
   readonly chunkGraph: ChunkGraph;
   readonly modules: ReadonlySet<Module>;
@@ -256,7 +257,33 @@ export interface DoneHook {
   promise(stats: Stats): Promise<void>;
 }
 
+export interface FinishModulesHook {
+  tap(options: string | TapOptions, callback: (modules: ReadonlySet<Module>) => void): void;
+  tapAsync(
+    options: string | TapOptions,
+    callback: (modules: ReadonlySet<Module>, done: (error?: Error | null) => void) => void
+  ): void;
+  tapPromise(
+    options: string | TapOptions,
+    callback: (modules: ReadonlySet<Module>) => PromiseLike<void>
+  ): void;
+  callAsync(
+    modules: ReadonlySet<Module>,
+    callback: (error?: Error | null) => void
+  ): void;
+  promise(modules: ReadonlySet<Module>): Promise<void>;
+}
+
+export interface CompilationHooks {
+  readonly finishModules: FinishModulesHook;
+}
+
+export interface CompilationHook {
+  tap(options: string | TapOptions, callback: (compilation: Compilation) => void): void;
+}
+
 export interface CompilerHooks {
+  readonly compilation: CompilationHook;
   readonly done: DoneHook;
 }
 
@@ -481,7 +508,9 @@ interface NativeBinding {
       resource: string,
       source: string,
       options: string
-    ) => Promise<string>
+    ) => Promise<string>,
+    compilation?: (compilation: NativeCompilation) => Promise<void>,
+    finishModules?: (compilation: NativeCompilation) => Promise<void>
   ): NativeCompiler;
 }
 
@@ -606,6 +635,31 @@ interface DoneTap {
   run(stats: Stats): Promise<void>;
 }
 
+interface OrderedTap {
+  name: string;
+  stage: number;
+  before: Set<string>;
+}
+
+function insertOrderedTap<TTap extends OrderedTap>(taps: TTap[], tap: TTap): void {
+  const before = new Set(tap.before);
+  let index = taps.length;
+  while (index > 0) {
+    const current = taps[index - 1];
+    if (before.has(current.name)) {
+      before.delete(current.name);
+      index -= 1;
+      continue;
+    }
+    if (before.size > 0 || current.stage > tap.stage) {
+      index -= 1;
+      continue;
+    }
+    break;
+  }
+  taps.splice(index, 0, tap);
+}
+
 class DoneHookImpl implements DoneHook {
   readonly #taps: DoneTap[] = [];
 
@@ -671,22 +725,86 @@ class DoneHookImpl implements DoneHook {
   ): void {
     const normalized = normalizeTapOptions(options);
     const tap: DoneTap = { ...normalized, run };
-    const before = new Set(tap.before);
-    let index = this.#taps.length;
-    while (index > 0) {
-      const current = this.#taps[index - 1];
-      if (before.has(current.name)) {
-        before.delete(current.name);
-        index -= 1;
-        continue;
-      }
-      if (before.size > 0 || current.stage > tap.stage) {
-        index -= 1;
-        continue;
-      }
-      break;
-    }
-    this.#taps.splice(index, 0, tap);
+    insertOrderedTap(this.#taps, tap);
+  }
+}
+
+interface FinishModulesTap {
+  name: string;
+  stage: number;
+  before: Set<string>;
+  run(modules: ReadonlySet<Module>): Promise<void>;
+}
+
+class FinishModulesHookImpl implements FinishModulesHook {
+  readonly #taps: FinishModulesTap[] = [];
+
+  tap(options: string | TapOptions, callback: (modules: ReadonlySet<Module>) => void): void {
+    assertFunction(callback, "callback");
+    this.#insert(options, async (modules) => { callback(modules); });
+  }
+
+  tapAsync(
+    options: string | TapOptions,
+    callback: (modules: ReadonlySet<Module>, done: (error?: Error | null) => void) => void
+  ): void {
+    assertFunction(callback, "callback");
+    this.#insert(options, (modules) => new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const done = (error?: Error | null): void => {
+        if (settled) return;
+        settled = true;
+        error == null ? resolve() : reject(error);
+      };
+      try { callback(modules, done); } catch (error) { done(toError(error, "HookError")); }
+    }));
+  }
+
+  tapPromise(
+    options: string | TapOptions,
+    callback: (modules: ReadonlySet<Module>) => PromiseLike<void>
+  ): void {
+    assertFunction(callback, "callback");
+    this.#insert(options, async (modules) => { await callback(modules); });
+  }
+
+  callAsync(
+    modules: ReadonlySet<Module>,
+    callback: (error?: Error | null) => void
+  ): void {
+    assertFunction(callback, "callback");
+    void this.promise(modules).then(() => callback(), (error) => callback(toError(error, "HookError")));
+  }
+
+  async promise(modules: ReadonlySet<Module>): Promise<void> {
+    for (const tap of this.#taps) await tap.run(modules);
+  }
+
+  #insert(
+    options: string | TapOptions,
+    run: (modules: ReadonlySet<Module>) => Promise<void>
+  ): void {
+    const tap = { ...normalizeTapOptions(options), run };
+    insertOrderedTap(this.#taps, tap);
+  }
+}
+
+class CompilationHookImpl implements CompilationHook {
+  readonly #taps: Array<{
+    name: string;
+    stage: number;
+    before: Set<string>;
+    run(compilation: Compilation): void;
+  }> = [];
+
+  tap(options: string | TapOptions, callback: (compilation: Compilation) => void): void {
+    assertFunction(callback, "callback");
+    const tap = { ...normalizeTapOptions(options), run: callback };
+    insertOrderedTap(this.#taps, tap);
+  }
+
+  call(compilation: Compilation): void {
+    for (const tap of this.#taps) tap.run(compilation);
   }
 }
 
@@ -717,7 +835,10 @@ type CompilerLifecycle =
   | { kind: "closed" };
 
 class CompilerImpl implements Compiler {
-  readonly hooks: CompilerHooks = { done: new DoneHookImpl() };
+  readonly hooks: CompilerHooks = {
+    compilation: new CompilationHookImpl(),
+    done: new DoneHookImpl()
+  };
   #lifecycle: CompilerLifecycle = { kind: "open" };
   #running = false;
   #watching: WatchingImpl | undefined;
@@ -731,12 +852,37 @@ class CompilerImpl implements Compiler {
   readonly #infrastructureLoggingLevel: InfrastructureLoggingLevel;
   readonly #nativeCompiler: NativeCompiler;
   readonly #loaderRuntime: LoaderRuntime | undefined;
+  #nativeHookError: Error | undefined;
+  #activeCompilation: CompilationImpl | undefined;
 
   constructor(options: NormalizedOptions) {
     this.#loaderRuntime = options.moduleRules.length > 0
       ? new LoaderRuntime(options.context)
       : undefined;
-    this.#nativeCompiler = native.createCompiler(options, this.#loaderRuntime?.run);
+    this.#nativeCompiler = native.createCompiler(
+      options,
+      this.#loaderRuntime?.run,
+      async (nativeCompilation) => {
+        try {
+          const compilation = new CompilationImpl(nativeCompilation);
+          this.#activeCompilation = compilation;
+          (this.hooks.compilation as CompilationHookImpl).call(compilation);
+        } catch (error) {
+          this.#nativeHookError = toError(error, "HookError");
+          throw this.#nativeHookError;
+        }
+      },
+      async (nativeCompilation) => {
+        try {
+          const compilation = this.#activeCompilation ?? new CompilationImpl(nativeCompilation);
+          compilation.update(nativeCompilation);
+          await compilation.hooks.finishModules.promise(compilation.modules);
+        } catch (error) {
+          this.#nativeHookError = toError(error, "HookError");
+          throw this.#nativeHookError;
+        }
+      }
+    );
     this.#writableFilesystemCache =
       options.cache.type === "filesystem" && !options.cache.readonly;
     this.#cacheIdleTimeout = options.cache.idleTimeout ?? 60_000;
@@ -793,7 +939,8 @@ class CompilerImpl implements Compiler {
       (result) => {
         this.#emitInfrastructureLogs(result.logs);
         if (result.error) {
-          const error = namedError(result.error.name, result.error.message);
+          const error = this.#nativeHookError ?? namedError(result.error.name, result.error.message);
+          this.#nativeHookError = undefined;
           this.#emitInfrastructureLog("error", "unpack.Compiler", error.message);
           this.#deliverRunCallback(callback, error);
           return;
@@ -808,7 +955,8 @@ class CompilerImpl implements Compiler {
         this.#emitInfrastructureLog("info", "unpack.Compiler", "run completed");
         const stats = new StatsImpl(
           normalizeNativeStats(result.stats),
-          result.compilation
+          result.compilation,
+          this.#takeActiveCompilation(result.compilation)
         );
         void this.hooks.done.promise(stats).then(
           () => this.#deliverRunCallback(callback, null, stats),
@@ -982,7 +1130,8 @@ class CompilerImpl implements Compiler {
       const result = await run;
       this.#emitInfrastructureLogs(result.logs);
       if (result.error) {
-        const error = namedError(result.error.name, result.error.message);
+        const error = this.#nativeHookError ?? namedError(result.error.name, result.error.message);
+        this.#nativeHookError = undefined;
         this.#emitInfrastructureLog("error", "unpack.Watch", error.message);
         handler(error);
         return;
@@ -997,7 +1146,8 @@ class CompilerImpl implements Compiler {
       this.#emitInfrastructureLog("info", "unpack.Watch", "watch compilation completed");
       const stats = new StatsImpl(
         normalizeNativeStats(result.stats),
-        result.compilation
+        result.compilation,
+        this.#takeActiveCompilation(result.compilation)
       );
       try {
         await this.hooks.done.promise(stats);
@@ -1014,8 +1164,19 @@ class CompilerImpl implements Compiler {
   }
 
   #runNativeCompilation(): Promise<NativeRunResult> {
+    this.#nativeHookError = undefined;
+    this.#activeCompilation = undefined;
     this.#loaderRuntime?.beginCompilation();
     return this.#nativeCompiler.run();
+  }
+
+  #takeActiveCompilation(
+    nativeCompilation: NativeCompilation | null | undefined
+  ): CompilationImpl | undefined {
+    const compilation = this.#activeCompilation;
+    this.#activeCompilation = undefined;
+    compilation?.update(nativeCompilation);
+    return compilation;
   }
 
   #scheduleIdleCacheFlush(delay: number): void {
@@ -1324,9 +1485,13 @@ class StatsImpl implements Stats {
   readonly compilation: Compilation;
   readonly #json: StatsJson;
 
-  constructor(json: StatsJson, compilation: NativeCompilation | null | undefined) {
+  constructor(
+    json: StatsJson,
+    compilation: NativeCompilation | null | undefined,
+    existingCompilation?: Compilation
+  ) {
     this.#json = json;
-    this.compilation = new CompilationImpl(compilation);
+    this.compilation = existingCompilation ?? new CompilationImpl(compilation);
   }
 
   hasErrors(): boolean {
@@ -1482,7 +1647,7 @@ const EMPTY_OPTIMIZATION_BAILOUTS: readonly string[] = [];
 const EMPTY_EXPORTS_INFO = new ExportsInfoImpl([]);
 
 class ModuleGraphImpl implements ModuleGraph {
-  readonly #nativeCompilation: NativeCompilation | undefined;
+  #nativeCompilation: NativeCompilation | undefined;
   readonly #modulesByHandle: ReadonlyMap<number, ModuleImpl>;
   readonly #connectionByHandle = new Map<number, ModuleGraphConnectionImpl>();
   readonly #connectionByDependency = new Map<Dependency, ModuleGraphConnectionImpl>();
@@ -1509,6 +1674,15 @@ class ModuleGraphImpl implements ModuleGraph {
     this.#modulesByHandle = modulesByHandle;
     for (const module of modulesByHandle.values()) {
       this.#exports.set(module, new ExportsInfoImpl(module.providedExports));
+    }
+  }
+
+  updateNativeCompilation(nativeCompilation: NativeCompilation | undefined): void {
+    this.#nativeCompilation = nativeCompilation;
+    for (const module of this.#modulesByHandle.values()) {
+      if (!this.#exports.has(module)) {
+        this.#exports.set(module, new ExportsInfoImpl(module.providedExports));
+      }
     }
   }
 
@@ -1711,7 +1885,7 @@ const EMPTY_CHUNK_ITERABLE: SortableSetView<Chunk> = new SortableSetView();
 const EMPTY_MODULE_ITERABLE: SortableSetView<Module> = new SortableSetView();
 
 class ChunkGraphImpl implements ChunkGraph {
-  readonly #nativeCompilation: NativeCompilation | undefined;
+  #nativeCompilation: NativeCompilation | undefined;
   readonly #modulesByHandle: ReadonlyMap<number, ModuleImpl>;
   readonly #chunksByHandle: ReadonlyMap<number, ChunkImpl>;
   readonly #moduleIds = new Map<Module, string | number | null>();
@@ -1732,6 +1906,16 @@ class ChunkGraphImpl implements ChunkGraph {
     this.#nativeCompilation = nativeCompilation;
     this.#modulesByHandle = modulesByHandle;
     this.#chunksByHandle = chunksByHandle;
+  }
+
+  updateNativeCompilation(nativeCompilation: NativeCompilation | undefined): void {
+    this.#nativeCompilation = nativeCompilation;
+    this.#moduleIds.clear();
+    this.#moduleChunks.clear();
+    this.#chunkModules.clear();
+    this.#moduleChunkIterables.clear();
+    this.#chunkModuleIterables.clear();
+    this.#orderedChunkModules.clear();
   }
 
   #loadModuleChunks(module: Module): SortableSetView<Chunk> {
@@ -1844,44 +2028,54 @@ class ChunkGraphImpl implements ChunkGraph {
 }
 
 class CompilationImpl implements Compilation {
-  readonly moduleGraph: ModuleGraph;
-  readonly chunkGraph: ChunkGraph;
+  readonly hooks: CompilationHooks = { finishModules: new FinishModulesHookImpl() };
+  readonly moduleGraph: ModuleGraphImpl;
+  readonly chunkGraph: ChunkGraphImpl;
   readonly modules: ReadonlySet<Module>;
+  readonly #modulesByHandle = new Map<number, ModuleImpl>();
+  readonly #chunksByHandle = new Map<number, ChunkImpl>();
+  readonly #moduleSet = new Set<Module>();
 
   constructor(compilation: NativeCompilation | null | undefined) {
-    const modulesByHandle = new Map(
-      (compilation?.modules() ?? []).map((module) => [
-        module.handle,
-        new ModuleImpl(
+    this.moduleGraph = new ModuleGraphImpl(undefined, this.#modulesByHandle);
+    this.chunkGraph = new ChunkGraphImpl(
+      undefined,
+      this.#modulesByHandle,
+      this.#chunksByHandle
+    );
+    this.modules = this.#moduleSet;
+    this.update(compilation);
+  }
+
+  update(compilation: NativeCompilation | null | undefined): void {
+    for (const module of compilation?.modules() ?? []) {
+      if (!this.#modulesByHandle.has(module.handle)) {
+        const moduleImpl = new ModuleImpl(
           module.handle,
           module.resource,
           module.type,
           module.providedExports,
           module.identifier
-        )
-      ])
-    );
-    const moduleGraph = new ModuleGraphImpl(compilation ?? undefined, modulesByHandle);
-    for (const module of modulesByHandle.values()) {
-      module.bindModuleGraph(moduleGraph);
+        );
+        moduleImpl.bindModuleGraph(this.moduleGraph);
+        this.#modulesByHandle.set(module.handle, moduleImpl);
+        this.#moduleSet.add(moduleImpl);
+      }
     }
-    const chunksByHandle = new Map(
-      (compilation?.chunks() ?? []).map((chunk) => [
-        chunk.handle,
-        new ChunkImpl(
+    for (const chunk of compilation?.chunks() ?? []) {
+      if (!this.#chunksByHandle.has(chunk.handle)) {
+        this.#chunksByHandle.set(
+          chunk.handle,
+          new ChunkImpl(
           chunk.handle,
           chunk.renderId ?? chunk.render_id ?? null,
           chunk.name ?? undefined
         )
-      ])
-    );
-    this.moduleGraph = moduleGraph;
-    this.chunkGraph = new ChunkGraphImpl(
-      compilation ?? undefined,
-      modulesByHandle,
-      chunksByHandle
-    );
-    this.modules = new Set(modulesByHandle.values());
+        );
+      }
+    }
+    this.moduleGraph.updateNativeCompilation(compilation ?? undefined);
+    this.chunkGraph.updateNativeCompilation(compilation ?? undefined);
   }
 }
 

--- a/packages/unpack/test/done-hook-module-graph.test.ts
+++ b/packages/unpack/test/done-hook-module-graph.test.ts
@@ -67,6 +67,89 @@ test("done taps run serially before the run callback", async () => {
   }
 });
 
+test("finishModules taps run after make and before done", async () => {
+  const fixture = await createGraphFixture();
+  const compiler = createCompiler(fixture);
+  const events: string[] = [];
+  let finishModulesCompilation: import("@unpack-js/core").Compilation | undefined;
+  let finishedModule: Module | undefined;
+  let capturedModules: ReadonlySet<Module> | undefined;
+  let capturedModuleGraph: import("@unpack-js/core").ModuleGraph | undefined;
+
+  compiler.hooks.compilation.tap("observe compilation", (compilation) => {
+    finishModulesCompilation = compilation;
+    capturedModules = compilation.modules;
+    capturedModuleGraph = compilation.moduleGraph;
+    events.push("compilation");
+    assert.equal(compilation.modules.size, 0);
+    compilation.hooks.finishModules.tap("early", () => events.push("early"));
+    compilation.hooks.finishModules.tap("target", () => events.push("target"));
+    compilation.hooks.finishModules.tap(
+      { name: "before target", before: "target" },
+      () => events.push("before target")
+    );
+    compilation.hooks.finishModules.tapAsync("async modules", (modules, done) => {
+      assert.equal(modules, capturedModules);
+      assert.equal(compilation.moduleGraph, capturedModuleGraph);
+      finishedModule = modules.values().next().value;
+      events.push(`finishModules:${modules.size}:start`);
+      setTimeout(() => {
+        events.push("finishModules:end");
+        done();
+      }, 5);
+    });
+  });
+  compiler.hooks.done.tap("done", (stats) => {
+    events.push("done");
+    assert.equal(stats.compilation, finishModulesCompilation);
+    assert.equal(stats.compilation.modules, capturedModules);
+    assert.equal(stats.compilation.moduleGraph, capturedModuleGraph);
+    assert.equal(stats.compilation.modules.has(finishedModule!), true);
+    assert.equal(stats.compilation.modules.size, finishModulesCompilation?.modules.size);
+  });
+
+  try {
+    await runCompiler(compiler, () => events.push("run:callback"));
+    assert.deepEqual(events, [
+      "compilation",
+      "early",
+      "before target",
+      "target",
+      "finishModules:4:start",
+      "finishModules:end",
+      "done",
+      "run:callback"
+    ]);
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("finishModules failures abort sealing and preserve the hook error", async () => {
+  const fixture = await createGraphFixture();
+  const compiler = createCompiler(fixture);
+  const expected = new Error("finishModules failed");
+  let doneCalled = false;
+
+  compiler.hooks.compilation.tap("register failure", (compilation) => {
+    compilation.hooks.finishModules.tapPromise("failure", async () => {
+      throw expected;
+    });
+  });
+  compiler.hooks.done.tap("must not run", () => { doneCalled = true; });
+
+  try {
+    const observation = await observeCompilerRun(compiler);
+    assert.equal(observation.error, expected);
+    assert.equal(observation.stats, undefined);
+    assert.equal(doneCalled, false);
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 // Ported from webpack's Compiler.run behavior: errors from done abort the
 // successful callback path and do not provide Stats to the final callback.
 test("done errors are delivered as run errors without Stats", async () => {


### PR DESCRIPTION
## Summary

- add a core compilation hooks boundary around module completion
- expose webpack-shaped `compiler.hooks.compilation` and `compilation.hooks.finishModules` APIs to JavaScript
- support sync, callback, and promise taps with webpack-compatible ordering and error propagation
- preserve compilation, graph, collection, and module identities across lifecycle phases

## Why

Plugins need a model-backed hook after module construction and before sealing. This adds that lifecycle boundary at the native compilation phase and makes it available through the JavaScript API without introducing a no-op compatibility surface.

The full Rust and JavaScript test suites pass, including lifecycle ordering, failure propagation, tap ordering, stable identity, and Node process-exit coverage.