### PR TITLE
Port Rspack plugin API config cases

### DIFF
--- a/packages/unpack/package.json
+++ b/packages/unpack/package.json
@@ -21,6 +21,7 @@
     "@types/node": "26.0.1",
     "typescript": "6.0.3",
     "webpack": "5.108.1",
-    "webpack-bundle-analyzer": "5.3.0"
+    "webpack-bundle-analyzer": "5.3.0",
+    "webpack-sources": "3.3.3"
   }
 }

--- a/packages/unpack/test/config-case.ts
+++ b/packages/unpack/test/config-case.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { access, cp, mkdtemp, readdir, rm } from "node:fs/promises";
+import { access, cp, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -34,6 +34,13 @@ interface TestCase {
   name: string;
   sourcePath: string;
   compiledPath: string;
+  skip?: TestCaseSkip;
+}
+
+interface TestCaseSkip {
+  issue: string;
+  reason: string;
+  upstream: string;
 }
 
 const testDirectory = dirname(fileURLToPath(import.meta.url));
@@ -47,9 +54,13 @@ export async function registerConfigCases(): Promise<void> {
   assert.notEqual(cases.length, 0, "expected at least one test case");
 
   for (const testCase of cases) {
-    test(`config case ${testCase.category}/${testCase.name}`, async () => {
-      await runCase(testCase);
-    });
+    test(
+      `config case ${testCase.category}/${testCase.name}`,
+      { skip: testCase.skip && `${testCase.skip.reason} (${testCase.skip.issue})` },
+      async () => {
+        await runCase(testCase);
+      }
+    );
   }
 }
 
@@ -58,16 +69,48 @@ async function discoverConfigCases(): Promise<TestCase[]> {
   const cases = await Promise.all(
     categories.map(async (category) => {
       const names = await readDirectories(join(sourceCasesPath, category));
-      return names.map((name) => ({
-        category,
-        name,
-        sourcePath: join(sourceCasesPath, category, name),
-        compiledPath: join(compiledCasesPath, category, name)
-      }));
+      return Promise.all(
+        names.map(async (name) => {
+          const sourcePath = join(sourceCasesPath, category, name);
+          return {
+            category,
+            name,
+            sourcePath,
+            compiledPath: join(compiledCasesPath, category, name),
+            skip: await readSkipMetadata(sourcePath)
+          };
+        })
+      );
     })
   );
 
   return cases.flat();
+}
+
+async function readSkipMetadata(sourcePath: string): Promise<TestCaseSkip | undefined> {
+  try {
+    const metadata = JSON.parse(
+      await readFile(join(sourcePath, "case.config.json"), "utf8")
+    ) as { skip?: unknown };
+    if (metadata.skip === undefined) return undefined;
+    if (!isTestCaseSkip(metadata.skip)) {
+      throw new TypeError(`invalid skip metadata in ${sourcePath}/case.config.json`);
+    }
+    return metadata.skip;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+function isTestCaseSkip(value: unknown): value is TestCaseSkip {
+  if (typeof value !== "object" || value === null) return false;
+  const skip = value as Partial<TestCaseSkip>;
+  return (
+    typeof skip.issue === "string" &&
+    typeof skip.reason === "string" &&
+    typeof skip.upstream === "string"
+  );
 }
 
 async function fileExists(path: string): Promise<boolean> {
@@ -128,6 +171,13 @@ async function runCase(testCase: TestCase): Promise<void> {
 }
 
 async function loadOptions(testCase: TestCase): Promise<ConfigCaseOptions> {
+  const sourceJavaScriptConfig = join(testCase.sourcePath, "webpack.config.js");
+  if (await fileExists(sourceJavaScriptConfig)) {
+    const optionsModule = (await import(pathToFileURL(sourceJavaScriptConfig).href)) as {
+      default: ConfigCaseOptions;
+    };
+    return optionsModule.default;
+  }
   const optionsModule = (await import(
     pathToFileURL(join(testCase.compiledPath, "webpack.config.js")).href
   )) as { default: ConfigCaseOptions };
@@ -171,7 +221,9 @@ async function copyFixture(sourcePath: string, fixturePath: string): Promise<voi
       .filter(
         (entry) =>
           entry.name !== "webpack.config.ts" &&
+          entry.name !== "webpack.config.js" &&
           entry.name !== "test.config.ts" &&
+          entry.name !== "case.config.json" &&
           entry.name !== "README.md"
       )
       .map((entry) =>

--- a/packages/unpack/test/configCases/README.md
+++ b/packages/unpack/test/configCases/README.md
@@ -8,6 +8,13 @@ Config cases follow webpack's `test/configCases/<category>/<case>` layout:
   entry execution.
 - all other files are copied into the fixture before compilation.
 
+Cases that document an upstream JavaScript API gap can provide a
+`case.config.json` with `skip.issue`, `skip.reason`, and `skip.upstream`. The
+harness registers these as skipped tests and includes the tracking issue in the
+skip reason. These ported cases can preserve an upstream-style
+`webpack.config.js`; after the model-backed surface is implemented, remove the
+skip metadata and the harness will load that configuration directly.
+
 The harness owns the isolated `context` and `output.path`. It defaults `entry`
 to `./index.js` and `sourcemap` to `false`. Cases only need to declare values
 that are relevant to the behavior under test. Cases that do not need custom

--- a/packages/unpack/test/configCases/plugins/child-compiler-jsonp-template/case.config.json
+++ b/packages/unpack/test/configCases/plugins/child-compiler-jsonp-template/case.config.json
@@ -1,0 +1,1 @@
+{"skip":{"upstream":"https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/plugins/child-compiler-jsonp-template","issue":"https://github.com/unpack-dev/unpack/issues/246","reason":"make and child compiler lifecycle APIs are not exposed"}}

--- a/packages/unpack/test/configCases/plugins/child-compiler-jsonp-template/child.js
+++ b/packages/unpack/test/configCases/plugins/child-compiler-jsonp-template/child.js
@@ -1,0 +1,1 @@
+export default "child";

--- a/packages/unpack/test/configCases/plugins/child-compiler-jsonp-template/index.js
+++ b/packages/unpack/test/configCases/plugins/child-compiler-jsonp-template/index.js
@@ -1,0 +1,1 @@
+export default "parent";

--- a/packages/unpack/test/configCases/plugins/child-compiler-jsonp-template/webpack.config.js
+++ b/packages/unpack/test/configCases/plugins/child-compiler-jsonp-template/webpack.config.js
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+
+export default { plugins: [{ apply(compiler) {
+  compiler.hooks.make.tapAsync("plugin", (compilation, done) => {
+    const child = compilation.createChildCompiler("child", {}, [
+      new compiler.webpack.EntryPlugin(compiler.context, "./child.js", {
+        name: "child"
+      })
+    ]);
+    child.runAsChild((error, entries) => {
+      assert.equal(error, null);
+      assert.equal(entries.length, 1);
+      done();
+    });
+  });
+} }] };

--- a/packages/unpack/test/configCases/plugins/chunk-group-chunks/case.config.json
+++ b/packages/unpack/test/configCases/plugins/chunk-group-chunks/case.config.json
@@ -1,0 +1,1 @@
+{"skip":{"upstream":"https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/plugins/chunk-group-chunks","issue":"https://github.com/unpack-dev/unpack/issues/244","reason":"Compilation.entrypoints and Entrypoint.chunks are not exposed"}}

--- a/packages/unpack/test/configCases/plugins/chunk-group-chunks/entry1.js
+++ b/packages/unpack/test/configCases/plugins/chunk-group-chunks/entry1.js
@@ -1,0 +1,1 @@
+export default "a";

--- a/packages/unpack/test/configCases/plugins/chunk-group-chunks/entry2.js
+++ b/packages/unpack/test/configCases/plugins/chunk-group-chunks/entry2.js
@@ -1,0 +1,1 @@
+export default "b";

--- a/packages/unpack/test/configCases/plugins/chunk-group-chunks/webpack.config.js
+++ b/packages/unpack/test/configCases/plugins/chunk-group-chunks/webpack.config.js
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+
+export default {
+  entry: { a: "./entry1.js", b: "./entry2.js" },
+  plugins: [(compiler) => compiler.hooks.compilation.tap("plugin", (compilation) => {
+    compilation.hooks.processAssets.tap("plugin", () => {
+      assert.deepEqual(compilation.entrypoints.get("a").chunks.map((chunk) => chunk.name), ["a"]);
+      assert.deepEqual(compilation.entrypoints.get("b").chunks.map((chunk) => chunk.name), ["b"]);
+    });
+  })]
+};

--- a/packages/unpack/test/configCases/plugins/chunk-modules/async.js
+++ b/packages/unpack/test/configCases/plugins/chunk-modules/async.js
@@ -1,0 +1,1 @@
+export default "async";

--- a/packages/unpack/test/configCases/plugins/chunk-modules/case.config.json
+++ b/packages/unpack/test/configCases/plugins/chunk-modules/case.config.json
@@ -1,0 +1,1 @@
+{"skip":{"upstream":"https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/plugins/chunk-modules","issue":"https://github.com/unpack-dev/unpack/issues/245","reason":"Compilation.chunks and complete Chunk Graph access are not exposed"}}

--- a/packages/unpack/test/configCases/plugins/chunk-modules/index.js
+++ b/packages/unpack/test/configCases/plugins/chunk-modules/index.js
@@ -1,0 +1,1 @@
+export default import("./async.js");

--- a/packages/unpack/test/configCases/plugins/chunk-modules/webpack.config.js
+++ b/packages/unpack/test/configCases/plugins/chunk-modules/webpack.config.js
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+
+export default { plugins: [(compiler) => compiler.hooks.compilation.tap("plugin", (compilation) => {
+  compilation.hooks.processAssets.tap("plugin", () => {
+    const chunks = [...compilation.chunks];
+    assert.equal(chunks.length > 0, true);
+    assert.equal([...compilation.chunkGraph.getChunkModulesIterable(chunks[0])].length > 0, true);
+    assert.equal([...compilation.chunkGraph.getChunkEntryModulesIterable(chunks[0])].length > 0, true);
+  });
+})] };

--- a/packages/unpack/test/configCases/plugins/compilation-chunk-groups/a.js
+++ b/packages/unpack/test/configCases/plugins/compilation-chunk-groups/a.js
@@ -1,0 +1,1 @@
+export default "a";

--- a/packages/unpack/test/configCases/plugins/compilation-chunk-groups/b.js
+++ b/packages/unpack/test/configCases/plugins/compilation-chunk-groups/b.js
@@ -1,0 +1,1 @@
+export default "b";

--- a/packages/unpack/test/configCases/plugins/compilation-chunk-groups/case.config.json
+++ b/packages/unpack/test/configCases/plugins/compilation-chunk-groups/case.config.json
@@ -1,0 +1,1 @@
+{"skip":{"upstream":"https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/plugins/compilation-chunk-groups","issue":"https://github.com/unpack-dev/unpack/issues/244","reason":"Chunk Group collections and facades are not exposed"}}

--- a/packages/unpack/test/configCases/plugins/compilation-chunk-groups/webpack.config.js
+++ b/packages/unpack/test/configCases/plugins/compilation-chunk-groups/webpack.config.js
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+
+export default { entry: { a: "./a.js", b: "./b.js" }, plugins: [(compiler) => compiler.hooks.compilation.tap("plugin", (compilation) => {
+  compilation.hooks.processAssets.tap("plugin", () => {
+    assert.equal(compilation.chunkGroups.length >= 2, true);
+    assert.deepEqual([...compilation.namedChunkGroups.keys()].sort(), ["a", "b"]);
+    assert.deepEqual(compilation.namedChunkGroups.get("a").getFiles(), ["a.js"]);
+  });
+})] };

--- a/packages/unpack/test/configCases/plugins/copy-plugin-input-file-system/case.config.json
+++ b/packages/unpack/test/configCases/plugins/copy-plugin-input-file-system/case.config.json
@@ -1,0 +1,1 @@
+{"skip":{"upstream":"https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/plugins/copy-plugin-input-file-system","issue":"https://github.com/unpack-dev/unpack/issues/247","reason":"Compiler.inputFileSystem and beforeCompile are not exposed"}}

--- a/packages/unpack/test/configCases/plugins/copy-plugin-input-file-system/index.js
+++ b/packages/unpack/test/configCases/plugins/copy-plugin-input-file-system/index.js
@@ -1,0 +1,1 @@
+export default "main";

--- a/packages/unpack/test/configCases/plugins/copy-plugin-input-file-system/webpack.config.js
+++ b/packages/unpack/test/configCases/plugins/copy-plugin-input-file-system/webpack.config.js
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+
+export default { plugins: [{ apply(compiler) {
+  const inputFileSystem = Object.create(compiler.inputFileSystem);
+  compiler.inputFileSystem = inputFileSystem;
+  compiler.hooks.beforeCompile.tap("plugin", () => {
+    assert.equal(compiler.inputFileSystem, inputFileSystem);
+  });
+} }] };

--- a/packages/unpack/test/configCases/plugins/get-runtime-chunk/case.config.json
+++ b/packages/unpack/test/configCases/plugins/get-runtime-chunk/case.config.json
@@ -1,0 +1,1 @@
+{"skip":{"upstream":"https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/plugins/get-runtime-chunk","issue":"https://github.com/unpack-dev/unpack/issues/244","reason":"Entrypoint.getRuntimeChunk is not exposed"}}

--- a/packages/unpack/test/configCases/plugins/get-runtime-chunk/index.js
+++ b/packages/unpack/test/configCases/plugins/get-runtime-chunk/index.js
@@ -1,0 +1,1 @@
+export default "main";

--- a/packages/unpack/test/configCases/plugins/get-runtime-chunk/webpack.config.js
+++ b/packages/unpack/test/configCases/plugins/get-runtime-chunk/webpack.config.js
@@ -1,0 +1,7 @@
+import assert from "node:assert/strict";
+
+export default { plugins: [(compiler) => compiler.hooks.compilation.tap("plugin", (compilation) => {
+  compilation.hooks.processAssets.tap("plugin", () => {
+    assert.equal(compilation.entrypoints.get("main").getRuntimeChunk().name, "main");
+  });
+})] };

--- a/packages/unpack/test/configCases/plugins/internal-entrypoints/case.config.json
+++ b/packages/unpack/test/configCases/plugins/internal-entrypoints/case.config.json
@@ -1,0 +1,1 @@
+{"skip":{"upstream":"https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/plugins/internal-entrypoints","issue":"https://github.com/unpack-dev/unpack/issues/244","reason":"Compilation.entrypoints and emitAsset are not exposed"}}

--- a/packages/unpack/test/configCases/plugins/internal-entrypoints/index.js
+++ b/packages/unpack/test/configCases/plugins/internal-entrypoints/index.js
@@ -1,0 +1,1 @@
+export default "main";

--- a/packages/unpack/test/configCases/plugins/internal-entrypoints/webpack.config.js
+++ b/packages/unpack/test/configCases/plugins/internal-entrypoints/webpack.config.js
@@ -1,0 +1,8 @@
+import { RawSource } from "webpack-sources";
+
+export default { plugins: [{ apply(compiler) { compiler.hooks.compilation.tap("plugin", (compilation) => {
+  compilation.hooks.processAssets.tapPromise("plugin", async () => {
+    const files = [...compilation.entrypoints].flatMap(([name, entrypoint]) => entrypoint.getFiles().map((file) => `${name}:${file}`));
+    compilation.emitAsset("inspect.txt", new RawSource(files.join("\n")));
+  });
+}); } }] };

--- a/packages/unpack/test/configCases/plugins/internal-processAssets-param-assets/case.config.json
+++ b/packages/unpack/test/configCases/plugins/internal-processAssets-param-assets/case.config.json
@@ -1,0 +1,1 @@
+{"skip":{"upstream":"https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/plugins/internal-processAssets-param-assets","issue":"https://github.com/unpack-dev/unpack/issues/243","reason":"the processAssets assets facade is not exposed"}}

--- a/packages/unpack/test/configCases/plugins/internal-processAssets-param-assets/index.js
+++ b/packages/unpack/test/configCases/plugins/internal-processAssets-param-assets/index.js
@@ -1,0 +1,1 @@
+export default "main";

--- a/packages/unpack/test/configCases/plugins/internal-processAssets-param-assets/webpack.config.js
+++ b/packages/unpack/test/configCases/plugins/internal-processAssets-param-assets/webpack.config.js
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { RawSource } from "webpack-sources";
+
+export default { plugins: [{ apply(compiler) { compiler.hooks.compilation.tap("plugin", (compilation) => {
+  compilation.hooks.processAssets.tapPromise("plugin", async (assets) => {
+    assets["dup.txt"] = new RawSource("dup");
+    assert.equal("dup.txt" in assets, true);
+    delete assets["dup.txt"];
+    assert.equal("dup.txt" in assets, false);
+  });
+}); } }] };

--- a/packages/unpack/test/configCases/plugins/internal-processAssets/case.config.json
+++ b/packages/unpack/test/configCases/plugins/internal-processAssets/case.config.json
@@ -1,0 +1,7 @@
+{
+  "skip": {
+    "upstream": "https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/plugins/internal-processAssets",
+    "issue": "https://github.com/unpack-dev/unpack/issues/243",
+    "reason": "compilation.hooks.processAssets and updateAsset are not exposed"
+  }
+}

--- a/packages/unpack/test/configCases/plugins/internal-processAssets/index.js
+++ b/packages/unpack/test/configCases/plugins/internal-processAssets/index.js
@@ -1,0 +1,1 @@
+export default "test";

--- a/packages/unpack/test/configCases/plugins/internal-processAssets/webpack.config.js
+++ b/packages/unpack/test/configCases/plugins/internal-processAssets/webpack.config.js
@@ -1,0 +1,31 @@
+// Ported from Rspack's plugins/internal-processAssets config case.
+import assert from "node:assert/strict";
+import { ConcatSource, RawSource } from "webpack-sources";
+
+export default {
+  plugins: [
+    {
+      name: "test",
+      apply(compiler) {
+        compiler.hooks.compilation.tap("compilation", (compilation) => {
+          compilation.hooks.processAssets.tapPromise("Test1", async (assets) => {
+            for (const [name, source] of Object.entries(assets)) {
+              compilation.updateAsset(
+                name,
+                new ConcatSource(new RawSource("//banner;\n"), source)
+              );
+            }
+          });
+
+          compilation.hooks.processAssets.tapPromise("Test2", async (assets) => {
+            assert.equal(Object.keys(assets).length, 1);
+            assert.equal(Object.getOwnPropertyNames(assets).length, 1);
+            assert.equal(Reflect.ownKeys(assets).length, 1);
+            assert.equal("main.js" in assets, true);
+            assert.equal(assets["main.js"].source().startsWith("//banner;\n"), true);
+          });
+        });
+      }
+    }
+  ]
+};

--- a/packages/unpack/test/configCases/plugins/manifest-plugin/case.config.json
+++ b/packages/unpack/test/configCases/plugins/manifest-plugin/case.config.json
@@ -1,0 +1,1 @@
+{"skip":{"upstream":"https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/plugins/manifest-plugin","issue":"https://github.com/unpack-dev/unpack/issues/243","reason":"processAssets and emitAsset are not exposed"}}

--- a/packages/unpack/test/configCases/plugins/manifest-plugin/index.js
+++ b/packages/unpack/test/configCases/plugins/manifest-plugin/index.js
@@ -1,0 +1,1 @@
+export default "main";

--- a/packages/unpack/test/configCases/plugins/manifest-plugin/webpack.config.js
+++ b/packages/unpack/test/configCases/plugins/manifest-plugin/webpack.config.js
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { RawSource } from "webpack-sources";
+
+export default { plugins: [{ apply(compiler) {
+  compiler.hooks.thisCompilation.tap("plugin", (compilation) => {
+    compilation.hooks.processAssets.tap("plugin", () => {
+      compilation.emitAsset("third.party.js", new RawSource("third party"));
+      assert.equal(compilation.getAsset("third.party.js") !== undefined, true);
+    });
+  });
+} }] };

--- a/packages/unpack/test/configCases/plugins/plugins-falsy/index.js
+++ b/packages/unpack/test/configCases/plugins/plugins-falsy/index.js
@@ -1,0 +1,1 @@
+export default "test";

--- a/packages/unpack/test/configCases/plugins/plugins-falsy/test.config.ts
+++ b/packages/unpack/test/configCases/plugins/plugins-falsy/test.config.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+
+import type { ConfigCaseTest } from "../../../config-case.js";
+
+export default {
+  validate({ requireEntry }) {
+    assert.equal((requireEntry() as { default: unknown }).default, "test");
+  }
+} satisfies ConfigCaseTest;

--- a/packages/unpack/test/configCases/plugins/plugins-falsy/webpack.config.ts
+++ b/packages/unpack/test/configCases/plugins/plugins-falsy/webpack.config.ts
@@ -1,0 +1,23 @@
+import type { ConfigCaseOptions } from "../../../config-case.js";
+
+class FailPlugin {
+  apply(): void {
+    throw new Error("FailedPlugin");
+  }
+}
+
+const nullValue = null;
+const undefinedValue = undefined;
+const falseValue = false;
+const zeroValue = 0 as const;
+const emptyStringValue = "" as const;
+
+export default {
+  plugins: [
+    undefinedValue && new FailPlugin(),
+    nullValue && new FailPlugin(),
+    falseValue && new FailPlugin(),
+    zeroValue && new FailPlugin(),
+    emptyStringValue && new FailPlugin()
+  ]
+} satisfies ConfigCaseOptions;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       webpack-bundle-analyzer:
         specifier: 5.3.0
         version: 5.3.0
+      webpack-sources:
+        specifier: 3.3.3
+        version: 3.3.3
 
 packages:
 
@@ -1815,6 +1818,10 @@ packages:
     resolution: {integrity: sha512-PEhAoqiJ+47d0uLMx/+zo5XOvaU+Vk6N2ZLht7H3n09QLy/fhyvqGNwjdRUHJDgMN8crBR2ZwVHkIswT3Xuawg==}
     engines: {node: '>= 20.9.0'}
     hasBin: true
+
+  webpack-sources@3.3.3:
+    resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
+    engines: {node: '>=10.13.0'}
 
   webpack-sources@3.5.0:
     resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
@@ -3880,6 +3887,8 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  webpack-sources@3.3.3: {}
 
   webpack-sources@3.5.0: {}
 


### PR DESCRIPTION
## Summary

- port selected Rspack plugin config cases that exercise the exposed JavaScript Plugin API
- add issue-backed skip metadata for model surfaces Unpack does not expose yet
- teach the config-case harness to register skipped upstream cases and load preserved JavaScript configs
- keep the falsy-plugin case runnable through the public package boundary

The public package typecheck and test suite pass. The config-case run reports 9 passing cases and 10 skipped cases, with each skip linked to issues #243–#247.
