### PR TITLE
Expose processAssets and asset mutation to JavaScript plugins

### DIFF
--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -102,12 +102,27 @@ impl Compilation {
         (self.module_graph, self.chunk_graph)
     }
 
+    pub fn into_parts(self) -> (ModuleGraph, ChunkGraph, Vec<Asset>) {
+        (self.module_graph, self.chunk_graph, self.assets)
+    }
+
     pub fn chunk_graph(&self) -> &ChunkGraph {
         &self.chunk_graph
     }
 
     pub fn assets(&self) -> &[Asset] {
         &self.assets
+    }
+
+    /// Temporarily detaches generated assets for an awaited host hook. The
+    /// caller must restore them before the compilation is emitted.
+    pub fn take_assets(&mut self) -> Vec<Asset> {
+        std::mem::take(&mut self.assets)
+    }
+
+    pub fn restore_assets(&mut self, assets: Vec<Asset>) {
+        debug_assert!(self.assets.is_empty());
+        self.assets = assets;
     }
 
     pub fn entries(&self) -> &[ModuleHandle] {

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -736,6 +736,9 @@ impl Compiler {
                 hooks.finish_modules(&mut compilation).await?;
             }
             compilation.seal();
+            if let Some(hooks) = &self.options.compilation_hooks {
+                hooks.process_assets(&mut compilation).await?;
+            }
             Ok(compilation)
         }
         .instrument(tracing::trace_span!("Compiler::run"))

--- a/crates/unpack_core/src/hooks.rs
+++ b/crates/unpack_core/src/hooks.rs
@@ -10,4 +10,5 @@ pub type HookFuture<'a> = Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
 pub trait CompilationHooks: Debug + Send + Sync {
     fn compilation<'a>(&'a self, compilation: &'a Compilation) -> HookFuture<'a>;
     fn finish_modules<'a>(&'a self, compilation: &'a mut Compilation) -> HookFuture<'a>;
+    fn process_assets<'a>(&'a self, compilation: &'a mut Compilation) -> HookFuture<'a>;
 }

