### PR TITLE
Add webpack source permalinks

### DIFF
--- a/crates/unpack_core/src/async_dependencies_block.rs
+++ b/crates/unpack_core/src/async_dependencies_block.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/AsyncDependenciesBlock.js
+
 use serde::{Deserialize, Serialize};
 
 use crate::Dependency;

--- a/crates/unpack_core/src/build_chunk_graph.rs
+++ b/crates/unpack_core/src/build_chunk_graph.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/buildChunkGraph.js
+
 use std::{
     cmp::Ordering,
     collections::{HashMap, VecDeque},

--- a/crates/unpack_core/src/cache.rs
+++ b/crates/unpack_core/src/cache.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/Cache.js
+
 //! Webpack-aligned Cache coordinator for ordered Cache Layer lookup, promotion, storage, and work accounting.
 
 mod build_cache;

--- a/crates/unpack_core/src/cache/build_cache.rs
+++ b/crates/unpack_core/src/cache/build_cache.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/Cache.js
+
 //! Compiler-owned Build Cache composition over the webpack-aligned Cache.
 //! It wires typed Cache Facades to Cache Layers and owns preparation and publication lifecycle.
 

--- a/crates/unpack_core/src/cache/build_cache/tests.rs
+++ b/crates/unpack_core/src/cache/build_cache/tests.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/Cache.js
+
 use std::{collections::BTreeSet, fs, io, path::Path, sync::Arc, time::Duration};
 
 use filetime::{FileTime, set_file_mtime};

--- a/crates/unpack_core/src/cache/cache_items.rs
+++ b/crates/unpack_core/src/cache/cache_items.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/CacheFacade.js
+
 //! Rust-native Cache Items and their stable cache keys.
 
 use std::{

--- a/crates/unpack_core/src/cache/memory_cache_plugin.rs
+++ b/crates/unpack_core/src/cache/memory_cache_plugin.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/cache/MemoryCachePlugin.js
+
 //! Webpack-aligned in-process Memory Cache Plugin.
 
 use std::collections::HashMap;

--- a/crates/unpack_core/src/cache/memory_with_gc_cache_plugin.rs
+++ b/crates/unpack_core/src/cache/memory_with_gc_cache_plugin.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/cache/MemoryWithGcCachePlugin.js
+
 //! Webpack-aligned Memory Cache Plugin with generation-based garbage collection.
 
 use std::collections::HashMap;

--- a/crates/unpack_core/src/cache/options.rs
+++ b/crates/unpack_core/src/cache/options.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/config/defaults.js
+
 //! Public Cache options and defaults consumed by the Cache composition root.
 
 use std::{path::PathBuf, time::Duration};

--- a/crates/unpack_core/src/cache/pack_file.rs
+++ b/crates/unpack_core/src/cache/pack_file.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/cache/PackFileCacheStrategy.js
+
 //! Private Pack File storage used by the Pack File Cache Strategy.
 
 #[cfg(test)]

--- a/crates/unpack_core/src/cache/pack_file_cache_strategy.rs
+++ b/crates/unpack_core/src/cache/pack_file_cache_strategy.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/cache/PackFileCacheStrategy.js
+
 //! Webpack-aligned Pack File Cache Strategy, including restore, publication, and writer diagnostics.
 
 use std::{

--- a/crates/unpack_core/src/cache_facade.rs
+++ b/crates/unpack_core/src/cache_facade.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/CacheFacade.js
+
 //! Webpack-aligned Cache Facade and cache-item identity primitives.
 //! This is the narrow caller-facing seam over the shared Cache coordinator.
 

--- a/crates/unpack_core/src/cache_hash.rs
+++ b/crates/unpack_core/src/cache_hash.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/CacheFacade.js
+
 use std::hash::{Hash, Hasher};
 
 pub(crate) fn stable_hash<T: Hash + ?Sized>(value: &T) -> u64 {

--- a/crates/unpack_core/src/chunk.rs
+++ b/crates/unpack_core/src/chunk.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/Chunk.js
+
 use crate::{
     ModuleHandle,
     chunk_group::{ChunkGroup, ChunkGroupHandle},

--- a/crates/unpack_core/src/chunk_graph.rs
+++ b/crates/unpack_core/src/chunk_graph.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/ChunkGraph.js
+
 use std::collections::{HashMap, HashSet};
 
 use crate::{

--- a/crates/unpack_core/src/chunk_group.rs
+++ b/crates/unpack_core/src/chunk_group.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/ChunkGroup.js
+
 use crate::{AsyncDependenciesBlockIndex, ModuleHandle, chunk::ChunkHandle};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/CodeGenerationResults.js
+
 use std::{
     collections::HashMap,
     hash::{Hash, Hasher},

--- a/crates/unpack_core/src/code_generation_record.rs
+++ b/crates/unpack_core/src/code_generation_record.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/CodeGenerationResults.js
+
 use rspack_sources::{
     ConcatSource, OriginalSource, RawStringSource, ReplaceSource, Replacement, ReplacementEnforce,
 };

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/Compilation.js
+
 use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
 
 use tokio::sync::Mutex;

--- a/crates/unpack_core/src/compilation/hooks.rs
+++ b/crates/unpack_core/src/compilation/hooks.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/Compilation.js
+
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use super::Compilation;

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/Compiler.js
+
 use std::{
     path::PathBuf,
     sync::{Arc, Mutex, Weak},

--- a/crates/unpack_core/src/compiler/hooks.rs
+++ b/crates/unpack_core/src/compiler/hooks.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/Compiler.js
+
 use std::sync::Arc;
 
 use crate::compilation::CompilationHookSet;

--- a/crates/unpack_core/src/dependencies/const_dependency.rs
+++ b/crates/unpack_core/src/dependencies/const_dependency.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/dependencies/ConstDependency.js
+
 use serde::{Deserialize, Serialize};
 
 use crate::SourceRange;

--- a/crates/unpack_core/src/dependencies/entry_dependency.rs
+++ b/crates/unpack_core/src/dependencies/entry_dependency.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/dependencies/EntryDependency.js
+
 use serde::{Deserialize, Serialize};
 
 use super::ModuleDependency;

--- a/crates/unpack_core/src/dependencies/harmony_export_expression_dependency.rs
+++ b/crates/unpack_core/src/dependencies/harmony_export_expression_dependency.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/dependencies/HarmonyExportExpressionDependency.js
+
 use serde::{Deserialize, Serialize};
 
 use crate::SourceRange;

--- a/crates/unpack_core/src/dependencies/harmony_export_header_dependency.rs
+++ b/crates/unpack_core/src/dependencies/harmony_export_header_dependency.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/dependencies/HarmonyExportHeaderDependency.js
+
 use serde::{Deserialize, Serialize};
 
 use crate::SourceRange;

--- a/crates/unpack_core/src/dependencies/harmony_export_imported_specifier_dependency.rs
+++ b/crates/unpack_core/src/dependencies/harmony_export_imported_specifier_dependency.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+
 use serde::{Deserialize, Serialize};
 
 use super::ModuleDependency;

--- a/crates/unpack_core/src/dependencies/harmony_export_specifier_dependency.rs
+++ b/crates/unpack_core/src/dependencies/harmony_export_specifier_dependency.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/dependencies/HarmonyExportSpecifierDependency.js
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/unpack_core/src/dependencies/harmony_import_side_effect_dependency.rs
+++ b/crates/unpack_core/src/dependencies/harmony_import_side_effect_dependency.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/dependencies/HarmonyImportSideEffectDependency.js
+
 use serde::{Deserialize, Serialize};
 
 use super::ModuleDependency;

--- a/crates/unpack_core/src/dependencies/harmony_import_specifier_dependency.rs
+++ b/crates/unpack_core/src/dependencies/harmony_import_specifier_dependency.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/dependencies/HarmonyImportSpecifierDependency.js
+
 use serde::{Deserialize, Serialize};
 
 use super::ModuleDependency;

--- a/crates/unpack_core/src/dependencies/import_dependency.rs
+++ b/crates/unpack_core/src/dependencies/import_dependency.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/dependencies/ImportDependency.js
+
 use serde::{Deserialize, Serialize};
 
 use super::ModuleDependency;

--- a/crates/unpack_core/src/dependencies/mod.rs
+++ b/crates/unpack_core/src/dependencies/mod.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/tree/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/dependencies
+
 mod const_dependency;
 mod entry_dependency;
 mod harmony_export_expression_dependency;

--- a/crates/unpack_core/src/dependencies/module_dependency.rs
+++ b/crates/unpack_core/src/dependencies/module_dependency.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/dependencies/ModuleDependency.js
+
 use std::fmt;
 
 use serde::{Deserialize, Serialize};

--- a/crates/unpack_core/src/dependencies/null_dependency.rs
+++ b/crates/unpack_core/src/dependencies/null_dependency.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/dependencies/NullDependency.js
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/unpack_core/src/dependencies_block.rs
+++ b/crates/unpack_core/src/dependencies_block.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/DependenciesBlock.js
+
 use serde::{Deserialize, Serialize};
 
 use crate::{AsyncDependenciesBlock, Dependency};

--- a/crates/unpack_core/src/dependency.rs
+++ b/crates/unpack_core/src/dependency.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/Dependency.js
+
 use serde::{Deserialize, Serialize};
 
 use crate::dependencies::{

--- a/crates/unpack_core/src/error.rs
+++ b/crates/unpack_core/src/error.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/WebpackError.js
+
 use std::path::PathBuf;
 
 use crate::ModuleHandle;

--- a/crates/unpack_core/src/exports_info.rs
+++ b/crates/unpack_core/src/exports_info.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/ExportsInfo.js
+
 use std::collections::BTreeSet;
 
 use crate::Dependency;

--- a/crates/unpack_core/src/flag_dependency_exports_plugin.rs
+++ b/crates/unpack_core/src/flag_dependency_exports_plugin.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/FlagDependencyExportsPlugin.js
+
 use crate::{Compilation, compilation::CompilationHookSet, compiler::CompilerHookSet};
 
 pub(crate) struct FlagDependencyExportsPlugin;

--- a/crates/unpack_core/src/flag_dependency_usage_plugin.rs
+++ b/crates/unpack_core/src/flag_dependency_usage_plugin.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/FlagDependencyUsagePlugin.js
+
 use std::collections::{BTreeSet, HashMap};
 
 use crate::{

--- a/crates/unpack_core/src/hooks.rs
+++ b/crates/unpack_core/src/hooks.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/Compilation.js
+
 use std::{fmt::Debug, future::Future, pin::Pin};
 
 use crate::{Compilation, Result};

--- a/crates/unpack_core/src/id_assignment.rs
+++ b/crates/unpack_core/src/id_assignment.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/ids/IdHelpers.js
+
 use std::{
     collections::{BTreeMap, HashSet},
     fmt,

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/tree/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib
+
 mod async_dependencies_block;
 mod build_chunk_graph;
 mod cache;

--- a/crates/unpack_core/src/loader.rs
+++ b/crates/unpack_core/src/loader.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/NormalModule.js
+
 use std::{
     fmt::Debug,
     future::Future,

--- a/crates/unpack_core/src/logging.rs
+++ b/crates/unpack_core/src/logging.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/logging/Logger.js
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InfrastructureLogLevel {
     Error,

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/Compilation.js
+
 use std::{
     collections::{BTreeMap, HashMap, HashSet, VecDeque},
     path::{Path, PathBuf},

--- a/crates/unpack_core/src/module.rs
+++ b/crates/unpack_core/src/module.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/Module.js
+
 use std::{
     hash::{Hash, Hasher},
     path::PathBuf,

--- a/crates/unpack_core/src/module_graph.rs
+++ b/crates/unpack_core/src/module_graph.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/ModuleGraph.js
+
 use std::collections::HashMap;
 
 use crate::{

--- a/crates/unpack_core/src/module_graph_connection.rs
+++ b/crates/unpack_core/src/module_graph_connection.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/ModuleGraphConnection.js
+
 use crate::{AsyncDependenciesBlockIndex, Dependency, DependencyIndex, ModuleHandle};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/crates/unpack_core/src/normal_module_factory.rs
+++ b/crates/unpack_core/src/normal_module_factory.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/NormalModuleFactory.js
+
 use std::{
     collections::{BTreeSet, HashSet},
     path::{Path, PathBuf},

--- a/crates/unpack_core/src/optimize/mod.rs
+++ b/crates/unpack_core/src/optimize/mod.rs
@@ -1,1 +1,3 @@
+// Webpack source: https://github.com/webpack/webpack/tree/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/optimize
+
 pub(crate) mod side_effects_flag_plugin;

--- a/crates/unpack_core/src/optimize/side_effects_flag_plugin.rs
+++ b/crates/unpack_core/src/optimize/side_effects_flag_plugin.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/optimize/SideEffectsFlagPlugin.js
+
 use regex::Regex;
 use serde_json::Value;
 

--- a/crates/unpack_core/src/output_filename.rs
+++ b/crates/unpack_core/src/output_filename.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/TemplatedPathPlugin.js
+
 use crate::Chunk;
 
 pub(crate) fn resolve_chunk_filename(chunk: &Chunk) -> String {

--- a/crates/unpack_core/src/parser.rs
+++ b/crates/unpack_core/src/parser.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/javascript/JavascriptParser.js
+
 use std::{
     collections::{HashMap, HashSet},
     path::{Path, PathBuf},

--- a/crates/unpack_core/src/rendered_source.rs
+++ b/crates/unpack_core/src/rendered_source.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/Compilation.js
+
 use rspack_sources::{
     ConcatSource, MapOptions, ObjectPool, RawStringSource, Source, SourceExt, SourceMap,
 };

--- a/crates/unpack_core/src/resolver.rs
+++ b/crates/unpack_core/src/resolver.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/ResolverFactory.js
+
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},

--- a/crates/unpack_core/src/runtime.rs
+++ b/crates/unpack_core/src/runtime.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/RuntimeGlobals.js
+
 use std::collections::BTreeMap;
 
 use crate::{

--- a/crates/unpack_core/src/snapshot.rs
+++ b/crates/unpack_core/src/snapshot.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/FileSystemInfo.js
+
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs, io,

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/webpack.js
+
 use std::{
     fs,
     path::{Path, PathBuf},

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -1,3 +1,5 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/webpack.js
+
 import { createRequire } from "node:module";
 import { statSync, watch as watchFileSystem } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";


### PR DESCRIPTION
## Summary

Add file-header comments that link each webpack-aligned implementation module to its corresponding upstream webpack source at the pinned webpack 5.108.1 commit.

This covers all `unpack_core` source modules plus the native and TypeScript API entrypoints, making directory and responsibility alignment directly traceable during future reviews and refactors.

The permalink targets were checked against the pinned webpack source tree. `cargo fmt --all -- --check`, `git diff --check`, and all 95 `unpack_core` unit tests pass. The JavaScript suite passed its reported assertions but did not exit cleanly and was interrupted after it stopped producing output.
