### PR TITLE
Avoid cloning ModuleGraph for finishModules hooks

### DIFF
--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -81,6 +81,19 @@ impl Compilation {
         &mut self.module_graph
     }
 
+    /// Temporarily detaches the module graph for a host hook that takes
+    /// ownership of it. The caller must restore the graph before compilation
+    /// continues.
+    pub fn take_module_graph(&mut self) -> ModuleGraph {
+        std::mem::take(&mut self.module_graph)
+    }
+
+    /// Restores a module graph previously detached by `take_module_graph`.
+    pub fn restore_module_graph(&mut self, module_graph: ModuleGraph) {
+        debug_assert!(self.module_graph.modules().is_empty());
+        self.module_graph = module_graph;
+    }
+
     pub(crate) fn module_computation_cache(&self) -> Option<&ModuleComputationCache> {
         self.module_computation_cache.as_ref()
     }

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -733,7 +733,7 @@ impl Compiler {
             }
             compilation.make().await?;
             if let Some(hooks) = &self.options.compilation_hooks {
-                hooks.finish_modules(&compilation).await?;
+                hooks.finish_modules(&mut compilation).await?;
             }
             compilation.seal();
             Ok(compilation)

--- a/crates/unpack_core/src/hooks.rs
+++ b/crates/unpack_core/src/hooks.rs
@@ -9,5 +9,5 @@ pub type HookFuture<'a> = Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
 /// Host callbacks invoked at webpack-compatible compilation boundaries.
 pub trait CompilationHooks: Debug + Send + Sync {
     fn compilation<'a>(&'a self, compilation: &'a Compilation) -> HookFuture<'a>;
-    fn finish_modules<'a>(&'a self, compilation: &'a Compilation) -> HookFuture<'a>;
+    fn finish_modules<'a>(&'a self, compilation: &'a mut Compilation) -> HookFuture<'a>;
 }

--- a/crates/unpack_core/src/module_graph.rs
+++ b/crates/unpack_core/src/module_graph.rs
@@ -76,6 +76,7 @@ impl ModuleGraph {
             origin_block,
             origin_dependency_index,
             dependency,
+            resolved_module: module,
             module,
             state: ModuleGraphConnectionState::Active,
         });