--- a/crates/unpack_core/tests/codegen.rs
+++ b/crates/unpack_core/tests/codegen.rs
@@ -897,7 +897,7 @@ async fn shared_async_cross_imports_do_not_materialize_a_group_cycle()
 async fn nested_shared_parent_shrink_rescans_newly_required_modules()
 -> Result<(), Box<dyn std::error::Error>> {
     let context = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../packages/unpack/test/e2e-cases/nested-shared-requeue")
+        .join("../../packages/unpack/test/defaultCases/nested-shared-requeue")
         .canonicalize()?;
     let compilation = Compiler::new(CompilerOptions::new(
         &context,

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
 
 use napi::{
     Result, Status,
-    bindgen_prelude::{Either, FnArgs, Function, Promise},
+    bindgen_prelude::{Buffer, Either, FnArgs, Function, Promise},
     threadsafe_function::ThreadsafeFunction,
 };
 use napi_derive::napi;
@@ -182,6 +182,12 @@ pub struct NativeAsset {
 }
 
 #[napi(object)]
+pub struct NativeAssetSource {
+    pub name: String,
+    pub source: Buffer,
+}
+
+#[napi(object)]
 pub struct NativeStatsJson {
     pub errors: Vec<NativeStatsError>,
     pub warnings: Vec<NativeStatsError>,
@@ -264,6 +270,7 @@ pub struct NativeRunResult {
 pub struct NativeCompilation {
     module_graph: NativeModuleGraph,
     chunk_graph: unpack_core::ChunkGraph,
+    assets: Vec<Asset>,
 }
 
 enum NativeModuleGraph {
@@ -328,6 +335,16 @@ impl NativeCompilation {
             .iter()
             .map(native_module)
             .collect())
+    }
+
+    #[napi(js_name = "takeAssetSources")]
+    pub fn take_asset_sources(&mut self) -> Vec<NativeAssetSource> {
+        native_asset_sources(std::mem::take(&mut self.assets))
+    }
+
+    #[napi(js_name = "clearAssetSources")]
+    pub fn clear_asset_sources(&mut self) {
+        self.assets.clear();
     }
 
     #[napi(js_name = "outgoingConnections")]
@@ -440,6 +457,78 @@ impl NativeCompilation {
     }
 }
 
+#[napi]
+pub struct NativeAssets {
+    state: NativeAssetsState,
+}
+
+enum NativeAssetsState {
+    Leased {
+        assets: Vec<Asset>,
+        return_sender: tokio::sync::oneshot::Sender<Vec<Asset>>,
+    },
+    Released,
+}
+
+impl NativeAssets {
+    fn assets_mut(&mut self) -> Result<&mut Vec<Asset>> {
+        match &mut self.state {
+            NativeAssetsState::Leased { assets, .. } => Ok(assets),
+            NativeAssetsState::Released => Err(napi::Error::from_reason(
+                "native assets lease has been released",
+            )),
+        }
+    }
+
+    fn return_lease(&mut self) -> Result<()> {
+        let state = std::mem::replace(&mut self.state, NativeAssetsState::Released);
+        let NativeAssetsState::Leased {
+            assets,
+            return_sender,
+        } = state
+        else {
+            return Err(napi::Error::from_reason(
+                "native assets lease has already been released",
+            ));
+        };
+        return_sender
+            .send(assets)
+            .map_err(|_| napi::Error::from_reason("native assets lease receiver was dropped"))
+    }
+}
+
+impl Drop for NativeAssets {
+    fn drop(&mut self) {
+        let state = std::mem::replace(&mut self.state, NativeAssetsState::Released);
+        if let NativeAssetsState::Leased {
+            assets,
+            return_sender,
+        } = state
+        {
+            let _ = return_sender.send(assets);
+        }
+    }
+}
+
+#[napi]
+impl NativeAssets {
+    #[napi(js_name = "takeAssetSources")]
+    pub fn take_asset_sources(&mut self) -> Result<Vec<NativeAssetSource>> {
+        Ok(native_asset_sources(std::mem::take(self.assets_mut()?)))
+    }
+
+    #[napi(js_name = "replaceAssetSources")]
+    pub fn replace_asset_sources(&mut self, assets: Vec<NativeAssetSource>) -> Result<()> {
+        *self.assets_mut()? = assets.into_iter().map(asset_from_native).collect();
+        Ok(())
+    }
+
+    #[napi(js_name = "returnAssetsLease")]
+    pub fn return_assets_lease(&mut self) -> Result<()> {
+        self.return_lease()
+    }
+}
+
 #[napi(object)]
 pub struct NativeFlushResult {
     pub error: Option<NativeInfrastructureError>,
@@ -454,6 +543,7 @@ pub fn create_compiler(
     >,
     compilation_callback: Option<Function<'_, NativeCompilation, Promise<()>>>,
     finish_modules_callback: Option<Function<'_, NativeCompilation, Promise<()>>>,
+    process_assets_callback: Option<Function<'_, NativeAssets, Promise<()>>>,
 ) -> Result<NativeCompiler> {
     init_internal_tracing_from_env();
     NativeCompiler::new(
@@ -461,6 +551,7 @@ pub fn create_compiler(
         loader_callback,
         compilation_callback,
         finish_modules_callback,
+        process_assets_callback,
     )
 }
 
@@ -512,10 +603,13 @@ impl LoaderRunner for NativeLoaderRunner {
 
 type NativeFinishModulesCallback =
     ThreadsafeFunction<NativeCompilation, Promise<()>, NativeCompilation, Status, false, true>;
+type NativeProcessAssetsCallback =
+    ThreadsafeFunction<NativeAssets, Promise<()>, NativeAssets, Status, false, true>;
 
 struct NativeCompilationHooks {
     compilation: Arc<NativeFinishModulesCallback>,
     finish_modules: Arc<NativeFinishModulesCallback>,
+    process_assets: Arc<NativeProcessAssetsCallback>,
 }
 
 impl std::fmt::Debug for NativeCompilationHooks {
@@ -535,6 +629,13 @@ impl CompilationHooks for NativeCompilationHooks {
     ) -> HookFuture<'a> {
         call_finish_modules_hook(Arc::clone(&self.finish_modules), compilation)
     }
+
+    fn process_assets<'a>(
+        &'a self,
+        compilation: &'a mut unpack_core::Compilation,
+    ) -> HookFuture<'a> {
+        call_process_assets_hook(Arc::clone(&self.process_assets), compilation)
+    }
 }
 
 fn call_compilation_hook<'a>(
@@ -544,6 +645,7 @@ fn call_compilation_hook<'a>(
     let native_compilation = NativeCompilation {
         module_graph: NativeModuleGraph::Owned(unpack_core::ModuleGraph::default()),
         chunk_graph: unpack_core::ChunkGraph::default(),
+        assets: Vec::new(),
     };
     Box::pin(async move {
         let promise = callback
@@ -570,6 +672,7 @@ fn call_finish_modules_hook<'a>(
             return_sender,
         },
         chunk_graph: unpack_core::ChunkGraph::default(),
+        assets: Vec::new(),
     };
     Box::pin(async move {
         let callback_result = match callback.call_async_catch(native_compilation).await {
@@ -585,6 +688,36 @@ fn call_finish_modules_hook<'a>(
             message: format!("finishModules did not return the module graph lease: {error}"),
         })?;
         compilation.restore_module_graph(module_graph);
+        callback_result
+    })
+}
+
+fn call_process_assets_hook<'a>(
+    callback: Arc<NativeProcessAssetsCallback>,
+    compilation: &'a mut unpack_core::Compilation,
+) -> HookFuture<'a> {
+    let assets = compilation.take_assets();
+    let (return_sender, return_receiver) = tokio::sync::oneshot::channel();
+    let native_assets = NativeAssets {
+        state: NativeAssetsState::Leased {
+            assets,
+            return_sender,
+        },
+    };
+    Box::pin(async move {
+        let callback_result = match callback.call_async_catch(native_assets).await {
+            Ok(promise) => promise.await.map_err(|error| CoreError::Hook {
+                message: error.to_string(),
+            }),
+            Err(error) => Err(CoreError::Hook {
+                message: error.to_string(),
+            }),
+        };
+
+        let assets = return_receiver.await.map_err(|error| CoreError::Hook {
+            message: format!("processAssets did not return the assets lease: {error}"),
+        })?;
+        compilation.restore_assets(assets);
         callback_result
     })
 }
