### PR TITLE
Use typed IndexVec for module graph connections

### DIFF
--- a/crates/unpack_core/src/index_vec.rs
+++ b/crates/unpack_core/src/index_vec.rs
@@ -1,0 +1,89 @@
+use std::{marker::PhantomData, ops};
+
+pub(crate) trait Idx: Copy {
+    fn from_usize(index: usize) -> Self;
+    fn index(self) -> usize;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IndexVec<I, T> {
+    raw: Vec<T>,
+    _index: PhantomData<fn(I) -> I>,
+}
+
+impl<I, T> IndexVec<I, T>
+where
+    I: Idx,
+{
+    pub(crate) fn push(&mut self, value: T) -> I {
+        let index = I::from_usize(self.raw.len());
+        self.raw.push(value);
+        index
+    }
+
+    pub(crate) fn get(&self, index: I) -> Option<&T> {
+        self.raw.get(index.index())
+    }
+}
+
+impl<I, T> Default for IndexVec<I, T> {
+    fn default() -> Self {
+        Self {
+            raw: Vec::new(),
+            _index: PhantomData,
+        }
+    }
+}
+
+impl<I, T> ops::Index<I> for IndexVec<I, T>
+where
+    I: Idx,
+{
+    type Output = T;
+
+    fn index(&self, index: I) -> &Self::Output {
+        &self.raw[index.index()]
+    }
+}
+
+impl<I, T> ops::IndexMut<I> for IndexVec<I, T>
+where
+    I: Idx,
+{
+    fn index_mut(&mut self, index: I) -> &mut Self::Output {
+        &mut self.raw[index.index()]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Idx, IndexVec};
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct TestIndex(usize);
+
+    impl Idx for TestIndex {
+        fn from_usize(index: usize) -> Self {
+            Self(index)
+        }
+
+        fn index(self) -> usize {
+            self.0
+        }
+    }
+
+    #[test]
+    fn assigns_and_uses_typed_indices() {
+        let mut values: IndexVec<TestIndex, _> = IndexVec::default();
+        let first = values.push("first");
+        let second = values.push("second");
+
+        assert_eq!(first, TestIndex(0));
+        assert_eq!(second, TestIndex(1));
+        assert_eq!(values[first], "first");
+        assert_eq!(values.get(second), Some(&"second"));
+
+        values[second] = "updated";
+        assert_eq!(values[second], "updated");
+    }
+}

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -22,6 +22,7 @@ mod flag_dependency_exports_plugin;
 mod flag_dependency_usage_plugin;
 mod hooks;
 mod id_assignment;
+mod index_vec;
 mod init_fragment;
 mod loader;
 mod logging;

--- a/crates/unpack_core/src/module.rs
+++ b/crates/unpack_core/src/module.rs
@@ -27,6 +27,16 @@ impl ModuleHandle {
     }
 }
 
+impl crate::index_vec::Idx for ModuleHandle {
+    fn from_usize(index: usize) -> Self {
+        Self(index)
+    }
+
+    fn index(self) -> usize {
+        self.0
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Module {
     handle: ModuleHandle,

--- a/crates/unpack_core/src/module_graph.rs
+++ b/crates/unpack_core/src/module_graph.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use crate::index_vec::IndexVec;
 use crate::{
     Dependency, Module, ModuleGraphConnection, ModuleGraphConnectionHandle,
     ModuleGraphConnectionState, ModuleHandle, ModuleIdentity,
@@ -11,9 +12,10 @@ use crate::{
 pub struct ModuleGraph {
     modules: Vec<Module>,
     connections: Vec<ModuleGraphConnection>,
-    outgoing: Vec<Vec<ModuleGraphConnectionHandle>>,
-    incoming: Vec<Vec<ModuleGraphConnectionHandle>>,
-    outgoing_by_location: Vec<HashMap<DependencyLocation, ModuleGraphConnectionHandle>>,
+    outgoing: IndexVec<ModuleHandle, Vec<ModuleGraphConnectionHandle>>,
+    incoming: IndexVec<ModuleHandle, Vec<ModuleGraphConnectionHandle>>,
+    outgoing_by_location:
+        IndexVec<ModuleHandle, HashMap<DependencyLocation, ModuleGraphConnectionHandle>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -46,9 +48,9 @@ impl ModuleGraph {
     pub(crate) fn add_module(&mut self, identity: ModuleIdentity) -> ModuleHandle {
         let handle = ModuleHandle::new(self.modules.len());
         self.modules.push(Module::new(handle, identity));
-        self.outgoing.push(Vec::new());
-        self.incoming.push(Vec::new());
-        self.outgoing_by_location.push(HashMap::new());
+        debug_assert_eq!(self.outgoing.push(Vec::new()), handle);
+        debug_assert_eq!(self.incoming.push(Vec::new()), handle);
+        debug_assert_eq!(self.outgoing_by_location.push(HashMap::new()), handle);
         handle
     }
 
@@ -75,9 +77,9 @@ impl ModuleGraph {
             state: ModuleGraphConnectionState::Active,
         });
         if let Some(origin_module) = origin_module {
-            self.outgoing[origin_module.index()].push(connection_handle);
+            self.outgoing[origin_module].push(connection_handle);
             if let Some(dependency_index) = origin_dependency_index {
-                self.outgoing_by_location[origin_module.index()].insert(
+                self.outgoing_by_location[origin_module].insert(
                     DependencyLocation {
                         block: origin_block,
                         dependency_index,
@@ -86,7 +88,7 @@ impl ModuleGraph {
                 );
             }
         }
-        self.incoming[module.index()].push(connection_handle);
+        self.incoming[module].push(connection_handle);
     }
 
     pub fn modules(&self) -> &[Module] {
@@ -114,8 +116,8 @@ impl ModuleGraph {
         if connection.module == module {
             return;
         }
-        self.incoming[connection.module.index()].retain(|candidate| *candidate != handle);
-        self.incoming[module.index()].push(handle);
+        self.incoming[connection.module].retain(|candidate| *candidate != handle);
+        self.incoming[module].push(handle);
         connection.module = module;
     }
 
@@ -130,7 +132,7 @@ impl ModuleGraph {
         &self,
         module: ModuleHandle,
     ) -> impl Iterator<Item = &ModuleGraphConnection> {
-        self.outgoing[module.index()]
+        self.outgoing[module]
             .iter()
             .map(|connection_handle| &self.connections[connection_handle.index()])
     }
@@ -139,7 +141,7 @@ impl ModuleGraph {
         &self,
         module: ModuleHandle,
     ) -> impl Iterator<Item = &ModuleGraphConnection> {
-        self.incoming[module.index()]
+        self.incoming[module]
             .iter()
             .map(|connection_handle| &self.connections[connection_handle.index()])
     }
@@ -155,7 +157,7 @@ impl ModuleGraph {
             dependency_index,
         };
         self.outgoing_by_location
-            .get(origin_module.index())?
+            .get(origin_module)?
             .get(&location)
             .map(|connection_handle| self.connections[connection_handle.index()].module)
     }


### PR DESCRIPTION
## Summary

- add a small crate-private `IndexVec<I, T>` backed by `Vec<T>`
- implement typed indexing for `ModuleHandle`
- store incoming, outgoing, and dependency-location connections in `IndexVec`
- assert that per-module connection storage stays aligned with module handles in debug builds

This keeps the dense storage characteristics of the existing vectors while making the `ModuleHandle` mapping explicit and removing repeated manual index conversion.

Checked with `cargo test -p unpack_core --lib` and `cargo test -p unpack_core --test make`.
