### PR TITLE
Add timeout to CI test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   tests:
     name: Run tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary

- cap the CI test job at 15 minutes
- prevent hung test processes from occupying runners indefinitely

## Context

Recent CI runs remained active for hours after test output stopped, causing later workflows to queue behind them. This timeout limits the impact of future hangs while the underlying loader lifecycle issue is handled separately.

The workflow continues to parse as valid YAML, and the committed diff passes whitespace checks.