@@ -676,6 +809,7 @@ impl NativeCompiler {
         >,
         compilation_callback: Option<Function<'_, NativeCompilation, Promise<()>>>,
         finish_modules_callback: Option<Function<'_, NativeCompilation, Promise<()>>>,
+        process_assets_callback: Option<Function<'_, NativeAssets, Promise<()>>>,
     ) -> Result<Self> {
         let context = PathBuf::from(&options.context);
         let output_path = PathBuf::from(&options.output_path);
@@ -736,22 +870,31 @@ impl NativeCompiler {
             .transpose()?;
         compiler_options.compilation_hooks = compilation_callback
             .zip(finish_modules_callback)
-            .map(|(compilation_callback, finish_modules_callback)| {
-                let compilation: NativeFinishModulesCallback = compilation_callback
-                    .build_threadsafe_function()
-                    .callee_handled::<false>()
-                    .weak::<true>()
-                    .build()?;
-                let finish_modules: NativeFinishModulesCallback = finish_modules_callback
-                    .build_threadsafe_function()
-                    .callee_handled::<false>()
-                    .weak::<true>()
-                    .build()?;
-                Ok::<Arc<dyn CompilationHooks>, napi::Error>(Arc::new(NativeCompilationHooks {
-                    compilation: Arc::new(compilation),
-                    finish_modules: Arc::new(finish_modules),
-                }))
-            })
+            .zip(process_assets_callback)
+            .map(
+                |((compilation_callback, finish_modules_callback), process_assets_callback)| {
+                    let compilation: NativeFinishModulesCallback = compilation_callback
+                        .build_threadsafe_function()
+                        .callee_handled::<false>()
+                        .weak::<true>()
+                        .build()?;
+                    let finish_modules: NativeFinishModulesCallback = finish_modules_callback
+                        .build_threadsafe_function()
+                        .callee_handled::<false>()
+                        .weak::<true>()
+                        .build()?;
+                    let process_assets: NativeProcessAssetsCallback = process_assets_callback
+                        .build_threadsafe_function()
+                        .callee_handled::<false>()
+                        .weak::<true>()
+                        .build()?;
+                    Ok::<Arc<dyn CompilationHooks>, napi::Error>(Arc::new(NativeCompilationHooks {
+                        compilation: Arc::new(compilation),
+                        finish_modules: Arc::new(finish_modules),
+                        process_assets: Arc::new(process_assets),
+                    }))
+                },
+            )
             .transpose()?;
         let compiler = Compiler::new(compiler_options);
 
@@ -963,7 +1106,7 @@ async fn run_compiler_inner(
         output_path: output_path.to_string_lossy().into_owned(),
         watch_dependencies: watch_dependencies(compilation.watch_dependencies()),
     };
-    let (module_graph, chunk_graph) = compilation.into_graphs();
+    let (module_graph, chunk_graph, assets) = compilation.into_parts();
 
     NativeRunResult {
         error: None,
@@ -971,6 +1114,7 @@ async fn run_compiler_inner(
         compilation: Some(NativeCompilation {
             module_graph: NativeModuleGraph::Owned(module_graph),
             chunk_graph,
+            assets,
         }),
         logs,
     }
@@ -1187,6 +1331,31 @@ fn asset_stats(asset: &Asset) -> NativeAsset {
     NativeAsset {
         name: asset.filename.clone(),
         size: asset.source_bytes().len().try_into().unwrap_or(u32::MAX),
+    }
+}
+
+fn native_asset_sources(assets: Vec<Asset>) -> Vec<NativeAssetSource> {
+    assets
+        .into_iter()
+        .map(|asset| NativeAssetSource {
+            name: asset.filename,
+            source: Buffer::from(
+                asset
+                    .binary_source
+                    .unwrap_or_else(|| asset.source.into_bytes()),
+            ),
+        })
+        .collect()
+}
+
+fn asset_from_native(asset: NativeAssetSource) -> Asset {
+    let bytes = asset.source.to_vec();
+    let source = String::from_utf8_lossy(&bytes).into_owned();
+    let binary_source = std::str::from_utf8(&bytes).is_err().then_some(bytes);
+    Asset {
+        filename: asset.name,
+        source,
+        binary_source,
     }
 }
 

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -27,6 +27,8 @@ Unpack currently runs a compact Rust pipeline with a webpack-shaped sealing boun
    2. assign render IDs
    3. generate one result per module
    4. create assets
+3. awaited JavaScript `processAssets`
+4. emit assets
 
 Webpack's lifecycle is much larger: `Compiler.run` guards concurrent runs, calls run hooks, reads records, compiles, emits assets, emits records, stores build dependencies, and returns `Stats`. `Compiler.compile` creates normal and context module factories, runs make hooks, finishes the compilation, seals it, and then runs after-compile hooks.
 
@@ -50,6 +52,27 @@ a raw pointer concurrently. Purely materialized JavaScript records remain
 ordinary values. The final native graph is then rebound to the same JavaScript
 `Compilation`; already materialized connection targets are refreshed by handle
 and phase-dependent caches are invalidated in place.
+
+Generated assets use the same ownership-handoff pattern at the
+`processAssets` boundary. Rust moves the asset vector into a phase-scoped Node
+lease after `seal`; JavaScript materializes webpack `Source` values only when a
+plugin actually taps the hook, runs taps serially, and returns the updated asset
+set before output is written. This keeps asset mutation lock-free and prevents
+Rust emission from racing asynchronous plugin work. The supported façade
+includes the assets argument, `Compilation.assets`, `emitAsset`, `updateAsset`,
+and `getAsset`. Mutations made through the façade before `processAssets` are
+staged and merged when generated assets cross the host boundary. Unlike
+webpack, emitting different content to an existing filename currently uses the
+latest Source without adding a Compilation error; source-map metadata and the
+rest of webpack's Asset Info API remain outside this slice.
+
+The root Rust `CompilationHooks` trait is an object-safe host-transport seam
+owned by `CompilerOptions`, not an implementation of webpack's individual Hook
+classes. It aggregates the Node callbacks needed to pause the compiler at
+`compilation`, `finishModules`, and `processAssets`; the public hook objects and
+ordering behavior remain on the JavaScript `Compiler` and `Compilation`
+facades. This Rust-specific aggregate keeps N-API transport out of the core
+Compilation module.
 
 ## Cache layout
 

--- a/packages/unpack/package.json
+++ b/packages/unpack/package.json
@@ -17,11 +17,13 @@
     "test": "pnpm run build && tsc -p tsconfig.test.json && node --test dist-test/test/*.test.js",
     "typecheck": "tsc -p tsconfig.build.json --noEmit && tsc -p tsconfig.test.json --noEmit"
   },
+  "dependencies": {
+    "webpack-sources": "3.3.3"
+  },
   "devDependencies": {
     "@types/node": "26.0.1",
     "typescript": "6.0.3",
     "webpack": "5.108.1",
-    "webpack-bundle-analyzer": "5.3.0",
-    "webpack-sources": "3.3.3"
+    "webpack-bundle-analyzer": "5.3.0"
   }
 }

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -4,6 +4,7 @@ import { createRequire } from "node:module";
 import { statSync, watch as watchFileSystem } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { Source } from "webpack-sources";
 
 export interface UnpackOptions {
   name?: string;
@@ -173,6 +174,15 @@ export interface Compilation {
   readonly moduleGraph: ModuleGraph;
   readonly chunkGraph: ChunkGraph;
   readonly modules: ReadonlySet<Module>;
+  readonly assets: Record<string, Source>;
+  emitAsset(name: string, source: Source): void;
+  updateAsset(name: string, source: Source | ((source: Source) => Source)): void;
+  getAsset(name: string): CompilationAsset | undefined;
+}
+
+export interface CompilationAsset {
+  readonly name: string;
+  readonly source: Source;
 }
 
 export interface Chunk {
@@ -319,8 +329,32 @@ export interface FinishModulesHook {
   promise(modules: ReadonlySet<Module>): Promise<void>;
 }
 
+export interface ProcessAssetsHook {
+  tap(
+    options: string | TapOptions,
+    callback: (assets: Record<string, Source>) => void
+  ): void;
+  tapAsync(
+    options: string | TapOptions,
+    callback: (
+      assets: Record<string, Source>,
+      done: (error?: Error | null) => void
+    ) => void
+  ): void;
+  tapPromise(
+    options: string | TapOptions,
+    callback: (assets: Record<string, Source>) => PromiseLike<void>
+  ): void;
+  callAsync(
+    assets: Record<string, Source>,
+    callback: (error?: Error | null) => void
+  ): void;
+  promise(assets: Record<string, Source>): Promise<void>;
+}
+
 export interface CompilationHooks {
   readonly finishModules: FinishModulesHook;
+  readonly processAssets: ProcessAssetsHook;
 }
 
 export interface CompilationHook {
@@ -328,6 +362,7 @@ export interface CompilationHook {
 }
 
 export interface CompilerHooks {
+  readonly thisCompilation: CompilationHook;
   readonly compilation: CompilationHook;
   readonly done: DoneHook;
 }
@@ -494,6 +529,8 @@ interface NativeStatsJson {
 
 interface NativeCompilation {
   modules(): NativeModule[];
+  takeAssetSources(): NativeAssetSource[];
+  clearAssetSources(): void;
   outgoingConnections(moduleHandle: number): NativeModuleGraphConnection[];
   incomingConnections(moduleHandle: number): NativeModuleGraphConnection[];
   connectionsByHandle(connectionHandles: number[]): NativeModuleGraphConnection[];
@@ -502,6 +539,17 @@ interface NativeCompilation {
   moduleChunks(moduleHandle: number): number[];
   moduleId(moduleHandle: number): string | number | null;
   returnModuleGraphLease(): void;
+}
+
+interface NativeAssetSource {
+  name: string;
+  source: Uint8Array;
+}
+
+interface NativeAssets {
+  takeAssetSources(): NativeAssetSource[];
+  replaceAssetSources(assets: NativeAssetSource[]): void;
+  returnAssetsLease(): void;
 }
 
 interface NativeModule {
@@ -568,12 +616,14 @@ interface NativeBinding {
       options: string
     ) => Promise<string>,
     compilation?: (compilation: NativeCompilation) => Promise<void>,
-    finishModules?: (compilation: NativeCompilation) => Promise<void>
+    finishModules?: (compilation: NativeCompilation) => Promise<void>,
+    processAssets?: (assets: NativeAssets) => Promise<void>
   ): NativeCompiler;
 }
 
 const require = createRequire(import.meta.url);
 const native = require("./unpack_node.node") as NativeBinding;
+const { RawSource } = require("webpack-sources") as typeof import("webpack-sources");
 const unpackJavaScriptPath = fileURLToPath(import.meta.url);
 // The native addon is the compiled closure of the Rust compiler, parser, and
 // resolver; together with the JS entry and package metadata it is the runtime toolchain.
@@ -847,6 +897,79 @@ class FinishModulesHookImpl implements FinishModulesHook {
   }
 }
 
+interface ProcessAssetsTap {
+  name: string;
+  stage: number;
+  before: Set<string>;
+  run(assets: Record<string, Source>): Promise<void>;
+}
+
+class ProcessAssetsHookImpl implements ProcessAssetsHook {
+  readonly #taps: ProcessAssetsTap[] = [];
+
+  tap(
+    options: string | TapOptions,
+    callback: (assets: Record<string, Source>) => void
+  ): void {
+    assertFunction(callback, "callback");
+    this.#insert(options, async (assets) => { callback(assets); });
+  }
+
+  tapAsync(
+    options: string | TapOptions,
+    callback: (
+      assets: Record<string, Source>,
+      done: (error?: Error | null) => void
+    ) => void
+  ): void {
+    assertFunction(callback, "callback");
+    this.#insert(options, (assets) => new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const done = (error?: Error | null): void => {
+        if (settled) return;
+        settled = true;
+        error == null ? resolve() : reject(error);
+      };
+      try { callback(assets, done); } catch (error) { done(toError(error, "HookError")); }
+    }));
+  }
+
+  tapPromise(
+    options: string | TapOptions,
+    callback: (assets: Record<string, Source>) => PromiseLike<void>
+  ): void {
+    assertFunction(callback, "callback");
+    this.#insert(options, async (assets) => { await callback(assets); });
+  }
+
+  callAsync(
+    assets: Record<string, Source>,
+    callback: (error?: Error | null) => void
+  ): void {
+    assertFunction(callback, "callback");
+    void this.promise(assets).then(
+      () => callback(),
+      (error) => callback(toError(error, "HookError"))
+    );
+  }
+
+  async promise(assets: Record<string, Source>): Promise<void> {
+    for (const tap of this.#taps) await tap.run(assets);
+  }
+
+  isUsed(): boolean {
+    return this.#taps.length > 0;
+  }
+
+  #insert(
+    options: string | TapOptions,
+    run: (assets: Record<string, Source>) => Promise<void>
+  ): void {
+    const tap = { ...normalizeTapOptions(options), run };
+    insertOrderedTap(this.#taps, tap);
+  }
+}
+
 class CompilationHookImpl implements CompilationHook {
   readonly #taps: Array<{
     name: string;
@@ -894,6 +1017,7 @@ type CompilerLifecycle =
 
 class CompilerImpl implements Compiler {
   readonly hooks: CompilerHooks = {
+    thisCompilation: new CompilationHookImpl(),
     compilation: new CompilationHookImpl(),
     done: new DoneHookImpl()
   };
@@ -926,6 +1050,7 @@ class CompilerImpl implements Compiler {
         try {
           const compilation = new CompilationImpl(nativeCompilation);
           this.#activeCompilation = compilation;
+          (this.hooks.thisCompilation as CompilationHookImpl).call(compilation);
           (this.hooks.compilation as CompilationHookImpl).call(compilation);
         } catch (error) {
           this.#nativeHookError = toError(error, "HookError");
@@ -945,6 +1070,31 @@ class CompilerImpl implements Compiler {
             nativeCompilation.returnModuleGraphLease();
           } finally {
             compilation.releaseNativeCompilation();
+          }
+        }
+      },
+      async (nativeAssets) => {
+        const compilation = this.#activeCompilation;
+        let assetPhaseStarted = false;
+        try {
+          if (!compilation) {
+            throw new Error("processAssets ran without an active Compilation");
+          }
+          const hook = compilation.hooks.processAssets as ProcessAssetsHookImpl;
+          if (hook.isUsed() || compilation.hasPendingAssetMutations()) {
+            compilation.beginProcessAssets(nativeAssets.takeAssetSources());
+            assetPhaseStarted = true;
+            await hook.promise(compilation.assets);
+            nativeAssets.replaceAssetSources(compilation.serializeAssets());
+          }
+        } catch (error) {
+          this.#nativeHookError = toError(error, "HookError");
+          throw this.#nativeHookError;
+        } finally {
+          try {
+            nativeAssets.returnAssetsLease();
+          } finally {
+            if (assetPhaseStarted) compilation?.endProcessAssets();
           }
         }
       }
@@ -2198,13 +2348,36 @@ class ChunkGraphImpl implements ChunkGraph {
 }
 
 class CompilationImpl implements Compilation {
-  readonly hooks: CompilationHooks = { finishModules: new FinishModulesHookImpl() };
+  readonly hooks: CompilationHooks = {
+    finishModules: new FinishModulesHookImpl(),
+    processAssets: new ProcessAssetsHookImpl()
+  };
   readonly moduleGraph: ModuleGraphImpl;
   readonly chunkGraph: ChunkGraphImpl;
   readonly modules: ReadonlySet<Module>;
   readonly #modulesByHandle = new Map<number, ModuleImpl>();
   readonly #chunksByHandle = new Map<number, ChunkImpl>();
   readonly #moduleSet = new Set<Module>();
+  readonly #assetValues = Object.create(null) as Record<string, Source>;
+  readonly assets: Record<string, Source> = new Proxy(this.#assetValues, {
+    set: (target, property, value) => {
+      Reflect.set(target, property, value);
+      if (typeof property === "string" && !this.#assetMutationActive) {
+        this.#assetMutationPending = true;
+      }
+      return true;
+    },
+    deleteProperty: (target, property) => {
+      const deleted = Reflect.deleteProperty(target, property);
+      if (deleted && typeof property === "string" && !this.#assetMutationActive) {
+        this.#assetMutationPending = true;
+      }
+      return deleted;
+    }
+  });
+  #assetMutationActive = false;
+  #assetMutationPending = false;
+  #assetsMaterialized = false;
 
   constructor(compilation: NativeCompilation | null | undefined) {
     this.moduleGraph = new ModuleGraphImpl(this.#modulesByHandle);
@@ -2253,6 +2426,15 @@ class CompilationImpl implements Compilation {
         );
       }
     }
+    if (!this.#assetsMaterialized) {
+      const assetSources = compilation?.takeAssetSources() ?? [];
+      if (assetSources.length > 0) {
+        this.#replaceAssets(assetSources);
+        this.#assetsMaterialized = true;
+      }
+    } else {
+      compilation?.clearAssetSources();
+    }
     this.moduleGraph.updateNativeCompilation(compilation ?? undefined);
     this.chunkGraph.updateNativeCompilation(compilation ?? undefined);
   }
@@ -2260,6 +2442,72 @@ class CompilationImpl implements Compilation {
   releaseNativeCompilation(): void {
     this.moduleGraph.releaseNativeCompilation();
     this.chunkGraph.updateNativeCompilation(undefined);
+  }
+
+  beginProcessAssets(assets: NativeAssetSource[]): void {
+    const pendingAssets = this.#assetMutationPending
+      ? Object.entries(this.assets)
+      : [];
+    this.#replaceAssets(assets);
+    this.#assetMutationActive = true;
+    for (const [name, source] of pendingAssets) this.assets[name] = source;
+    this.#assetsMaterialized = true;
+    this.#assetMutationPending = false;
+  }
+
+  endProcessAssets(): void {
+    this.#assetMutationActive = false;
+  }
+
+  hasPendingAssetMutations(): boolean {
+    return this.#assetMutationPending;
+  }
+
+  serializeAssets(): NativeAssetSource[] {
+    return Object.entries(this.assets).map(([name, source]) => {
+      assertSource(source, `assets[${JSON.stringify(name)}]`);
+      const buffer = source.buffer();
+      return { name, source: Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer) };
+    });
+  }
+
+  emitAsset(name: string, source: Source): void {
+    assertNonEmptyString(name, "name");
+    assertSource(source, "source");
+    this.assets[name] = source;
+  }
+
+  updateAsset(name: string, source: Source | ((source: Source) => Source)): void {
+    assertNonEmptyString(name, "name");
+    const current = this.assets[name];
+    if (!current) throw new Error(`asset ${JSON.stringify(name)} does not exist`);
+    const updated = typeof source === "function" ? source(current) : source;
+    assertSource(updated, "source");
+    this.assets[name] = updated;
+  }
+
+  getAsset(name: string): CompilationAsset | undefined {
+    const source = this.assets[name];
+    return source ? { name, source } : undefined;
+  }
+
+  #replaceAssets(assets: NativeAssetSource[]): void {
+    for (const name of Object.keys(this.#assetValues)) delete this.#assetValues[name];
+    for (const asset of assets) {
+      const source = Buffer.isBuffer(asset.source)
+        ? asset.source
+        : Buffer.from(asset.source);
+      this.#assetValues[asset.name] = new RawSource(source);
+    }
+  }
+
+}
+
+function assertSource(value: unknown, name: string): asserts value is Source {
+  if (typeof value !== "object" || value === null ||
+      typeof (value as { source?: unknown }).source !== "function" ||
+      typeof (value as { buffer?: unknown }).buffer !== "function") {
+    throw new TypeError(`${name} must be a webpack Source`);
   }
 }
 

--- a/packages/unpack/test/configCases/plugins/internal-entrypoints/case.config.json
+++ b/packages/unpack/test/configCases/plugins/internal-entrypoints/case.config.json
@@ -1,1 +1,1 @@
-{"skip":{"upstream":"https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/plugins/internal-entrypoints","issue":"https://github.com/unpack-dev/unpack/issues/244","reason":"Compilation.entrypoints and emitAsset are not exposed"}}
+{"skip":{"upstream":"https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/plugins/internal-entrypoints","issue":"https://github.com/unpack-dev/unpack/issues/244","reason":"Compilation.entrypoints is not exposed"}}

--- a/packages/unpack/test/configCases/plugins/internal-processAssets-param-assets/case.config.json
+++ b/packages/unpack/test/configCases/plugins/internal-processAssets-param-assets/case.config.json
@@ -1,1 +1,0 @@
-{"skip":{"upstream":"https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/plugins/internal-processAssets-param-assets","issue":"https://github.com/unpack-dev/unpack/issues/243","reason":"the processAssets assets facade is not exposed"}}

--- a/packages/unpack/test/configCases/plugins/internal-processAssets-param-assets/test.config.ts
+++ b/packages/unpack/test/configCases/plugins/internal-processAssets-param-assets/test.config.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+
+import type { ConfigCaseTest } from "../../../config-case.js";
+
+export default {
+  validate({ outputFiles, requireEntry }) {
+    assert.equal(outputFiles.includes("dup.txt"), false);
+    requireEntry();
+  }
+} satisfies ConfigCaseTest;

--- a/packages/unpack/test/configCases/plugins/internal-processAssets-param-assets/webpack.config.js
+++ b/packages/unpack/test/configCases/plugins/internal-processAssets-param-assets/webpack.config.js
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
-import { RawSource } from "webpack-sources";
+import webpackSources from "webpack-sources";
+
+const { RawSource } = webpackSources;
 
 export default { plugins: [{ apply(compiler) { compiler.hooks.compilation.tap("plugin", (compilation) => {
   compilation.hooks.processAssets.tapPromise("plugin", async (assets) => {

--- a/packages/unpack/test/configCases/plugins/internal-processAssets/case.config.json
+++ b/packages/unpack/test/configCases/plugins/internal-processAssets/case.config.json
@@ -1,7 +1,0 @@
-{
-  "skip": {
-    "upstream": "https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/plugins/internal-processAssets",
-    "issue": "https://github.com/unpack-dev/unpack/issues/243",
-    "reason": "compilation.hooks.processAssets and updateAsset are not exposed"
-  }
-}

--- a/packages/unpack/test/configCases/plugins/internal-processAssets/test.config.ts
+++ b/packages/unpack/test/configCases/plugins/internal-processAssets/test.config.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { ConfigCaseTest } from "../../../config-case.js";
+
+export default {
+  async validate({ outputPath, requireEntry }) {
+    assert.equal((await readFile(join(outputPath, "main.js"), "utf8")).startsWith("//banner;\n"), true);
+    requireEntry();
+  }
+} satisfies ConfigCaseTest;

--- a/packages/unpack/test/configCases/plugins/internal-processAssets/webpack.config.js
+++ b/packages/unpack/test/configCases/plugins/internal-processAssets/webpack.config.js
@@ -1,6 +1,8 @@
 // Ported from Rspack's plugins/internal-processAssets config case.
 import assert from "node:assert/strict";
-import { ConcatSource, RawSource } from "webpack-sources";
+import webpackSources from "webpack-sources";
+
+const { ConcatSource, RawSource } = webpackSources;
 
 export default {
   plugins: [

--- a/packages/unpack/test/configCases/plugins/manifest-plugin/case.config.json
+++ b/packages/unpack/test/configCases/plugins/manifest-plugin/case.config.json
@@ -1,1 +1,0 @@
-{"skip":{"upstream":"https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/plugins/manifest-plugin","issue":"https://github.com/unpack-dev/unpack/issues/243","reason":"processAssets and emitAsset are not exposed"}}

--- a/packages/unpack/test/configCases/plugins/manifest-plugin/test.config.ts
+++ b/packages/unpack/test/configCases/plugins/manifest-plugin/test.config.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { ConfigCaseTest } from "../../../config-case.js";
+
+export default {
+  async validate({ outputFiles, outputPath, requireEntry }) {
+    assert.equal(outputFiles.includes("third.party.js"), true);
+    assert.equal(await readFile(join(outputPath, "third.party.js"), "utf8"), "third party");
+    requireEntry();
+  }
+} satisfies ConfigCaseTest;

--- a/packages/unpack/test/configCases/plugins/manifest-plugin/webpack.config.js
+++ b/packages/unpack/test/configCases/plugins/manifest-plugin/webpack.config.js
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
-import { RawSource } from "webpack-sources";
+import webpackSources from "webpack-sources";
+
+const { RawSource } = webpackSources;
 
 export default { plugins: [{ apply(compiler) {
   compiler.hooks.thisCompilation.tap("plugin", (compilation) => {

--- a/packages/unpack/test/process-assets.test.ts
+++ b/packages/unpack/test/process-assets.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import unpack from "@unpack-js/core";
+import type { Compiler as UnpackCompiler, WebpackPlugin } from "@unpack-js/core";
+import webpack from "webpack";
+import type { Compiler as WebpackCompiler, WebpackPluginInstance } from "webpack";
+import webpackSources from "webpack-sources";
+
+const { ConcatSource, RawSource } = webpackSources;
+
+interface ProcessAssetsCompilation {
+  readonly assets: Record<string, import("webpack-sources").Source>;
+  readonly hooks: {
+    processAssets: {
+      tapPromise(
+        name: string,
+        callback: (assets: Record<string, import("webpack-sources").Source>) => Promise<void>
+      ): void;
+    };
+  };
+  emitAsset(name: string, source: import("webpack-sources").Source): void;
+  updateAsset(name: string, source: import("webpack-sources").Source): void;
+}
+
+interface ProcessAssetsCompiler {
+  readonly hooks: {
+    thisCompilation: {
+      tap(name: string, callback: (compilation: ProcessAssetsCompilation) => void): void;
+    };
+  };
+}
+
+test("processAssets matches webpack ordering and emitted asset mutations", async () => {
+  const fixture = await mkdtemp(join(tmpdir(), "unpack-process-assets-"));
+  await mkdir(join(fixture, "src"), { recursive: true });
+  await writeFile(join(fixture, "src/index.js"), "export default 42;\n");
+  const unpackOutput = join(fixture, "dist-unpack");
+  const webpackOutput = join(fixture, "dist-webpack");
+  const unpackEvents: string[] = [];
+  const webpackEvents: string[] = [];
+  const unpackCompiler = unpack({
+    context: fixture,
+    mode: "none",
+    entry: "./src/index.js",
+    output: { path: unpackOutput },
+    sourcemap: false,
+    plugins: [createProcessAssetsPlugin(unpackEvents) as unknown as WebpackPlugin]
+  });
+  assert.ok(unpackCompiler);
+  const webpackCompiler = webpack({
+    context: fixture,
+    mode: "none",
+    entry: "./src/index.js",
+    output: { path: webpackOutput },
+    devtool: false,
+    plugins: [
+      createProcessAssetsPlugin(webpackEvents) as unknown as WebpackPluginInstance
+    ]
+  });
+
+  try {
+    await Promise.all([runUnpack(unpackCompiler), runWebpack(webpackCompiler)]);
+    assert.deepEqual(unpackEvents, webpackEvents);
+    assert.deepEqual(unpackEvents, ["first:start", "first:end", "second"]);
+    for (const outputPath of [unpackOutput, webpackOutput]) {
+      assert.equal(
+        (await readFile(join(outputPath, "main.js"), "utf8")).startsWith("//banner;\n"),
+        true
+      );
+      assert.equal(await readFile(join(outputPath, "early.txt"), "utf8"), "early");
+      assert.equal(await readFile(join(outputPath, "manifest.txt"), "utf8"), "manifest");
+    }
+  } finally {
+    await Promise.all([closeUnpack(unpackCompiler), closeWebpack(webpackCompiler)]);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+function createProcessAssetsPlugin(events: string[]): { apply(compiler: ProcessAssetsCompiler): void } {
+  return {
+    apply(compiler) {
+      compiler.hooks.thisCompilation.tap("process assets comparison", (compilation) => {
+        compilation.emitAsset("early.txt", new RawSource("early"));
+        compilation.hooks.processAssets.tapPromise("first", async () => {
+          events.push("first:start");
+          await Promise.resolve();
+          compilation.updateAsset(
+            "main.js",
+            new ConcatSource(new RawSource("//banner;\n"), compilation.assets["main.js"])
+          );
+          compilation.emitAsset("manifest.txt", new RawSource("manifest"));
+          events.push("first:end");
+        });
+        compilation.hooks.processAssets.tapPromise("second", async (assets) => {
+          assert.deepEqual(Object.keys(assets).sort(), ["early.txt", "main.js", "manifest.txt"]);
+          events.push("second");
+        });
+      });
+    }
+  };
+}
+
+function runUnpack(compiler: UnpackCompiler): Promise<void> {
+  return new Promise((resolve, reject) => {
+    compiler.run((error) => error ? reject(error) : resolve());
+  });
+}
+
+function runWebpack(compiler: WebpackCompiler): Promise<void> {
+  return new Promise((resolve, reject) => {
+    compiler.run((error) => error ? reject(error) : resolve());
+  });
+}
+
+function closeUnpack(compiler: UnpackCompiler): Promise<void> {
+  return new Promise((resolve, reject) => {
+    compiler.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+function closeWebpack(compiler: WebpackCompiler): Promise<void> {
+  return new Promise((resolve, reject) => {
+    compiler.close((error) => error ? reject(error) : resolve());
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,10 @@ importers:
         version: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))
 
   packages/unpack:
+    dependencies:
+      webpack-sources:
+        specifier: 3.3.3
+        version: 3.3.3
     devDependencies:
       '@types/node':
         specifier: 26.0.1
@@ -52,9 +56,6 @@ importers:
       webpack-bundle-analyzer:
         specifier: 5.3.0
         version: 5.3.0
-      webpack-sources:
-        specifier: 3.3.3
-        version: 3.3.3
 
 packages:
 


### PR DESCRIPTION
Closes #243.

## Summary

- add webpack-shaped `thisCompilation` and asynchronous `compilation.hooks.processAssets` lifecycle support
- expose the process-assets argument, `Compilation.assets`, `emitAsset`, `updateAsset`, and `getAsset`
- hand generated assets to Node through an ownership lease, materialize `webpack-sources` values only when needed, then return mutations before output is written
- enable the three Rspack-derived process-assets config cases and add a pinned-webpack comparison covering early emission, tap ordering, updates, and emitted files
- correct the stale default-case fixture path that caused the existing main CI failure

## Why

The ported plugin cases could not run because Unpack stopped its JavaScript Compilation surface at `finishModules`. This adds a model-backed asset phase after seal and before emission, while keeping Rust and asynchronous JavaScript from sharing mutable asset state.

The bridge uses consumptive Buffer handoff so final assets are not retained as duplicate native and JavaScript copies. Asset Info/source-map metadata remain out of scope. Duplicate filename conflicts currently use the latest Source without adding webpack's Compilation diagnostic; that alignment gap is documented.

## Tests

- `cargo fmt --all -- --check`
- `pnpm --filter @unpack-js/core typecheck`
- `git diff --check`
- `pnpm test`