--- a/crates/unpack_core/src/module_graph_connection.rs
+++ b/crates/unpack_core/src/module_graph_connection.rs
@@ -22,6 +22,7 @@ pub struct ModuleGraphConnection {
     pub origin_block: Option<AsyncDependenciesBlockIndex>,
     pub origin_dependency_index: Option<DependencyIndex>,
     pub dependency: Dependency,
+    pub resolved_module: ModuleHandle,
     pub module: ModuleHandle,
     pub(crate) state: ModuleGraphConnectionState,
 }

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -214,6 +214,8 @@ pub struct NativeModuleGraphConnection {
     pub origin_module_handle: Option<u32>,
     #[napi(js_name = "moduleHandle")]
     pub module_handle: u32,
+    #[napi(js_name = "resolvedModuleHandle")]
+    pub resolved_module_handle: u32,
     #[napi(js_name = "dependencyType")]
     pub dependency_type: String,
     pub request: Option<String>,
@@ -990,6 +992,7 @@ fn native_module_graph_connection(
         handle: connection.handle.index().try_into().unwrap_or(u32::MAX),
         origin_module_handle: connection.origin_module.map(native_module_handle),
         module_handle: native_module_handle(connection.module),
+        resolved_module_handle: native_module_handle(connection.resolved_module),
         dependency_type: dependency_type(&connection.dependency).to_string(),
         request: connection.dependency.request().map(str::to_string),
         weak: dependency_is_weak(&connection.dependency),

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -328,12 +328,47 @@ impl NativeCompilation {
             .collect())
     }
 
-    #[napi]
-    pub fn connections(&self) -> Result<Vec<NativeModuleGraphConnection>> {
-        Ok(self
-            .module_graph()?
-            .connections()
-            .iter()
+    #[napi(js_name = "outgoingConnections")]
+    pub fn outgoing_connections(
+        &self,
+        module_handle: u32,
+    ) -> Result<Vec<NativeModuleGraphConnection>> {
+        let module_graph = self.module_graph()?;
+        let module_handle = unpack_core::ModuleHandle::new(module_handle as usize);
+        if module_graph.module(module_handle).is_none() {
+            return Ok(Vec::new());
+        }
+        Ok(module_graph
+            .outgoing_connections(module_handle)
+            .map(native_module_graph_connection)
+            .collect())
+    }
+
+    #[napi(js_name = "incomingConnections")]
+    pub fn incoming_connections(
+        &self,
+        module_handle: u32,
+    ) -> Result<Vec<NativeModuleGraphConnection>> {
+        let module_graph = self.module_graph()?;
+        let module_handle = unpack_core::ModuleHandle::new(module_handle as usize);
+        if module_graph.module(module_handle).is_none() {
+            return Ok(Vec::new());
+        }
+        Ok(module_graph
+            .incoming_connections(module_handle)
+            .map(native_module_graph_connection)
+            .collect())
+    }
+
+    #[napi(js_name = "connectionsByHandle")]
+    pub fn connections_by_handle(
+        &self,
+        connection_handles: Vec<u32>,
+    ) -> Result<Vec<NativeModuleGraphConnection>> {
+        let module_graph = self.module_graph()?;
+        Ok(connection_handles
+            .into_iter()
+            .filter_map(|handle| module_graph.connections().get(handle as usize))
             .map(native_module_graph_connection)
             .collect())
     }

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -260,48 +260,89 @@ pub struct NativeRunResult {
 
 #[napi]
 pub struct NativeCompilation {
-    module_graph: Arc<unpack_core::ModuleGraph>,
-    chunk_graph: Arc<unpack_core::ChunkGraph>,
+    module_graph: NativeModuleGraph,
+    chunk_graph: unpack_core::ChunkGraph,
+}
+
+enum NativeModuleGraph {
+    Owned(unpack_core::ModuleGraph),
+    Leased {
+        module_graph: unpack_core::ModuleGraph,
+        return_sender: tokio::sync::oneshot::Sender<unpack_core::ModuleGraph>,
+    },
+    Released,
+}
+
+impl NativeCompilation {
+    fn module_graph(&self) -> Result<&unpack_core::ModuleGraph> {
+        match &self.module_graph {
+            NativeModuleGraph::Owned(module_graph)
+            | NativeModuleGraph::Leased { module_graph, .. } => Ok(module_graph),
+            NativeModuleGraph::Released => Err(napi::Error::from_reason(
+                "native compilation graph lease has been released",
+            )),
+        }
+    }
+
+    fn return_module_graph_lease(&mut self) -> Result<()> {
+        let state = std::mem::replace(&mut self.module_graph, NativeModuleGraph::Released);
+        let NativeModuleGraph::Leased {
+            module_graph,
+            return_sender,
+        } = state
+        else {
+            self.module_graph = state;
+            return Err(napi::Error::from_reason(
+                "native compilation does not hold a module graph lease",
+            ));
+        };
+        return_sender.send(module_graph).map_err(|module_graph| {
+            self.module_graph = NativeModuleGraph::Owned(module_graph);
+            napi::Error::from_reason("native compilation graph lease receiver was dropped")
+        })
+    }
+}
+
+impl Drop for NativeCompilation {
+    fn drop(&mut self) {
+        let state = std::mem::replace(&mut self.module_graph, NativeModuleGraph::Released);
+        if let NativeModuleGraph::Leased {
+            module_graph,
+            return_sender,
+        } = state
+        {
+            let _ = return_sender.send(module_graph);
+        }
+    }
 }
 
 #[napi]
 impl NativeCompilation {
     #[napi]
-    pub fn modules(&self) -> Vec<NativeModule> {
-        self.module_graph
+    pub fn modules(&self) -> Result<Vec<NativeModule>> {
+        Ok(self
+            .module_graph()?
             .modules()
             .iter()
             .map(native_module)
-            .collect()
-    }
-
-    #[napi(js_name = "incomingConnections")]
-    pub fn incoming_connections(&self, module_handle: u32) -> Vec<NativeModuleGraphConnection> {
-        let module_handle = unpack_core::ModuleHandle::new(module_handle as usize);
-        if self.module_graph.module(module_handle).is_none() {
-            return Vec::new();
-        }
-        self.module_graph
-            .incoming_connections(module_handle)
-            .map(native_module_graph_connection)
-            .collect()
-    }
-
-    #[napi(js_name = "outgoingConnections")]
-    pub fn outgoing_connections(&self, module_handle: u32) -> Vec<NativeModuleGraphConnection> {
-        let module_handle = unpack_core::ModuleHandle::new(module_handle as usize);
-        if self.module_graph.module(module_handle).is_none() {
-            return Vec::new();
-        }
-        self.module_graph
-            .outgoing_connections(module_handle)
-            .map(native_module_graph_connection)
-            .collect()
+            .collect())
     }
 
     #[napi]
-    pub fn chunks(&self) -> Vec<NativeChunk> {
-        self.chunk_graph
+    pub fn connections(&self) -> Result<Vec<NativeModuleGraphConnection>> {
+        Ok(self
+            .module_graph()?
+            .connections()
+            .iter()
+            .map(native_module_graph_connection)
+            .collect())
+    }
+
+    #[napi]
+    pub fn chunks(&self) -> Result<Vec<NativeChunk>> {
+        self.module_graph()?;
+        Ok(self
+            .chunk_graph
             .chunks()
             .iter()
             .map(|chunk| NativeChunk {
@@ -309,46 +350,56 @@ impl NativeCompilation {
                 name: chunk.name().map(str::to_string),
                 render_id: native_render_id(chunk.render_id_string(), chunk.render_id_number()),
             })
-            .collect()
+            .collect())
     }
 
     #[napi(js_name = "chunkModules")]
-    pub fn chunk_modules(&self, chunk_handle: u32) -> Vec<u32> {
+    pub fn chunk_modules(&self, chunk_handle: u32) -> Result<Vec<u32>> {
+        self.module_graph()?;
         let chunk_handle = unpack_core::ChunkHandle::new(chunk_handle as usize);
         if self.chunk_graph.chunk(chunk_handle).is_none() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
-        self.chunk_graph
+        Ok(self
+            .chunk_graph
             .chunk_modules(chunk_handle)
             .iter()
             .copied()
             .map(native_module_handle)
-            .collect()
+            .collect())
     }
 
     #[napi(js_name = "moduleChunks")]
-    pub fn module_chunks(&self, module_handle: u32) -> Vec<u32> {
+    pub fn module_chunks(&self, module_handle: u32) -> Result<Vec<u32>> {
+        let module_graph = self.module_graph()?;
         let module_handle = unpack_core::ModuleHandle::new(module_handle as usize);
-        if self.module_graph.module(module_handle).is_none() {
-            return Vec::new();
+        if module_graph.module(module_handle).is_none() {
+            return Ok(Vec::new());
         }
-        self.chunk_graph
+        Ok(self
+            .chunk_graph
             .module_chunks(module_handle)
             .iter()
             .map(|chunk| chunk.index().try_into().unwrap_or(u32::MAX))
-            .collect()
+            .collect())
     }
 
     #[napi(js_name = "moduleId")]
-    pub fn module_id(&self, module_handle: u32) -> Option<Either<String, u32>> {
+    pub fn module_id(&self, module_handle: u32) -> Result<Option<Either<String, u32>>> {
+        let module_graph = self.module_graph()?;
         let module_handle = unpack_core::ModuleHandle::new(module_handle as usize);
-        if self.module_graph.module(module_handle).is_none() {
-            return None;
+        if module_graph.module(module_handle).is_none() {
+            return Ok(None);
         }
-        native_render_id(
+        Ok(native_render_id(
             self.chunk_graph.module_render_id_string(module_handle),
             self.chunk_graph.module_render_id_number(module_handle),
-        )
+        ))
+    }
+
+    #[napi(js_name = "returnModuleGraphLease")]
+    pub fn return_module_graph_lease_to_compiler(&mut self) -> Result<()> {
+        self.return_module_graph_lease()
     }
 }
 
@@ -441,18 +492,21 @@ impl CompilationHooks for NativeCompilationHooks {
         call_compilation_hook(Arc::clone(&self.compilation), compilation)
     }
 
-    fn finish_modules<'a>(&'a self, compilation: &'a unpack_core::Compilation) -> HookFuture<'a> {
-        call_compilation_hook(Arc::clone(&self.finish_modules), compilation)
+    fn finish_modules<'a>(
+        &'a self,
+        compilation: &'a mut unpack_core::Compilation,
+    ) -> HookFuture<'a> {
+        call_finish_modules_hook(Arc::clone(&self.finish_modules), compilation)
     }
 }
 
 fn call_compilation_hook<'a>(
     callback: Arc<NativeFinishModulesCallback>,
-    compilation: &'a unpack_core::Compilation,
+    _compilation: &'a unpack_core::Compilation,
 ) -> HookFuture<'a> {
     let native_compilation = NativeCompilation {
-        module_graph: Arc::new(compilation.module_graph().clone()),
-        chunk_graph: Arc::new(unpack_core::ChunkGraph::default()),
+        module_graph: NativeModuleGraph::Owned(unpack_core::ModuleGraph::default()),
+        chunk_graph: unpack_core::ChunkGraph::default(),
     };
     Box::pin(async move {
         let promise = callback
@@ -464,6 +518,37 @@ fn call_compilation_hook<'a>(
         promise.await.map_err(|error| CoreError::Hook {
             message: error.to_string(),
         })
+    })
+}
+
+fn call_finish_modules_hook<'a>(
+    callback: Arc<NativeFinishModulesCallback>,
+    compilation: &'a mut unpack_core::Compilation,
+) -> HookFuture<'a> {
+    let module_graph = compilation.take_module_graph();
+    let (return_sender, return_receiver) = tokio::sync::oneshot::channel();
+    let native_compilation = NativeCompilation {
+        module_graph: NativeModuleGraph::Leased {
+            module_graph,
+            return_sender,
+        },
+        chunk_graph: unpack_core::ChunkGraph::default(),
+    };
+    Box::pin(async move {
+        let callback_result = match callback.call_async_catch(native_compilation).await {
+            Ok(promise) => promise.await.map_err(|error| CoreError::Hook {
+                message: error.to_string(),
+            }),
+            Err(error) => Err(CoreError::Hook {
+                message: error.to_string(),
+            }),
+        };
+
+        let module_graph = return_receiver.await.map_err(|error| CoreError::Hook {
+            message: format!("finishModules did not return the module graph lease: {error}"),
+        })?;
+        compilation.restore_module_graph(module_graph);
+        callback_result
     })
 }
 
@@ -847,8 +932,8 @@ async fn run_compiler_inner(
         error: None,
         stats: Some(stats),
         compilation: Some(NativeCompilation {
-            module_graph: Arc::new(module_graph),
-            chunk_graph: Arc::new(chunk_graph),
+            module_graph: NativeModuleGraph::Owned(module_graph),
+            chunk_graph,
         }),
         logs,
     }

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -37,10 +37,13 @@ The Node adapter moves the completed Module Graph into the awaited
 `finishModules` callback and requires the callback wrapper to return that graph
 before Rust continues into `seal`. This avoids cloning the full graph at the
 native seam. Before returning ownership, the JavaScript wrapper materializes
-the lightweight module and connection view used by its webpack-shaped graph,
-so a retained `Compilation` remains queryable while Rust seals the graph. The
-final native graph is then rebound to the same JavaScript `Compilation`, and
-connection targets plus phase-dependent caches are refreshed in place.
+the module wrappers required by the hook, while Module Graph connections cross
+the native boundary lazily in per-module batches. Once the awaited hook has
+settled, graph queries from detached JavaScript work fail with an expired-lease
+error while Rust seals instead of reading a raw pointer concurrently. The final
+native graph is then rebound to the same JavaScript `Compilation`; already
+materialized connection targets are refreshed by handle and phase-dependent
+caches are invalidated in place.
 
 ## Cache layout
 

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -39,11 +39,12 @@ before Rust continues into `seal`. This avoids cloning the full graph at the
 native seam. Before returning ownership, the JavaScript wrapper materializes
 the module wrappers required by the hook, while Module Graph connections cross
 the native boundary lazily in per-module batches. Once the awaited hook has
-settled, graph queries from detached JavaScript work fail with an expired-lease
-error while Rust seals instead of reading a raw pointer concurrently. The final
-native graph is then rebound to the same JavaScript `Compilation`; already
-materialized connection targets are refreshed by handle and phase-dependent
-caches are invalidated in place.
+settled, queries from detached JavaScript work that require another native
+graph read fail with an expired-lease error while Rust seals instead of reading
+a raw pointer concurrently. Purely materialized JavaScript records remain
+ordinary values. The final native graph is then rebound to the same JavaScript
+`Compilation`; already materialized connection targets are refreshed by handle
+and phase-dependent caches are invalidated in place.
 
 ## Cache layout
 

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -33,6 +33,15 @@ Necessity:
   results deliberately belong to one `Compilation`; they are not a persistent
   cache boundary.
 
+The Node adapter moves the completed Module Graph into the awaited
+`finishModules` callback and requires the callback wrapper to return that graph
+before Rust continues into `seal`. This avoids cloning the full graph at the
+native seam. Before returning ownership, the JavaScript wrapper materializes
+the lightweight module and connection view used by its webpack-shaped graph,
+so a retained `Compilation` remains queryable while Rust seals the graph. The
+final native graph is then rebound to the same JavaScript `Compilation`, and
+connection targets plus phase-dependent caches are refreshed in place.
+
 ## Cache layout
 
 Unpack's top-level `cache` and `cache_facade` modules map to webpack's root

--- a/docs/research/rspack-live-compilation-module-graph-binding.md
+++ b/docs/research/rspack-live-compilation-module-graph-binding.md
@@ -158,8 +158,7 @@ Sources:
 
 ## Implications for Unpack's ownership handoff
 
-The uncommitted Unpack design is more conservative than Rspack in the right
-place:
+The current Unpack design is more conservative than Rspack in the right place:
 
 1. Rust moves the `ModuleGraph` into a phase-scoped native lease before calling
    JS. The compiler cannot access the graph while JS owns it, so the awaited
@@ -169,10 +168,11 @@ place:
    `'static` graph reference.
 3. The TypeScript wrapper materializes the modules required by the hook, then
    requests incoming or outgoing connections in per-module batches only when a
-   graph API reads them. After the hook settles, detached graph queries fail
-   with an expired-lease error while Rust seals. Later `done` rebinds the final
-   native graph and refreshes already-materialized connections by stable handle
-   on the same JS object.
+   graph API reads them. After the hook settles, detached queries that need
+   another native graph read fail with an expired-lease error while Rust seals;
+   purely materialized JavaScript records remain readable. Later `done` rebinds
+   the final native graph and refreshes already-materialized connections by
+   stable handle on the same JS object.
 
 The cost profile differs:
 

--- a/docs/research/rspack-live-compilation-module-graph-binding.md
+++ b/docs/research/rspack-live-compilation-module-graph-binding.md
@@ -16,10 +16,10 @@ pipeline, so this is a zero-clone, phase-serialized live view during the hook.
 That implementation validates the main performance premise behind Unpack's
 current ownership handoff: no full graph clone is required merely to service an
 awaited hook. It does not, however, provide a memory-safe pattern worth copying.
-Unpack should keep the ownership-handoff design and its post-hook JS-owned view.
-The main follow-up is to measure and reduce the new eager O(modules +
-connections) N-API materialization cost, because Rspack normally fetches graph
-data lazily.
+Unpack should keep the ownership-handoff design and fetch graph connections in
+lazy per-module batches. This avoids the eager O(modules + connections) N-API
+materialization cost while preserving a checked lifetime boundary instead of
+copying Rspack's raw pointer.
 
 ## Rust ownership and storage
 
@@ -167,20 +167,21 @@ place:
 2. A `finally` path returns the graph before seal continues, and native `Drop`
    is a fallback return path. Unlike Rspack, no raw pointer is exposed as a
    `'static` graph reference.
-3. Before releasing the native lease, the TypeScript wrapper materializes the
-   modules and connections it needs to remain queryable during seal. Later
-   `done` rebinds the final native graph and refreshes phase-dependent data on
-   the same JS object. This gives retained-object semantics intentionally,
-   rather than as an unchecked consequence of a compiler-field pointer.
+3. The TypeScript wrapper materializes the modules required by the hook, then
+   requests incoming or outgoing connections in per-module batches only when a
+   graph API reads them. After the hook settles, detached graph queries fail
+   with an expired-lease error while Rust seals. Later `done` rebinds the final
+   native graph and refreshes already-materialized connections by stable handle
+   on the same JS object.
 
 The cost profile differs:
 
 - Rspack: O(1) to expose the handle; graph records cross N-API lazily per JS
   query; unsafe lifetime/concurrency assumptions remain.
-- Current Unpack handoff: O(1) Rust graph move, but O(modules + connections) to
-  create/update the persistent JS view at `finishModules`, plus another
-  synchronization at final rebinding; no deep Rust graph clone and no live raw
-  pointer.
+- Current Unpack handoff: O(1) Rust graph move, O(modules) to expose the hook's
+  module set, and O(accessed connections) in lazy per-module batches. Final
+  rebinding refreshes only connection handles that JavaScript already
+  materialized; there is no deep Rust graph clone or live raw pointer.
 
 For this repository, keep the Unpack design. Do not replace it with Rspack's
 `NonNull<Compilation>` approach merely to match Rspack. The safer ownership
@@ -192,14 +193,13 @@ Before considering the clone problem closed, benchmark these separately on a
 large graph:
 
 1. the old Rust `ModuleGraph::clone()` time and peak memory;
-2. the new `connections()` DTO allocation and N-API conversion time;
+2. lazy incoming/outgoing connection DTO allocation and N-API conversion time;
 3. JS `ModuleGraphConnectionImpl` allocation/indexing time;
-4. the second full connection synchronization at final rebinding.
+4. materialized-handle synchronization at final rebinding.
 
-If eager JS materialization is still expensive, optimize the representation
-(batched compact arrays, fewer strings, stable handles, and in-place target
-patches) rather than reintroducing a raw live pointer. The semantic requirement
-to answer arbitrary graph queries while the native lease has returned means
-the retained JS view must own enough information; that O(graph size) data
-movement can be compressed and batched, but it cannot be made O(1) without
-weakening retained-query behavior or introducing another shared snapshot.
+If lazy JS materialization is still expensive under full-graph traversal,
+optimize the representation (compact arrays, fewer strings, stable handles,
+and in-place target patches) rather than reintroducing a raw live pointer. A
+plugin that detaches work beyond its awaited hook receives an explicit expired
+lease error until the final compilation is rebound; `done` and later supported
+lifecycle surfaces see the final graph normally.

--- a/docs/research/rspack-live-compilation-module-graph-binding.md
+++ b/docs/research/rspack-live-compilation-module-graph-binding.md
@@ -1,0 +1,205 @@
+# Rspack live `Compilation` / `ModuleGraph` binding assessment
+
+## Scope and conclusion
+
+This note checks Rspack commit
+[`cd0781da31eaf107b64eaee8a55db4296527dcb5`](https://github.com/web-infra-dev/rspack/commit/cd0781da31eaf107b64eaee8a55db4296527dcb5),
+the repository `HEAD` observed on 2026-07-12.
+
+Rspack does not clone its Rust `ModuleGraph` for `finishModules`, put it behind
+an `Arc<RwLock<_>>`, or transfer graph ownership to the Node binding. Its JS
+binding holds an unsafe, non-owning pointer to the compiler-owned
+`Compilation`; each JS graph query follows that pointer to the current Rust
+graph. Rspack awaits the JS `finishModules` promise before advancing the Rust
+pipeline, so this is a zero-clone, phase-serialized live view during the hook.
+
+That implementation validates the main performance premise behind Unpack's
+current ownership handoff: no full graph clone is required merely to service an
+awaited hook. It does not, however, provide a memory-safe pattern worth copying.
+Unpack should keep the ownership-handoff design and its post-hook JS-owned view.
+The main follow-up is to measure and reduce the new eager O(modules +
+connections) N-API materialization cost, because Rspack normally fetches graph
+data lazily.
+
+## Rust ownership and storage
+
+Rspack's `Compiler` directly owns one `Compilation` as a struct field; there is
+no `Arc<Compilation>` in this ownership chain. The `Compilation` contains a
+`StealCell<BuildModuleGraphArtifact>`, and that artifact directly owns the
+`ModuleGraph`. `Compilation::get_module_graph()` and
+`get_module_graph_mut()` return ordinary references into the artifact.
+
+Sources:
+
+- [`Compiler` owns `Compilation`](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_core/src/compiler/mod.rs#L85-L104)
+- [`Compilation` owns the build-module-graph artifact](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_core/src/compilation/mod.rs#L303-L310)
+- [`BuildModuleGraphArtifact` owns `ModuleGraph`](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs#L16-L37)
+- [ordinary immutable and mutable graph accessors](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_core/src/compilation/mod.rs#L460-L479)
+
+Rspack does use rollback/overlay containers inside `ModuleGraph`, but for
+incremental recovery across make/seal mutations. The source explicitly
+classifies fields by make-phase and seal-phase mutation and places graph-module
+and connection records in overlay maps. This is not the Node-binding mechanism
+and does not create a per-JS-hook graph snapshot.
+
+Source:
+
+- [module-graph rollback/overlay classification and storage](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_core/src/module_graph/mod.rs#L100-L152)
+
+## How the N-API binding exposes the graph
+
+The native `JsCompilation` stores `NonNull<Compilation>`. Its `as_ref()` and
+`as_mut()` methods unsafely turn that pointer into `'static` Rust references,
+with a comment relying on the `Compiler` not being dropped and its field address
+not changing. `JsModuleGraph` independently stores the same kind of
+`NonNull<Compilation>` and resolves `compilation.get_module_graph()` afresh for
+every call. It rejects access only while the build-module-graph artifact has
+been temporarily stolen.
+
+Sources:
+
+- [`JsCompilation` raw pointer and unsafe `'static` references](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_binding_api/src/compilation/mod.rs#L44-L67)
+- [`JsCompilation.moduleGraph` constructs a pointer-backed `JsModuleGraph`](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_binding_api/src/compilation/mod.rs#L751-L760)
+- [`JsModuleGraph` pointer storage and per-call graph lookup](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_binding_api/src/module_graph.rs#L14-L39)
+- [example live connection query](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_binding_api/src/module_graph.rs#L181-L203)
+
+The TypeScript `Compilation` constructs its `moduleGraph` once from that native
+binding. `ModuleGraph` methods are thin delegates to native methods; they do not
+hold a materialized JS copy of the full graph. The `Compilation.modules` getter
+also requests the native module list each time and then wraps it in a new JS
+`Set`.
+
+Sources:
+
+- [TypeScript `Compilation` retains the native-backed graph wrapper](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/packages/rspack/src/Compilation.ts#L450-L465)
+- [live `modules` getter](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/packages/rspack/src/Compilation.ts#L521-L526)
+- [`ModuleGraph` delegates queries to the binding](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/packages/rspack/src/ModuleGraph.ts#L6-L70)
+
+There is therefore no graph clone or graph-level lock on this JS query path.
+The binding cost is paid by the particular query: module lists and connection
+arrays are converted to JS values as requested.
+
+## `finishModules` timing
+
+Rspack's pass order is build-module-graph, `finishModules`, then seal and the
+later optimization/chunk/code-generation passes. The `finishModules` source
+describes the topology (modules, connections, dependencies) as frozen at this
+boundary, then awaits all hook taps before continuing.
+
+Sources:
+
+- [pass order](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_core/src/compilation/run_passes.rs#L17-L50)
+- [`finishModules` boundary and awaited hook call](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_core/src/compilation/finish_modules/mod.rs#L111-L129)
+
+The Node adapter creates a pointer wrapper for the existing `&Compilation` and
+awaits `call_with_promise`. On the TypeScript side, the adapter invokes the
+existing current `Compilation` object's `finishModules` hook and supplies its
+live `modules` getter. No graph or compilation snapshot is passed through this
+hook seam.
+
+Sources:
+
+- [binding tap awaits the JS promise with a pointer wrapper](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_binding_api/src/plugins/interceptor.rs#L1298-L1325)
+- [TypeScript finish-modules adapter](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/packages/rspack/src/taps/compilation.ts#L303-L317)
+
+Consequently, an async `finishModules` tap can query the live graph for its
+whole awaited duration while the Rust pass runner is paused. This is the useful
+part of Rspack's design for Unpack to mirror.
+
+## Retained `Compilation` behavior and safety boundary
+
+Within one compilation, Rspack preserves JS object identity. A thread-local
+weak-reference map keyed by `CompilationId` returns the same native
+`JsCompilation` object each time Rust crosses into JS. TypeScript likewise
+stores the current `Compilation`, and later hooks such as `done` receive that
+same TypeScript object. Because core mutates the same compiler-owned
+`Compilation` throughout all passes, a retained JS object queries later live
+seal/done state rather than a `finishModules` snapshot.
+
+Sources:
+
+- [native per-compilation wrapper identity cache](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_binding_api/src/compilation/mod.rs#L1025-L1077)
+- [core runs every pass against the same compiler field](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_core/src/compiler/mod.rs#L297-L326)
+- [TypeScript creates/caches the current `Compilation`](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/packages/rspack/src/Compiler.ts#L882-L897)
+- [`done` receives the compilation returned by that build](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/packages/rspack/src/Compiler.ts#L577-L614)
+
+The tradeoff is explicit unsafe lifetime management, not ownership. The binding
+transmutes a mutable compiler reference to `'static`, keeps the JS compiler
+alive with a N-API `Reference`, and rejects a second concurrent compiler run.
+Its own safety comment says access beyond the compiler state guard can create a
+race. There is no phase token, compilation-id check, `RwLock`, or borrow guard
+on ordinary `JsCompilation` / `JsModuleGraph` reads.
+
+Source:
+
+- [binding run guard, unsafe lifetime extension, and concurrent-run check](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_binding_api/src/lib.rs#L485-L520)
+
+This means Rspack's normal plugin discipline is part of the safety model:
+query during the hook Rust is awaiting. If a plugin retains the object, lets an
+async hook resolve, and later queries it from unrelated scheduled JS work while
+Rust is advancing another async pass, the raw-pointer API itself does not
+serialize that read with Rust mutation. This is an inference from the cited
+pointer and pass-runner code, not a documented Rspack guarantee or a claim that
+a known race is reproducible in every runtime configuration.
+
+Rebuilds create a new `Compilation` and use `mem::replace` on the compiler's
+field, while the binding removes only its weak identity-cache entry. Since
+`JsCompilation::as_ref()` does not validate its stored `CompilationId`, an old
+user-retained wrapper is not an immutable old-compilation snapshot. At minimum,
+cross-rebuild retention is outside the semantics established by this binding;
+from the source layout, its pointer continues to address the compiler field
+that now contains the next compilation. This is also a source-based inference.
+
+Sources:
+
+- [rebuild replaces the compiler-owned compilation in place](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_core/src/compiler/rebuild.rs#L95-L115)
+- [binding cleanup removes wrapper caches](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_binding_api/src/lib.rs#L519-L530)
+- [`as_ref()` dereferences without an ID/phase check](https://github.com/web-infra-dev/rspack/blob/cd0781da31eaf107b64eaee8a55db4296527dcb5/crates/rspack_binding_api/src/compilation/mod.rs#L51-L67)
+
+## Implications for Unpack's ownership handoff
+
+The uncommitted Unpack design is more conservative than Rspack in the right
+place:
+
+1. Rust moves the `ModuleGraph` into a phase-scoped native lease before calling
+   JS. The compiler cannot access the graph while JS owns it, so the awaited
+   hook is zero-clone and safe without a lock.
+2. A `finally` path returns the graph before seal continues, and native `Drop`
+   is a fallback return path. Unlike Rspack, no raw pointer is exposed as a
+   `'static` graph reference.
+3. Before releasing the native lease, the TypeScript wrapper materializes the
+   modules and connections it needs to remain queryable during seal. Later
+   `done` rebinds the final native graph and refreshes phase-dependent data on
+   the same JS object. This gives retained-object semantics intentionally,
+   rather than as an unchecked consequence of a compiler-field pointer.
+
+The cost profile differs:
+
+- Rspack: O(1) to expose the handle; graph records cross N-API lazily per JS
+  query; unsafe lifetime/concurrency assumptions remain.
+- Current Unpack handoff: O(1) Rust graph move, but O(modules + connections) to
+  create/update the persistent JS view at `finishModules`, plus another
+  synchronization at final rebinding; no deep Rust graph clone and no live raw
+  pointer.
+
+For this repository, keep the Unpack design. Do not replace it with Rspack's
+`NonNull<Compilation>` approach merely to match Rspack. The safer ownership
+boundary is worth the explicit code, and it better supports the repository's
+tested requirement that a retained compilation remain usable across later
+phases.
+
+Before considering the clone problem closed, benchmark these separately on a
+large graph:
+
+1. the old Rust `ModuleGraph::clone()` time and peak memory;
+2. the new `connections()` DTO allocation and N-API conversion time;
+3. JS `ModuleGraphConnectionImpl` allocation/indexing time;
+4. the second full connection synchronization at final rebinding.
+
+If eager JS materialization is still expensive, optimize the representation
+(batched compact arrays, fewer strings, stable handles, and in-place target
+patches) rather than reintroducing a raw live pointer. The semantic requirement
+to answer arbitrary graph queries while the native lease has returned means
+the retained JS view must own enough information; that O(graph size) data
+movement can be compressed and batched, but it cannot be made O(1) without
+weakening retained-query behavior or introducing another shared snapshot.

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -498,6 +498,7 @@ interface NativeModuleGraphConnection {
   handle: number;
   originModuleHandle?: number | null;
   moduleHandle: number;
+  resolvedModuleHandle: number;
   dependencyType?: string;
   dependency_type?: string;
   request?: string | null;
@@ -1833,6 +1834,10 @@ class ModuleGraphImpl implements ModuleGraph {
     const origin = originHandle == null
       ? null
       : this.#modulesByHandle.get(originHandle) ?? null;
+    const resolvedTarget = this.#modulesByHandle.get(
+      nativeConnection.resolvedModuleHandle
+    );
+    if (!resolvedTarget) return undefined;
     const dependency = new DependencyImpl(
       nativeConnection.dependencyType ?? nativeConnection.dependency_type ?? "unknown",
       nativeConnection.request ?? undefined,
@@ -1842,9 +1847,10 @@ class ModuleGraphImpl implements ModuleGraph {
     const connection = new ModuleGraphConnectionImpl(
       origin,
       dependency,
-      target,
+      resolvedTarget,
       nativeConnection.weak
     );
+    connection.updateModule(target);
     this.#connectionByHandle.set(nativeConnection.handle, connection);
     this.#connectionByDependency.set(dependency, connection);
     addToSetMap(this.#incoming, target, connection);

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -474,12 +474,12 @@ interface NativeStatsJson {
 
 interface NativeCompilation {
   modules(): NativeModule[];
-  incomingConnections(moduleHandle: number): NativeModuleGraphConnection[];
-  outgoingConnections(moduleHandle: number): NativeModuleGraphConnection[];
+  connections(): NativeModuleGraphConnection[];
   chunks(): NativeChunk[];
   chunkModules(chunkHandle: number): number[];
   moduleChunks(moduleHandle: number): number[];
   moduleId(moduleHandle: number): string | number | null;
+  returnModuleGraphLease(): void;
 }
 
 interface NativeModule {
@@ -908,13 +908,19 @@ class CompilerImpl implements Compiler {
         }
       },
       async (nativeCompilation) => {
+        const compilation = this.#activeCompilation ?? new CompilationImpl(nativeCompilation);
         try {
-          const compilation = this.#activeCompilation ?? new CompilationImpl(nativeCompilation);
           compilation.update(nativeCompilation);
           await compilation.hooks.finishModules.promise(compilation.modules);
         } catch (error) {
           this.#nativeHookError = toError(error, "HookError");
           throw this.#nativeHookError;
+        } finally {
+          try {
+            nativeCompilation.returnModuleGraphLease();
+          } finally {
+            compilation.releaseNativeCompilation();
+          }
         }
       }
     );
@@ -1624,15 +1630,25 @@ class ModuleGraphConnectionImpl implements ModuleGraphConnection {
   readonly conditional = false as const;
   readonly active = true;
   readonly explanations: ReadonlySet<string> = new Set();
+  #module: Module;
 
   constructor(
     readonly originModule: Module | null,
     readonly dependency: Dependency,
-    readonly module: Module,
+    module: Module,
     readonly weak: boolean
   ) {
     this.resolvedOriginModule = originModule;
     this.resolvedModule = module;
+    this.#module = module;
+  }
+
+  get module(): Module {
+    return this.#module;
+  }
+
+  updateModule(module: Module): void {
+    this.#module = module;
   }
 
   getActiveState(_runtime?: unknown): boolean {
@@ -1720,7 +1736,6 @@ const EMPTY_OPTIMIZATION_BAILOUTS: readonly string[] = [];
 const EMPTY_EXPORTS_INFO = new ExportsInfoImpl([], null);
 
 class ModuleGraphImpl implements ModuleGraph {
-  #nativeCompilation: NativeCompilation | undefined;
   readonly #modulesByHandle: ReadonlyMap<number, ModuleImpl>;
   readonly #connectionByHandle = new Map<number, ModuleGraphConnectionImpl>();
   readonly #connectionByDependency = new Map<Dependency, ModuleGraphConnectionImpl>();
@@ -1735,15 +1750,9 @@ class ModuleGraphImpl implements ModuleGraph {
     ReadonlyMap<Module, readonly ModuleGraphConnection[]>
   >();
   readonly #issuers = new Map<Module, Module | null>();
-  readonly #loadedIncoming = new Set<Module>();
-  readonly #loadedOutgoing = new Set<Module>();
   readonly #exports = new Map<Module, ExportsInfoImpl>();
 
-  constructor(
-    nativeCompilation: NativeCompilation | undefined,
-    modulesByHandle: ReadonlyMap<number, ModuleImpl>
-  ) {
-    this.#nativeCompilation = nativeCompilation;
+  constructor(modulesByHandle: ReadonlyMap<number, ModuleImpl>) {
     this.#modulesByHandle = modulesByHandle;
     for (const module of modulesByHandle.values()) {
       this.#exports.set(
@@ -1758,7 +1767,9 @@ class ModuleGraphImpl implements ModuleGraph {
   }
 
   updateNativeCompilation(nativeCompilation: NativeCompilation | undefined): void {
-    this.#nativeCompilation = nativeCompilation;
+    if (nativeCompilation) {
+      this.#synchronizeConnections(nativeCompilation.connections());
+    }
     for (const module of this.#modulesByHandle.values()) {
       this.#exports.set(
         module,
@@ -1774,10 +1785,17 @@ class ModuleGraphImpl implements ModuleGraph {
   #materializeConnection(
     nativeConnection: NativeModuleGraphConnection
   ): ModuleGraphConnectionImpl | undefined {
-    const existing = this.#connectionByHandle.get(nativeConnection.handle);
-    if (existing) return existing;
     const target = this.#modulesByHandle.get(nativeConnection.moduleHandle);
     if (!target) return undefined;
+    const existing = this.#connectionByHandle.get(nativeConnection.handle);
+    if (existing) {
+      if (existing.module !== target) {
+        removeFromSetMap(this.#incoming, existing.module, existing);
+        addToSetMap(this.#incoming, target, existing);
+        existing.updateModule(target);
+      }
+      return existing;
+    }
     const originHandle = nativeConnection.originModuleHandle;
     const origin = originHandle == null
       ? null
@@ -1801,24 +1819,15 @@ class ModuleGraphImpl implements ModuleGraph {
     return connection;
   }
 
-  #loadIncoming(module: Module): void {
-    if (this.#loadedIncoming.has(module)) return;
-    this.#loadedIncoming.add(module);
-    if (!(module instanceof ModuleImpl)) return;
-    for (const connection of
-      this.#nativeCompilation?.incomingConnections(module.nativeHandle) ?? []) {
-      this.#materializeConnection(connection);
+  #synchronizeConnections(
+    nativeConnections: readonly NativeModuleGraphConnection[]
+  ): void {
+    for (const nativeConnection of nativeConnections) {
+      this.#materializeConnection(nativeConnection);
     }
-  }
-
-  #loadOutgoing(module: Module): void {
-    if (this.#loadedOutgoing.has(module)) return;
-    this.#loadedOutgoing.add(module);
-    if (!(module instanceof ModuleImpl)) return;
-    for (const connection of
-      this.#nativeCompilation?.outgoingConnections(module.nativeHandle) ?? []) {
-      this.#materializeConnection(connection);
-    }
+    this.#incomingByOrigin.clear();
+    this.#outgoingByModule.clear();
+    this.#issuers.clear();
   }
 
   getResolvedModule(dependency: Dependency): Module | null {
@@ -1854,12 +1863,10 @@ class ModuleGraphImpl implements ModuleGraph {
   }
 
   getIncomingConnections(module: Module): ReadonlySet<ModuleGraphConnection> {
-    this.#loadIncoming(module);
     return this.#incoming.get(module) ?? EMPTY_CONNECTIONS;
   }
 
   getOutgoingConnections(module: Module): ReadonlySet<ModuleGraphConnection> {
-    this.#loadOutgoing(module);
     return this.#outgoing.get(module) ?? EMPTY_CONNECTIONS;
   }
 
@@ -1880,7 +1887,6 @@ class ModuleGraphImpl implements ModuleGraph {
   getOutgoingConnectionsByModule(
     module: Module
   ): ReadonlyMap<Module, readonly ModuleGraphConnection[]> | undefined {
-    this.#loadOutgoing(module);
     const outgoing = this.#outgoing.get(module);
     if (!outgoing) return undefined;
     let groups = this.#outgoingByModule.get(module);
@@ -2122,7 +2128,7 @@ class CompilationImpl implements Compilation {
   readonly #moduleSet = new Set<Module>();
 
   constructor(compilation: NativeCompilation | null | undefined) {
-    this.moduleGraph = new ModuleGraphImpl(undefined, this.#modulesByHandle);
+    this.moduleGraph = new ModuleGraphImpl(this.#modulesByHandle);
     this.chunkGraph = new ChunkGraphImpl(
       undefined,
       this.#modulesByHandle,
@@ -2171,6 +2177,10 @@ class CompilationImpl implements Compilation {
     this.moduleGraph.updateNativeCompilation(compilation ?? undefined);
     this.chunkGraph.updateNativeCompilation(compilation ?? undefined);
   }
+
+  releaseNativeCompilation(): void {
+    this.chunkGraph.updateNativeCompilation(undefined);
+  }
 }
 
 function addToSetMap<TKey, TValue>(
@@ -2184,6 +2194,17 @@ function addToSetMap<TKey, TValue>(
     map.set(key, values);
   }
   values.add(value);
+}
+
+function removeFromSetMap<TKey, TValue>(
+  map: Map<TKey, Set<TValue>>,
+  key: TKey,
+  value: TValue
+): void {
+  const values = map.get(key);
+  if (!values) return;
+  values.delete(value);
+  if (values.size === 0) map.delete(key);
 }
 
 function groupConnections<TKey>(

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -474,7 +474,9 @@ interface NativeStatsJson {
 
 interface NativeCompilation {
   modules(): NativeModule[];
-  connections(): NativeModuleGraphConnection[];
+  outgoingConnections(moduleHandle: number): NativeModuleGraphConnection[];
+  incomingConnections(moduleHandle: number): NativeModuleGraphConnection[];
+  connectionsByHandle(connectionHandles: number[]): NativeModuleGraphConnection[];
   chunks(): NativeChunk[];
   chunkModules(chunkHandle: number): number[];
   moduleChunks(moduleHandle: number): number[];
@@ -1736,6 +1738,10 @@ const EMPTY_OPTIMIZATION_BAILOUTS: readonly string[] = [];
 const EMPTY_EXPORTS_INFO = new ExportsInfoImpl([], null);
 
 class ModuleGraphImpl implements ModuleGraph {
+  #nativeBinding:
+    | { kind: "unbound" }
+    | { kind: "active"; compilation: NativeCompilation }
+    | { kind: "released" } = { kind: "unbound" };
   readonly #modulesByHandle: ReadonlyMap<number, ModuleImpl>;
   readonly #connectionByHandle = new Map<number, ModuleGraphConnectionImpl>();
   readonly #connectionByDependency = new Map<Dependency, ModuleGraphConnectionImpl>();
@@ -1751,6 +1757,8 @@ class ModuleGraphImpl implements ModuleGraph {
   >();
   readonly #issuers = new Map<Module, Module | null>();
   readonly #exports = new Map<Module, ExportsInfoImpl>();
+  readonly #loadedIncoming = new Set<Module>();
+  readonly #loadedOutgoing = new Set<Module>();
 
   constructor(modulesByHandle: ReadonlyMap<number, ModuleImpl>) {
     this.#modulesByHandle = modulesByHandle;
@@ -1768,8 +1776,18 @@ class ModuleGraphImpl implements ModuleGraph {
 
   updateNativeCompilation(nativeCompilation: NativeCompilation | undefined): void {
     if (nativeCompilation) {
-      this.#synchronizeConnections(nativeCompilation.connections());
+      this.#nativeBinding = { kind: "active", compilation: nativeCompilation };
+      const materializedHandles = [...this.#connectionByHandle.keys()];
+      if (materializedHandles.length > 0) {
+        this.#synchronizeConnections(
+          nativeCompilation.connectionsByHandle(materializedHandles)
+        );
+      }
+    } else {
+      this.#nativeBinding = { kind: "unbound" };
     }
+    this.#loadedIncoming.clear();
+    this.#loadedOutgoing.clear();
     for (const module of this.#modulesByHandle.values()) {
       this.#exports.set(
         module,
@@ -1780,6 +1798,21 @@ class ModuleGraphImpl implements ModuleGraph {
         )
       );
     }
+  }
+
+  releaseNativeCompilation(): void {
+    this.#nativeBinding = { kind: "released" };
+    this.#loadedIncoming.clear();
+    this.#loadedOutgoing.clear();
+  }
+
+  #nativeCompilationForRead(): NativeCompilation | undefined {
+    if (this.#nativeBinding.kind === "released") {
+      throw new Error("module graph lease has been released");
+    }
+    return this.#nativeBinding.kind === "active"
+      ? this.#nativeBinding.compilation
+      : undefined;
   }
 
   #materializeConnection(
@@ -1863,10 +1896,28 @@ class ModuleGraphImpl implements ModuleGraph {
   }
 
   getIncomingConnections(module: Module): ReadonlySet<ModuleGraphConnection> {
+    const nativeCompilation = this.#nativeCompilationForRead();
+    if (module instanceof ModuleImpl && !this.#loadedIncoming.has(module)) {
+      if (nativeCompilation) {
+        this.#synchronizeConnections(
+          nativeCompilation.incomingConnections(module.nativeHandle)
+        );
+      }
+      this.#loadedIncoming.add(module);
+    }
     return this.#incoming.get(module) ?? EMPTY_CONNECTIONS;
   }
 
   getOutgoingConnections(module: Module): ReadonlySet<ModuleGraphConnection> {
+    const nativeCompilation = this.#nativeCompilationForRead();
+    if (module instanceof ModuleImpl && !this.#loadedOutgoing.has(module)) {
+      if (nativeCompilation) {
+        this.#synchronizeConnections(
+          nativeCompilation.outgoingConnections(module.nativeHandle)
+        );
+      }
+      this.#loadedOutgoing.add(module);
+    }
     return this.#outgoing.get(module) ?? EMPTY_CONNECTIONS;
   }
 
@@ -1887,8 +1938,8 @@ class ModuleGraphImpl implements ModuleGraph {
   getOutgoingConnectionsByModule(
     module: Module
   ): ReadonlyMap<Module, readonly ModuleGraphConnection[]> | undefined {
-    const outgoing = this.#outgoing.get(module);
-    if (!outgoing) return undefined;
+    const outgoing = this.getOutgoingConnections(module);
+    if (outgoing.size === 0) return undefined;
     let groups = this.#outgoingByModule.get(module);
     if (!groups) {
       groups = groupConnections(outgoing, (connection) => connection.module);
@@ -2179,6 +2230,7 @@ class CompilationImpl implements Compilation {
   }
 
   releaseNativeCompilation(): void {
+    this.moduleGraph.releaseNativeCompilation();
     this.chunkGraph.updateNativeCompilation(undefined);
   }
 }

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -2094,7 +2094,12 @@ test("watch option validation throws synchronously", async () => {
 });
 
 async function runCompiler(options: Parameters<typeof unpack>[0]) {
-  return runExistingCompiler(unpack(options));
+  const compiler = unpack(options);
+  try {
+    return await runExistingCompiler(compiler);
+  } finally {
+    await closeCompiler(compiler);
+  }
 }
 
 async function assertSameTimestampModuleEditEmits(

--- a/packages/unpack/test/done-hook-module-graph.test.ts
+++ b/packages/unpack/test/done-hook-module-graph.test.ts
@@ -206,6 +206,35 @@ test("finishModules exposes a live webpack-shaped ModuleGraph", async () => {
   }
 });
 
+test("module graph access after finishModules rejects an expired native lease", async () => {
+  const fixture = await createGraphFixture();
+  const compiler = createCompiler(fixture);
+  let detachedAccess: Promise<Error | undefined> | undefined;
+
+  compiler.hooks.compilation.tap("schedule detached graph access", (compilation) => {
+    compilation.hooks.finishModules.tap("schedule detached graph access", (modules) => {
+      const entry = findModule(modules, "/src/index.js");
+      detachedAccess = afterMicrotasks(20).then(() => {
+        try {
+          compilation.moduleGraph.getOutgoingConnections(entry);
+          return undefined;
+        } catch (error) {
+          return error instanceof Error ? error : new Error(String(error));
+        }
+      });
+    });
+  });
+
+  try {
+    await runCompiler(compiler);
+    const error = await detachedAccess;
+    assert.match(error?.message ?? "", /module graph lease has been released/i);
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 test("done refreshes connections materialized before seal", async () => {
   const fixture = await mkdtemp(join(tmpdir(), "unpack-module-graph-rewrite-"));
   await writeFixtureFile(join(fixture, "package.json"), JSON.stringify({ sideEffects: false }));
@@ -708,4 +737,12 @@ function closeCompiler(compiler: Compiler): Promise<void> {
 
 function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function afterMicrotasks(turns: number): Promise<void> {
+  let pending = Promise.resolve();
+  for (let index = 0; index < turns; index += 1) {
+    pending = pending.then(() => undefined);
+  }
+  return pending;
 }

--- a/packages/unpack/test/done-hook-module-graph.test.ts
+++ b/packages/unpack/test/done-hook-module-graph.test.ts
@@ -92,8 +92,13 @@ test("finishModules taps run after make and before done", async () => {
       assert.equal(modules, capturedModules);
       assert.equal(compilation.moduleGraph, capturedModuleGraph);
       finishedModule = modules.values().next().value;
+      const entry = findModule(modules, "/src/index.js");
       events.push(`finishModules:${modules.size}:start`);
       setTimeout(() => {
+        assert.equal(
+          compilation.moduleGraph.getOutgoingConnections(entry).size > 0,
+          true
+        );
         events.push("finishModules:end");
         done();
       }, 5);
@@ -197,6 +202,57 @@ test("finishModules exposes a live webpack-shaped ModuleGraph", async () => {
     await new Promise<void>((resolve, reject) => {
       webpackCompiler.close((error) => (error ? reject(error) : resolve()));
     });
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("done refreshes connections materialized before seal", async () => {
+  const fixture = await mkdtemp(join(tmpdir(), "unpack-module-graph-rewrite-"));
+  await writeFixtureFile(join(fixture, "package.json"), JSON.stringify({ sideEffects: false }));
+  await writeFixtureFile(
+    join(fixture, "src/index.js"),
+    'import { value } from "./barrel.js"; export const result = value;\n'
+  );
+  await writeFixtureFile(
+    join(fixture, "src/barrel.js"),
+    'export { value } from "./leaf.js";\n'
+  );
+  await writeFixtureFile(join(fixture, "src/leaf.js"), "export const value = 42;\n");
+  const compiler = unpack({
+    context: fixture,
+    mode: "production",
+    entry: "./src/index.js",
+    output: { path: join(fixture, "dist") },
+    sourcemap: false,
+    optimization: { sideEffects: true, usedExports: true }
+  });
+  assert.ok(compiler);
+  let connection: ModuleGraphConnection | undefined;
+  let resolvedModule: Module | undefined;
+
+  compiler.hooks.compilation.tap("capture pre-seal connection", (compilation) => {
+    compilation.hooks.finishModules.tap("capture pre-seal connection", (modules) => {
+      const entry = findModule(modules, "/src/index.js");
+      const barrel = findModule(modules, "/src/barrel.js");
+      connection = [...compilation.moduleGraph.getOutgoingConnections(entry)].find(
+        (candidate) => candidate.module === barrel
+      );
+      assert.ok(connection);
+      resolvedModule = connection.resolvedModule;
+    });
+  });
+  compiler.hooks.done.tap("inspect rewritten connection", (stats) => {
+    assert.ok(connection);
+    const leaf = findModule(stats.compilation.modules, "/src/leaf.js");
+    assert.equal(connection.module, leaf);
+    assert.equal(connection.resolvedModule, resolvedModule);
+    assert.equal(stats.compilation.moduleGraph.getConnection(connection.dependency), connection);
+  });
+
+  try {
+    await runCompiler(compiler);
+  } finally {
+    await closeCompiler(compiler);
     await rm(fixture, { recursive: true, force: true });
   }
 });

--- a/packages/unpack/test/done-hook-module-graph.test.ts
+++ b/packages/unpack/test/done-hook-module-graph.test.ts
@@ -214,6 +214,7 @@ test("module graph access after finishModules rejects an expired native lease", 
   compiler.hooks.compilation.tap("schedule detached graph access", (compilation) => {
     compilation.hooks.finishModules.tap("schedule detached graph access", (modules) => {
       const entry = findModule(modules, "/src/index.js");
+      assert.equal(compilation.moduleGraph.getOutgoingConnections(entry).size > 0, true);
       detachedAccess = afterMicrotasks(20).then(() => {
         try {
           compilation.moduleGraph.getOutgoingConnections(entry);
@@ -276,6 +277,47 @@ test("done refreshes connections materialized before seal", async () => {
     assert.equal(connection.module, leaf);
     assert.equal(connection.resolvedModule, resolvedModule);
     assert.equal(stats.compilation.moduleGraph.getConnection(connection.dependency), connection);
+  });
+
+  try {
+    await runCompiler(compiler);
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("done preserves resolvedModule for a connection first loaded after seal", async () => {
+  const fixture = await mkdtemp(join(tmpdir(), "unpack-module-graph-lazy-rewrite-"));
+  await writeFixtureFile(join(fixture, "package.json"), JSON.stringify({ sideEffects: false }));
+  await writeFixtureFile(
+    join(fixture, "src/index.js"),
+    'import { value } from "./barrel.js"; export const result = value;\n'
+  );
+  await writeFixtureFile(
+    join(fixture, "src/barrel.js"),
+    'export { value } from "./leaf.js";\n'
+  );
+  await writeFixtureFile(join(fixture, "src/leaf.js"), "export const value = 42;\n");
+  const compiler = unpack({
+    context: fixture,
+    mode: "production",
+    entry: "./src/index.js",
+    output: { path: join(fixture, "dist") },
+    sourcemap: false,
+    optimization: { sideEffects: true, usedExports: true }
+  });
+  assert.ok(compiler);
+
+  compiler.hooks.done.tap("inspect lazy rewritten connection", (stats) => {
+    const modules = stats.compilation.modules;
+    const entry = findModule(modules, "/src/index.js");
+    const barrel = findModule(modules, "/src/barrel.js");
+    const leaf = findModule(modules, "/src/leaf.js");
+    const connection = [...stats.compilation.moduleGraph.getOutgoingConnections(entry)]
+      .find((candidate) => candidate.module === leaf);
+    assert.ok(connection);
+    assert.equal(connection.resolvedModule, barrel);
   });
 
   try {


### PR DESCRIPTION
## Summary

- transfer ownership of the native `ModuleGraph` into `NativeCompilation` while asynchronous `finishModules` taps run, then return the same graph before sealing
- load incoming and outgoing connections lazily in per-module batches instead of projecting every connection into JavaScript up front
- reject detached queries that require another native graph read after the lease expires, while keeping already materialized JavaScript records safe to read
- rebind the final graph for `done`, refresh only materialized connection handles, and preserve wrapper identity plus separate `resolvedModule` and rewritten `module` targets
- document how this ownership model compares with Rspack's unsafe live-pointer binding

## Motivation

Cloning the complete native module graph before invoking JavaScript `finishModules` taps duplicates graph storage and becomes increasingly expensive for large compilations. The lease makes ownership and lifetime explicit without locks or unsafe pointers.

The hook still materializes its module set, but connection DTO cost is now proportional to the graph portions a plugin actually reads. Full graph traversal remains O(N+E), while taps that inspect only a small area avoid an eager E-sized projection.

## Tests

- `cargo fmt --all -- --check`
- `pnpm --filter @unpack-js/core typecheck`
- `git diff --check`
- `pnpm test`
