### PR TITLE
Support the plugins configuration option

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,8 +29,12 @@ The Node.js-facing programmable API for configuring and running Unpack from Java
 _Avoid_: Rust API, Unpack-only API
 
 **Exposed JavaScript API Surface**:
-The currently callable JavaScript API behavior, including `unpack(options, callback?)`, compiler lifecycle methods, watching lifecycle methods, stats reporting, and supported option normalization. It is the first priority for webpack alignment before generated runtime or graph internals.
-_Avoid_: Internal Rust API, future plugin API surface
+The currently callable JavaScript API behavior, including `unpack(options, callback?)`, configured JavaScript Plugins, compiler lifecycle methods, watching lifecycle methods, stats reporting, and supported option normalization. It is the first priority for webpack alignment before generated runtime or graph internals.
+_Avoid_: Internal Rust API, unimplemented plugin surface
+
+**JavaScript Plugin**:
+A webpack-shaped object with an `apply(compiler)` method or a function-style plugin configured through `options.plugins`. It is applied once in configuration order and can use only the model-backed Compiler and Compilation Hooks and façade properties that Unpack exposes.
+_Avoid_: Rust plugin, arbitrary webpack plugin compatibility
 
 **JavaScript Lifecycle Alignment**:
 The webpack-aligned behavior of JavaScript API calls around synchronous validation, asynchronous callback timing, callback `err` values, returned `Stats`, and compiler or watching lifecycle conflicts. It is the first exposed API alignment area to stabilize.

--- a/docs/adr/0071-do-not-accept-plugins-in-the-first-javascript-api.md
+++ b/docs/adr/0071-do-not-accept-plugins-in-the-first-javascript-api.md
@@ -1,3 +1,0 @@
-# Do not accept plugins in the first JavaScript API
-
-The first JavaScript API will not yet support a plugin API and will reject a `plugins` option instead of silently ignoring it. This keeps Unpack from implying plugin lifecycle support before that lifecycle has been deliberately designed, while leaving webpack's plugin API shape as the reference for future plugin work.

--- a/docs/adr/0071-support-a-bounded-plugins-option.md
+++ b/docs/adr/0071-support-a-bounded-plugins-option.md
@@ -1,0 +1,25 @@
+# Support a bounded plugins option
+
+The JavaScript API accepts webpack-shaped `plugins` entries now that its
+model-backed Compiler and Compilation Hooks can support useful integrations.
+Object plugins provide an `apply(compiler)` method. Function-style plugins are
+called with the Compiler as both `this` and their argument. Plugins are applied
+once in configuration order after Compiler construction and before the first
+run; `false`, `null`, `undefined`, `0`, and the empty string are ignored.
+
+Plugin validation and application are part of top-level Compiler
+initialization. Without a callback, failures throw synchronously. With a
+callback, initialization returns `null` and reports the failure asynchronously
+without Stats, following the existing top-level initialization contract.
+
+This option opens only the Hooks and Compiler or Compilation façade properties
+that Unpack implements. Each community-plugin compatibility case proves only
+the behavior it exercises and does not imply compatibility with arbitrary
+webpack plugins or unavailable webpack surfaces.
+
+Community-plugin cases must pass the same plugin through `options.plugins` in
+both Unpack and pinned webpack when comparing observable integration output.
+The option's bounded normalization rules, apply ordering, function-plugin
+calling convention, and initialization-error contract remain direct API
+contract tests: they define Unpack's supported subset and are not a claim that
+the complete webpack plugin loader or every plugin lifecycle edge is exposed.

--- a/packages/unpack/package.json
+++ b/packages/unpack/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@types/node": "26.0.1",
     "typescript": "6.0.3",
-    "webpack": "5.108.1"
+    "webpack": "5.108.1",
+    "webpack-bundle-analyzer": "5.3.0"
   }
 }

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -20,7 +20,26 @@ export interface UnpackOptions {
   module?: ModuleOptions;
   optimization?: OptimizationOptions;
   experiments?: ExperimentsOptions;
+  plugins?: WebpackPlugin[];
 }
