### PR TITLE
Document webpack architecture deviation policy

### DIFF
--- a/docs/adr/0141-require-confirmation-before-performance-driven-webpack-architecture-deviations.md
+++ b/docs/adr/0141-require-confirmation-before-performance-driven-webpack-architecture-deviations.md
@@ -1,0 +1,22 @@
+# Require confirmation before performance-driven webpack architecture deviations
+
+Performance optimization does not by itself authorize an implementation that
+deviates from webpack's architectural responsibilities, boundaries, naming, or
+compilation flow. Before implementing such a deviation, the proposal must
+identify the webpack-aligned design, describe the exact deviation, provide the
+performance evidence or hypothesis motivating it, explain the compatibility
+and maintenance consequences, and receive explicit project agreement to
+proceed. The accepted deviation and its boundary must then be documented in an
+ADR or in the relevant implementation-differences document.
+
+Until that agreement exists, implementations must preserve the webpack-aligned
+architecture even when an alternative appears faster. Benchmarks and profiling
+may motivate a proposal, but neither anticipated nor measured performance gains
+silently override the alignment goal established by ADR 0137. Rust-native data
+representations, ownership, and concurrency remain permitted without separate
+confirmation when they preserve webpack's architectural responsibilities and
+observable functionality.
+
+`docs/implementation/webpack-architecture-deviation-register.md` is the
+central index of active deviations, violations, resolved violations, and
+reviewed implementation techniques under this decision.