+
+export interface WebpackPluginInstance {
+  apply(compiler: Compiler): void;
+}
+
+export type WebpackPluginFunction = (
+  this: Compiler,
+  compiler: Compiler
+) => void;
+
+export type WebpackPlugin =
+  | WebpackPluginInstance
+  | WebpackPluginFunction
+  | false
+  | null
+  | undefined
+  | 0
+  | "";
 
 export interface ExperimentsOptions {
   cacheUnaffected?: boolean;
@@ -315,6 +334,7 @@ export interface CompilerHooks {
 
 export interface Compiler {
   readonly hooks: CompilerHooks;
+  readonly outputPath: string;
   run(callback: RunCallback): void;
   watch(watchOptions: WatchOptions, handler: WatchHandler): Watching;
   close(callback: CloseCallback): void;
@@ -874,6 +894,7 @@ class CompilerImpl implements Compiler {
     compilation: new CompilationHookImpl(),
     done: new DoneHookImpl()
   };
+  readonly outputPath: string;
   #lifecycle: CompilerLifecycle = { kind: "open" };
   #running = false;
   #watching: WatchingImpl | undefined;
@@ -891,6 +912,7 @@ class CompilerImpl implements Compiler {
   #activeCompilation: CompilationImpl | undefined;
 
   constructor(options: NormalizedOptions) {
+    this.outputPath = options.outputPath;
     this.#loaderRuntime = options.moduleRules.some((rule) => rule.loader !== undefined)
       ? new LoaderRuntime(options.context)
       : undefined;
@@ -2218,7 +2240,10 @@ export default function unpack(
 
   let compiler: Compiler;
   try {
-    compiler = new CompilerImpl(normalizeOptions(options));
+    const normalizedOptions = normalizeOptions(options);
+    const plugins = normalizePlugins(options.plugins);
+    compiler = new CompilerImpl(normalizedOptions);
+    applyPlugins(plugins, compiler);
   } catch (error) {
     if (callback === undefined) {
       throw error;
@@ -2250,7 +2275,8 @@ function normalizeOptions(options: UnpackOptions): NormalizedOptions {
       "infrastructureLogging",
       "module",
       "optimization",
-      "experiments"
+      "experiments",
+      "plugins"
     ],
     "options"
   );
@@ -2305,6 +2331,56 @@ function normalizeOptions(options: UnpackOptions): NormalizedOptions {
     usedExports: optimization.usedExports,
     sideEffects: optimization.sideEffects
   };
+}
+
+function normalizePlugins(plugins: unknown): Array<WebpackPluginInstance | WebpackPluginFunction> {
+  if (plugins === undefined) {
+    return [];
+  }
+  if (!Array.isArray(plugins)) {
+    throw new TypeError("options.plugins must be an array");
+  }
+
+  const normalized: Array<WebpackPluginInstance | WebpackPluginFunction> = [];
+  for (const [index, plugin] of plugins.entries()) {
+    if (
+      plugin === false ||
+      plugin === null ||
+      plugin === undefined ||
+      plugin === 0 ||
+      plugin === ""
+    ) {
+      continue;
+    }
+    if (typeof plugin === "function") {
+      normalized.push(plugin as WebpackPluginFunction);
+      continue;
+    }
+    if (
+      typeof plugin === "object" &&
+      typeof (plugin as { apply?: unknown }).apply === "function"
+    ) {
+      normalized.push(plugin as WebpackPluginInstance);
+      continue;
+    }
+    throw new TypeError(
+      `options.plugins[${index}] must be a function, a plugin with an apply method, or falsy`
+    );
+  }
+  return normalized;
+}
+
+function applyPlugins(
+  plugins: readonly (WebpackPluginInstance | WebpackPluginFunction)[],
+  compiler: Compiler
+): void {
+  for (const plugin of plugins) {
+    if (typeof plugin === "function") {
+      (plugin as WebpackPluginFunction).call(compiler, compiler);
+    } else {
+      plugin.apply(compiler);
+    }
+  }
 }
 
 function normalizeExperimentsOptions(experiments: ExperimentsOptions | undefined): boolean {

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -6,7 +6,7 @@ import assert from "node:assert/strict";
 
 import unpack from "@unpack-js/core";
 import webpack from "webpack";
-import type { Stats } from "@unpack-js/core";
+import type { Compiler, Stats } from "@unpack-js/core";
 
 test("emits assets through the ESM default API", async () => {
   const fixture = await createFixture({
@@ -562,6 +562,81 @@ test("can disable sourcemap emission", async () => {
   } finally {
     await rm(fixture, { recursive: true, force: true });
   }
+});
+
+test("plugins apply once in configuration order and run on every compilation", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export const value = 1;"
+  });
+  const events: string[] = [];
+  const objectPlugin = {
+    apply(compiler: Compiler) {
+      events.push("object:apply");
+      compiler.hooks.done.tap("object plugin", () => events.push("object:done"));
+    }
+  };
+  function functionPlugin(this: Compiler, compiler: Compiler): void {
+    assert.equal(this, compiler);
+    events.push("function:apply");
+    compiler.hooks.done.tap("function plugin", () => events.push("function:done"));
+  }
+  const compiler = unpack({
+    context: fixture,
+    entry: "./src/index.js",
+    sourcemap: false,
+    plugins: [false, objectPlugin, null, functionPlugin, 0, "", undefined]
+  });
+
+  try {
+    assert.deepEqual(events, ["object:apply", "function:apply"]);
+    assert.equal((await runExistingCompiler(compiler)).err, null);
+    assert.equal((await runExistingCompiler(compiler)).err, null);
+    assert.deepEqual(events, [
+      "object:apply",
+      "function:apply",
+      "object:done",
+      "function:done",
+      "object:done",
+      "function:done"
+    ]);
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("plugin application failures follow top-level initialization error timing", async () => {
+  const synchronousFailure = new Error("synchronous plugin failure");
+  assert.throws(
+    () =>
+      unpack({
+        entry: "./src/index.js",
+        plugins: [{ apply: () => { throw synchronousFailure; } }]
+      }),
+    (error) => error === synchronousFailure
+  );
+
+  const asynchronousFailure = new Error("callback plugin failure");
+  let calledSynchronously = true;
+  const observation = new Promise<{ calledSynchronously: boolean; error: Error | null }>(
+    (resolve) => {
+      const returnedCompiler = unpack(
+        {
+          entry: "./src/index.js",
+          plugins: [{ apply: () => { throw asynchronousFailure; } }]
+        },
+        (error) => resolve({ calledSynchronously, error })
+      );
+      assert.equal(returnedCompiler, null);
+      calledSynchronously = false;
+    }
+  );
+
+  assert.deepEqual(await observation, {
+    calledSynchronously: false,
+    error: asynchronousFailure
+  });
+  assert.equal(asynchronousFailure.name, "InfrastructureError");
 });
 
 test("unpack options callback returns a reusable compiler", async () => {
@@ -1796,9 +1871,18 @@ test("top-level option validation throws synchronously", () => {
       unpack({
         entry: "./src/index.js",
         // @ts-expect-error intentionally testing runtime validation
-        plugins: []
+        plugins: {}
       }),
-    /unknown option 'plugins'/
+    /options.plugins must be an array/
+  );
+  assert.throws(
+    () =>
+      unpack({
+        entry: "./src/index.js",
+        // @ts-expect-error intentionally testing runtime validation
+        plugins: [{}]
+      }),
+    /options.plugins\[0\] must be a function, a plugin with an apply method, or falsy/
   );
   assert.throws(
     () =>

--- a/packages/unpack/test/configCases/plugins/webpack-bundle-analyzer/index.js
+++ b/packages/unpack/test/configCases/plugins/webpack-bundle-analyzer/index.js
@@ -1,0 +1,1 @@
+export const load = () => import("./lazy.js");

--- a/packages/unpack/test/configCases/plugins/webpack-bundle-analyzer/lazy.js
+++ b/packages/unpack/test/configCases/plugins/webpack-bundle-analyzer/lazy.js
@@ -1,0 +1,1 @@
+export const value = "lazy";

--- a/packages/unpack/test/configCases/plugins/webpack-bundle-analyzer/test.config.ts
+++ b/packages/unpack/test/configCases/plugins/webpack-bundle-analyzer/test.config.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import webpack from "webpack";
+import type { ConfigCaseTest } from "../../../config-case.js";
+import { createAnalyzerPlugin } from "./webpack.config.js";
+
+interface AnalyzerStats {
+  errors: unknown[];
+  warnings: unknown[];
+  assets: Array<{ name: string; size: number }>;
+}
+
+export default {
+  async validate({ fixturePath, outputFiles, outputPath }) {
+    assert.equal(outputFiles.includes("main.js"), true);
+    assert.equal(outputFiles.includes("stats.json"), true);
+
+    const unpackStats = await readAnalyzerStats(outputPath);
+    const webpackStats = await runWebpackAnalyzer(fixturePath);
+
+    assert.equal(unpackStats.assets.length, webpackStats.assets.length);
+    assert.equal(unpackStats.assets.length, 2);
+    assert.equal(unpackStats.assets.some((asset) => asset.name === "main.js"), true);
+    assert.equal(webpackStats.assets.some((asset) => asset.name === "main.js"), true);
+    assert.equal(unpackStats.assets.every((asset) => asset.size > 0), true);
+    assert.equal(webpackStats.assets.every((asset) => asset.size > 0), true);
+    assert.deepEqual(unpackStats.errors, []);
+    assert.deepEqual(unpackStats.warnings, []);
+  }
+} satisfies ConfigCaseTest;
+
+async function runWebpackAnalyzer(fixturePath: string): Promise<AnalyzerStats> {
+  const outputPath = join(fixturePath, "dist-webpack");
+  const compiler = webpack({
+    context: fixturePath,
+    mode: "none",
+    entry: "./index.js",
+    output: { path: outputPath },
+    devtool: false,
+    optimization: {
+      concatenateModules: false,
+      innerGraph: false,
+      minimize: false,
+      providedExports: false,
+      sideEffects: false,
+      usedExports: false
+    },
+    plugins: [
+      createAnalyzerPlugin() as unknown as import("webpack").WebpackPluginInstance
+    ]
+  });
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      compiler.run((error) => (error ? reject(error) : resolve()));
+    });
+    return readAnalyzerStats(outputPath);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      compiler.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function readAnalyzerStats(outputPath: string): Promise<AnalyzerStats> {
+  return JSON.parse(
+    await readFile(join(outputPath, "stats.json"), "utf8")
+  ) as AnalyzerStats;
+}

--- a/packages/unpack/test/configCases/plugins/webpack-bundle-analyzer/webpack.config.ts
+++ b/packages/unpack/test/configCases/plugins/webpack-bundle-analyzer/webpack.config.ts
@@ -1,0 +1,28 @@
+import { createRequire } from "node:module";
+
+import type { WebpackPluginInstance } from "@unpack-js/core";
+import type { ConfigCaseOptions } from "../../../config-case.js";
+
+interface BundleAnalyzerPluginConstructor {
+  new (options?: Record<string, unknown>): WebpackPluginInstance;
+}
+
+const require = createRequire(import.meta.url);
+const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer") as {
+  BundleAnalyzerPlugin: BundleAnalyzerPluginConstructor;
+};
+
+export const analyzerOptions = {
+  analyzerMode: "disabled",
+  generateStatsFile: true,
+  logLevel: "silent",
+  statsFilename: "stats.json"
+};
+
+export function createAnalyzerPlugin(): WebpackPluginInstance {
+  return new BundleAnalyzerPlugin(analyzerOptions);
+}
+
+export default {
+  plugins: [createAnalyzerPlugin()]
+} satisfies ConfigCaseOptions;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       webpack:
         specifier: 5.108.1
         version: 5.108.1
+      webpack-bundle-analyzer:
+        specifier: 5.3.0
+        version: 5.3.0
 
 packages:
 
@@ -132,6 +135,10 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@discoveryjs/json-ext@0.6.3':
+    resolution: {integrity: sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==}
+    engines: {node: '>=14.17.0'}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -636,6 +643,9 @@ packages:
     peerDependencies:
       '@parcel/core': ^2.16.4
 
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
   '@rolldown/binding-android-arm64@1.1.3':
     resolution: {integrity: sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1001,6 +1011,10 @@ packages:
     peerDependencies:
       acorn: ^8.14.0
 
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.17.0:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
@@ -1102,6 +1116,10 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -1176,6 +1194,10 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
@@ -1247,6 +1269,9 @@ packages:
 
   hermes-parser@0.36.1:
     resolution: {integrity: sha512-GApNk4zLHi2UWoWZZkx7LNCOSzLSc5lB55pZ/PhK7ycFeg7u5LcF88p/WbpIi1XUDtE0MpHE3uRR3u3KB7TjSQ==}
+
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -1533,6 +1558,10 @@ packages:
       uglify-js:
         optional: true
 
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -1584,6 +1613,10 @@ packages:
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
+
+  opener@1.5.2:
+    resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
+    hasBin: true
 
   ordered-binary@1.6.1:
     resolution: {integrity: sha512-QkCdPooczexPLiXIrbVOPYkR3VO3T6v2OyKRkR1Xbhpy7/LAVXwahnRCgRp78Oe/Ehf0C/HATAxfSr6eA1oX+w==}
@@ -1661,6 +1694,10 @@ packages:
     resolution: {integrity: sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==}
     engines: {node: '>=0.10.0'}
 
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
@@ -1724,6 +1761,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1770,6 +1811,11 @@ packages:
   weak-lru-cache@1.2.2:
     resolution: {integrity: sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==}
 
+  webpack-bundle-analyzer@5.3.0:
+    resolution: {integrity: sha512-PEhAoqiJ+47d0uLMx/+zo5XOvaU+Vk6N2ZLht7H3n09QLy/fhyvqGNwjdRUHJDgMN8crBR2ZwVHkIswT3Xuawg==}
+    engines: {node: '>= 20.9.0'}
+    hasBin: true
+
   webpack-sources@3.5.0:
     resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
     engines: {node: '>=10.13.0'}
@@ -1794,6 +1840,18 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -1933,6 +1991,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@discoveryjs/json-ext@0.6.3': {}
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -2699,6 +2759,8 @@ snapshots:
     transitivePeerDependencies:
       - napi-wasm
 
+  '@polka/url@1.0.0-next.29': {}
+
   '@rolldown/binding-android-arm64@1.1.3':
     optional: true
 
@@ -2996,6 +3058,10 @@ snapshots:
     dependencies:
       acorn: 8.17.0
 
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.17.0
+
   acorn@8.17.0: {}
 
   agent-base@7.1.4: {}
@@ -3079,6 +3145,8 @@ snapshots:
 
   commander@12.1.0: {}
 
+  commander@14.0.3: {}
+
   commander@2.20.3: {}
 
   connect@3.7.0:
@@ -3132,6 +3200,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
+
+  escape-string-regexp@5.0.0: {}
 
   eslint-scope@5.1.1:
     dependencies:
@@ -3195,6 +3265,8 @@ snapshots:
   hermes-parser@0.36.1:
     dependencies:
       hermes-estree: 0.36.1
+
+  html-escaper@3.0.3: {}
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -3553,6 +3625,8 @@ snapshots:
       terser: 5.48.0
       webpack: 5.108.1
 
+  mrmime@2.0.1: {}
+
   ms@2.0.0: {}
 
   ms@2.1.3: {}
@@ -3603,6 +3677,8 @@ snapshots:
   on-finished@2.3.0:
     dependencies:
       ee-first: 1.1.1
+
+  opener@1.5.2: {}
 
   ordered-binary@1.6.1: {}
 
@@ -3693,6 +3769,12 @@ snapshots:
 
   serialize-error@2.1.0: {}
 
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   source-map-support@0.5.21:
     dependencies:
       buffer-from: 1.1.2
@@ -3749,6 +3831,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  totalist@3.0.1: {}
+
   tslib@2.8.1: {}
 
   type-fest@0.20.2: {}
@@ -3780,6 +3864,22 @@ snapshots:
       graceful-fs: 4.2.11
 
   weak-lru-cache@1.2.2: {}
+
+  webpack-bundle-analyzer@5.3.0:
+    dependencies:
+      '@discoveryjs/json-ext': 0.6.3
+      acorn: 8.17.0
+      acorn-walk: 8.3.5
+      commander: 14.0.3
+      escape-string-regexp: 5.0.0
+      html-escaper: 3.0.3
+      opener: 1.5.2
+      picocolors: 1.1.1
+      sirv: 3.0.2
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   webpack-sources@3.5.0: {}
 
@@ -3866,6 +3966,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   ws@7.5.11: {}
+
+  ws@8.21.0: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary

- add a bounded `options.plugins` API for object and function-style webpack plugins
- preserve configuration order, ignore webpack-compatible falsy entries, and align initialization error timing
- add a dedicated `configCases/plugins` compatibility case using `webpack-bundle-analyzer@5.3.0`
- run the real analyzer through `options.plugins` in both Unpack and pinned webpack and compare its generated stats
- update ADR 0071 and the domain context to define the supported surface and comparison-test boundary

## Why

Unpack's model-backed Compiler and Compilation hooks now support useful community integrations. This change exposes that capability through the familiar plugins configuration while keeping compatibility claims bounded to implemented hooks and façade properties.

The JavaScript, Rust workspace, TypeScript, benchmark, and focused community-plugin suites pass locally.