--- a/docs/implementation/webpack-architecture-deviation-register.md
+++ b/docs/implementation/webpack-architecture-deviation-register.md
@@ -1,0 +1,154 @@
+# Webpack architecture deviation register
+
+This register is the source of record for audits under ADR 0141. It records
+webpack architecture differences that require later refactoring, distinguishes
+approved deviations from violations, and keeps resolved violations visible so
+performance work does not reintroduce them.
+
+The initial audit was performed on 2026-07-12 at commit `1af9791`, using the
+repository-pinned `webpack@5.108.1` for observable behavior and webpack source
+commit `da91761ed92c8e133ee321c7db4ad6c4698cae0a` for architecture and source
+layout. Future architecture-changing performance work must update this register
+before implementation and link the explicit project agreement that authorizes
+the change.
+
+## Classification
+
+- **Violation**: a performance-driven implementation changes webpack's
+  architectural responsibilities, boundaries, naming, or compilation flow
+  without explicit agreement before implementation.
+- **Confirmed deviation**: the implementation differs from webpack, but its
+  constraint, boundary, and approval are documented. It remains a refactoring
+  candidate, not a violation.
+- **Alignment gap**: a claimed webpack-shaped surface does not yet match the
+  corresponding architecture or behavior. Staged unsupported functionality is
+  not automatically an alignment gap.
+- **Reviewed non-violation**: a Rust-native representation or concurrency
+  technique preserves webpack's responsibilities and observable functionality.
+- **Resolved violation**: a violating implementation existed historically but
+  is absent from the audited revision.
+
+## Current violations
+
+None found in the initial audit. This means no current implementation was shown
+to satisfy all three violation conditions; it does not mean Unpack has no
+documented deviations or staged webpack scope.
+
+## Confirmed deviations and refactoring triggers
+
+### DEV-001: Async Chunk plans are reused by target Module
+
+- **Status**: Confirmed deviation.
+- **Performance-driven**: No. This is staged code-splitting scope.
+- **Webpack shape**: webpack starts from each Async Dependencies Block and keeps
+  block-first `ChunkGroupInfo` identity.
+- **Current shape**: Unpack reuses one Async Chunk plan per target Module while
+  retaining each Dependency Block mapping and logical runtime-tree edge.
+- **Confirmation**: ADR 0058 and
+  `docs/implementation/webpack-implementation-differences.md` document the
+  boundary.
+- **Refactor before**: named async groups, per-block chunk options, or full
+  split-point identity are implemented. Preserve the terminating worklist,
+  parent available-module intersections, nested split points, and cycle-safe
+  runtime traversal during the refactor.
+
+### DEV-002: JavaScript parser hooks are registered through Compilation
+
+- **Status**: Confirmed deviation.
+- **Performance-driven**: No. The constraint is current Rust ownership across
+  the asynchronous loader boundary.
+- **Webpack shape**: `SideEffectsFlagPlugin` reaches parser instances through
+  `NormalModuleFactory.hooks.parser`.
+- **Current shape**: plugins register an immutable
+  `JavascriptParserHookSet` on `CompilationHookSet`; Compilation transports the
+  plan through Make to each parser session.
+- **Confirmation**: ADR 0140 documents the ownership constraint, narrow
+  alternative, cache-key contract, and required tests.
+- **Refactor when**: Normal Module Factory owns parser creation or a public
+  parser-hook surface is introduced. Move registration to the webpack-equivalent
+  boundary without moving analysis policy into Make.
+
+### DEV-003: Cache lifecycle and serialization use typed Rust seams
+
+- **Status**: Confirmed deviation.
+- **Performance-driven**: No. The constraints are Rust typing, ownership, and
+  staged cache-plugin exposure.
+- **Webpack shape**: Cache behavior is composed through Tapable hooks, and
+  PackFile serialization is divided into reusable serializer and middleware
+  responsibilities.
+- **Current shape**: Compiler-owned `Cache` uses explicit lifecycle methods and
+  typed Cache Layers. The reusable Serializer is separate, while binary framing
+  and file/index persistence remain private Pack File responsibilities.
+- **Confirmation**: ADR 0131 and
+  `docs/implementation/webpack-implementation-differences.md` document these
+  boundaries.
+- **Refactor when**: public cache plugin hooks, Binary Middleware, or File
+  Middleware become implemented webpack surfaces. Do not reintroduce a separate
+  `BuildCache`, whole-Compilation cache, or whole-project fingerprint during the
+  refactor.
+
+## Resolved violations and alignment gaps
+
+### RES-001: Whole-Compilation warm cache shortcut
+
+- **Status**: Resolved violation.
+- **Performance-driven**: Yes.
+- **Introduced by**: [PR #76](https://github.com/unpack-dev/unpack/pull/76).
+- **Violation**: readonly warm builds could restore final Assets and watch
+  dependencies from a cached Compilation record without running Make, rebuilding
+  Module Graph and Chunk Graph, or running Code Generation. This replaced the
+  webpack-aligned compilation flow for benchmark performance and contradicted
+  ADR 0064's existing Cache Item boundary.
+- **Resolution**: [PR #81](https://github.com/unpack-dev/unpack/pull/81) removed
+  the shortcut. Each run now creates a fresh Compilation and graph while Resolve,
+  Module Build, Code Generation, Asset Render, and unaffected-module computations
+  are reused through their separate webpack-shaped boundaries.
+- **Regression guard**: the Rust compiler tests assert that repeated and aged
+  filesystem-cache runs reuse records without sharing a Compilation Graph; the
+  JavaScript persistent-cache contract asserts per-item restoration and
+  invalidation.
+
+### RES-002: Side-effects policy was placed in Make and Chunk Graph
+
+- **Status**: Resolved alignment gap; not an ADR 0141 violation because the
+  motivating change was feature implementation rather than performance.
+- **Previous shape**: Make read package metadata, `true` and `"flag"` were
+  collapsed, and `build_chunk_graph` decided side-effects connection activity.
+- **Resolution**: ADR 0138 required and the current implementation provides a
+  webpack-recognizable `SideEffectsFlagPlugin`, distinct provided-exports and
+  used-exports plugins, Module Graph connection state, and parser-hook analysis.
+- **Regression guard**: JavaScript comparison tests cover option distinctions,
+  package patterns, pure analysis, re-export redirection, and rule overrides.
+
+### RES-003: Cache was organized as a separate BuildCache architecture
+
+- **Status**: Resolved alignment gap; not an ADR 0141 violation because no
+  unconfirmed performance-driven replacement was identified.
+- **Previous shape**: reusable cache responsibilities lived under a separate
+  `BuildCache` type and source hierarchy.
+- **Resolution**: PR #224 aligned the cache source layout and PR #228
+  consolidated ownership into the Compiler-owned webpack `Cache` responsibility.
+  ADR 0131 records the current Cache, Cache Facade, Cache Layer, and Cache Item
+  boundaries.
+
+## Reviewed non-violations
+
+The initial audit explicitly reviewed the following performance-relevant
+techniques. They do not require separate confirmation while their listed
+webpack responsibility remains intact:
+
+- `FuturesUnordered`, Tokio tasks, a semaphore, sharded maps, and atomics in
+  Make and Cache preserve factorize, add, build, process-dependencies, Cache,
+  and Cache Facade responsibilities.
+- dense `ModuleHandle` storage, `IndexVec`, and `ModuleMask` preserve separate
+  Module Graph, Chunk Graph, and `buildChunkGraph` responsibilities; webpack's
+  Module ID and Chunk ID terms remain reserved for generated output identity.
+- inline Runtime Requirement and Runtime Module masks preserve named Runtime
+  Requirements, Runtime Modules, stages, prerequisite closure, and generated
+  runtime behavior.
+- Compiler-owned Module Computation Cache preserves webpack's unaffected-module
+  memoization boundary and remains separate from record-oriented and persistent
+  Cache Layers under ADR 0139.
+
+If a future optimization removes or merges one of those responsibilities, it
+must be reclassified as a proposed deviation and confirmed before implementation.

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -1,6 +1,11 @@
 # Webpack implementation differences
 
-This note compares the current Unpack implementation with the local webpack checkout at `/Users/bytedance/github/webpack` commit `10f5fccb2`. The goal is to identify gaps between current Unpack behavior and webpack so staged scope decisions can be separated from alignment gaps.
+This note compares current Unpack behavior with the repository-pinned
+`webpack@5.108.1` and current source-layout decisions with webpack commit
+`da91761ed92c8e133ee321c7db4ad6c4698cae0a`. The goal is to identify gaps
+between current Unpack behavior and webpack so staged scope decisions can be
+separated from alignment gaps. The central classification and refactoring index
+is `webpack-architecture-deviation-register.md`.
 
 ## Webpack alignment boundary
 
@@ -199,9 +204,10 @@ tracks (#140, #145, and #147). The JavaScript package entry remains ESM-only,
 while emitted entry assets intentionally use CommonJS startup. Render IDs are
 readable and deterministic with controlled churn, but are not a byte-for-byte
 webpack ID contract. Context modules, general CommonJS parsing/interop, broader
-loader rules and loader chains, plugins, tree shaking, module concatenation,
-browser loading targets, and other
-unimplemented options remain explicit unsupported surfaces.
+loader rules and loader chains, public JavaScript plugins, Inner Graph, module
+concatenation, browser loading targets, and other unimplemented options remain
+explicit unsupported surfaces. Provided-exports, used-exports, and Side Effects
+Flag Plugin responsibilities are implemented for the current ESM surface.
 
 ## ESM code generation
 
@@ -217,8 +223,12 @@ Webpack templates include additional behavior for used exports, inlined exports,
 Necessity:
 
 - Getter-based export bindings and import-usage rewrites are necessary for webpack-like ESM live binding semantics.
-- Always treating exports as used is a deliberate first implementation.
-- Full export usage pruning, ambiguous star export conflict handling, namespace/default interop, and module concatenation should be deferred until optimization or CommonJS interop becomes a goal.
+- The current provided-exports and used-exports plugins drive export getter
+  emission and side-effects connection optimization for the supported ESM
+  surface.
+- Inner Graph, broader export-usage semantics, ambiguous star export conflict
+  handling, namespace/default interop, and module concatenation should be
+  deferred until their corresponding webpack surfaces are chosen.
 
 ## Render IDs and filenames
 
@@ -241,10 +251,10 @@ Current staged scope limits:
 - Readable render IDs and semantic tests.
 - Byte-offset source ranges in Rust.
 
-Implementation gaps to resolve for current stated semantics:
-
-- Nested dynamic imports: async blocks discovered inside async chunks must create further async chunk groups.
-- Runtime requirements should either drive helper emission or be kept clearly internal until needed.
+Current documented architecture deviations and resolved violations are tracked
+in `webpack-architecture-deviation-register.md`. Nested dynamic imports and
+Runtime Requirement-driven helper emission are implemented and are no longer
+alignment gaps.
 
 Feature work to defer until explicitly chosen:
 
@@ -253,4 +263,4 @@ Feature work to defer until explicitly chosen:
 - Broader loader rules, loader chains, loader options, async loaders, and plugin API parity.
 - Magic comments, dynamic import modes, import attributes, deferred/source import phases.
 - Split chunks, cache groups, runtime chunks, HMR, browser/ESM/webworker chunk loading.
-- Export usage analysis, tree shaking, module concatenation, and deterministic id plugins.
+- Inner Graph, module concatenation, broader export-usage semantics, and deterministic id plugins.


### PR DESCRIPTION
## Summary

- add an ADR requiring explicit agreement before performance work diverges from webpack architecture
- add a central deviation register covering current confirmed deviations, resolved violations, refactoring triggers, and reviewed Rust-native techniques
- refresh stale webpack implementation-difference classifications for nested dynamic imports, runtime requirements, and tree-shaking support

## Why

Performance optimization must not silently replace webpack-aligned responsibilities or compilation flow. The register preserves the historical whole-Compilation cache violation, records why it was invalid, and gives future refactors an explicit source of truth for accepted boundaries.

## Impact

This is documentation-only and does not change runtime behavior. Future architecture-changing performance proposals now have a defined confirmation and recording process.

Checks: `cargo test --workspace`; JavaScript core tests with Node's forced test-runner exit (129 passed, 1 Linux-only skip); benchmark tests (21 passed).
