### PR TITLE
Implement unsafe module cache reuse

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -435,3 +435,7 @@ _Avoid_: Path joiner, import parser
 **Normal Module Factory**:
 The component that factorizes module dependencies into normal modules by resolving requests and creating module identities.
 _Avoid_: Module builder, resolver wrapper
+
+**Unsafe Module Cache**:
+A Compiler-owned cache that reuses a previously factorized Module in a fresh Compilation, skipping request resolution and factory work while still running the normal Build stage and its snapshot validation.
+_Avoid_: Resolve cache, Module Build Cache, shared Module Graph

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -11,7 +11,7 @@ use crate::{
     cache::Cache,
     code_generation::{self, CodeGenerationResults, RenderManifest},
     id_assignment::{assign_chunk_render_ids, assign_module_render_ids},
-    make::{self, MakeState},
+    make::{self, MakeState, UnsafeModuleCache},
     module_computation_cache::ModuleComputationCache,
     snapshot::FileSystemInfo,
 };
@@ -26,6 +26,7 @@ pub struct Compilation {
     resolver: UnpackResolver,
     cache: Cache,
     module_computation_cache: Option<ModuleComputationCache>,
+    unsafe_module_cache: Option<UnsafeModuleCache>,
     module_graph: ModuleGraph,
     chunk_graph: ChunkGraph,
     render_ids_assigned: bool,
@@ -46,6 +47,7 @@ impl Compilation {
         resolver: UnpackResolver,
         cache: Cache,
         module_computation_cache: Option<ModuleComputationCache>,
+        unsafe_module_cache: Option<UnsafeModuleCache>,
         hooks: CompilationHookSet,
     ) -> Self {
         let file_system_info = FileSystemInfo::from_snapshot_options(&options.snapshot);
@@ -54,6 +56,7 @@ impl Compilation {
             resolver,
             cache,
             module_computation_cache,
+            unsafe_module_cache,
             module_graph: ModuleGraph::default(),
             chunk_graph: ChunkGraph::default(),
             render_ids_assigned: false,
@@ -160,6 +163,7 @@ impl Compilation {
                 &self.options,
                 self.resolver.clone(),
                 self.cache.clone(),
+                self.unsafe_module_cache.clone(),
                 self.file_system_info.clone(),
                 self.hooks.normal_module_factory_hooks.clone(),
                 self.hooks.javascript_parser.clone(),

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -1,7 +1,7 @@
 // Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/Compiler.js
 
 use std::{
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{Arc, Mutex, Weak},
     time::Duration,
 };
@@ -13,7 +13,8 @@ use crate::{
     flag_dependency_exports_plugin::FlagDependencyExportsPlugin,
     flag_dependency_usage_plugin::FlagDependencyUsagePlugin,
     javascript::javascript_modules_plugin::JavascriptModulesPlugin,
-    json::json_modules_plugin::JsonModulesPlugin, module_computation_cache::ModuleComputationCache,
+    json::json_modules_plugin::JsonModulesPlugin, make::UnsafeModuleCache,
+    module_computation_cache::ModuleComputationCache,
     optimize::side_effects_flag_plugin::SideEffectsFlagPlugin,
 };
 use tracing::Instrument;
@@ -28,6 +29,25 @@ pub enum SideEffectsOption {
     Disabled,
     Flag,
     Analyze,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModuleUnsafeCache {
+    Disabled,
+    NodeModules,
+    All,
+}
+
+impl ModuleUnsafeCache {
+    pub(crate) fn allows(self, resource: &Path) -> bool {
+        match self {
+            Self::Disabled => false,
+            Self::All => true,
+            Self::NodeModules => resource
+                .components()
+                .any(|component| component.as_os_str() == "node_modules"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -61,6 +81,7 @@ pub struct CompilerOptions {
     pub provided_exports: bool,
     pub used_exports: bool,
     pub side_effects: SideEffectsOption,
+    pub module_unsafe_cache: ModuleUnsafeCache,
 }
 
 impl CompilerOptions {
@@ -80,6 +101,7 @@ impl CompilerOptions {
             provided_exports: true,
             used_exports: true,
             side_effects: SideEffectsOption::Flag,
+            module_unsafe_cache: ModuleUnsafeCache::Disabled,
         }
     }
 }
@@ -90,6 +112,7 @@ pub struct Compiler {
     cache: Cache,
     cache_lifecycle: Arc<CacheLifecycle>,
     module_computation_cache: Option<ModuleComputationCache>,
+    unsafe_module_cache: Option<UnsafeModuleCache>,
     hooks: CompilerHookSet,
 }
 
@@ -669,6 +692,9 @@ impl Compiler {
             .cache
             .cache_unaffected
             .then(ModuleComputationCache::default);
+        let unsafe_module_cache = (options.cache.kind != crate::CacheKind::Disabled
+            && options.module_unsafe_cache != ModuleUnsafeCache::Disabled)
+            .then(UnsafeModuleCache::default);
         let mut hooks = CompilerHookSet::default();
         configure_default_module_types(&mut hooks);
         apply_builtin_module_plugins(&mut hooks);
@@ -688,6 +714,7 @@ impl Compiler {
             cache,
             cache_lifecycle,
             module_computation_cache,
+            unsafe_module_cache,
             hooks,
         }
     }
@@ -704,6 +731,7 @@ impl Compiler {
             UnpackResolver::new(self.options.resolve.clone()),
             self.cache.clone(),
             self.module_computation_cache.clone(),
+            self.unsafe_module_cache.clone(),
             compilation_hooks,
         )
     }
@@ -943,6 +971,58 @@ mod tests {
             first.chunk_graph().chunks().as_ptr(),
             second.chunk_graph().chunks().as_ptr()
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unsafe_cache_reuses_modules_without_factorizing_or_sharing_compilation_graphs()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write(
+            temp.path().join("index.js"),
+            r#"
+                import "./dep";
+                export const result = "ok";
+            "#,
+        )?;
+        write(temp.path().join("dep.js"), "export const value = 1;")?;
+
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.module_unsafe_cache = crate::ModuleUnsafeCache::All;
+        let compiler = Compiler::new(options);
+
+        let first = compiler.run().await?;
+        let first_cache = compiler.cache.stats();
+        assert_eq!(first_cache.resolve_misses, 2);
+        assert_eq!(first_cache.module_misses, 2);
+
+        let second = compiler.run().await?;
+        let second_cache = compiler.cache.stats();
+        assert_eq!(second_cache.resolve_hits, 0);
+        assert_eq!(second_cache.module_hits, 2);
+        assert_eq!(second_cache.resolve_misses, 2);
+        assert_eq!(second_cache.module_misses, 2);
+
+        assert_eq!(first.errors(), []);
+        assert_eq!(second.errors(), []);
+        assert_eq!(asset_sources(&first), asset_sources(&second));
+        assert_eq!(first.module_graph(), second.module_graph());
+        assert_ne!(
+            first.module_graph().modules().as_ptr(),
+            second.module_graph().modules().as_ptr()
+        );
+        for (first_module, second_module) in first
+            .module_graph()
+            .modules()
+            .iter()
+            .zip(second.module_graph().modules())
+        {
+            assert!(Arc::ptr_eq(
+                first_module.built_content(),
+                second_module.built_content()
+            ));
+        }
 
         Ok(())
     }

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -53,7 +53,7 @@ pub use code_generation::Asset;
 pub use compilation::{Compilation, WatchDependencies};
 pub use compiler::{
     CacheIdleReason, CacheLifecycleOutcome, Compiler, CompilerOptions, DEFAULT_EXTENSIONS, Entry,
-    PendingCompilation, SideEffectsOption,
+    ModuleUnsafeCache, PendingCompilation, SideEffectsOption,
 };
 pub use dependencies::{
     ConstDependency, EntryDependency, HarmonyExportExpressionDependency,

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -10,6 +10,7 @@ use std::{
     time::Instant,
 };
 
+use dashmap::DashMap;
 use futures::{StreamExt, stream::FuturesUnordered};
 use tokio::{
     sync::{Mutex, Semaphore},
@@ -18,8 +19,9 @@ use tokio::{
 
 use crate::{
     AsyncDependenciesBlockIndex, CompilerOptions, Dependency, DependencyIndex, EntryDependency,
-    Error, FactorizedModule, LoaderRequest, LoaderRunner, MatchedLoader, ModuleGraph, ModuleHandle,
-    ModuleIdentity, NormalModuleFactory, Result, SnapshotStrategy, UnpackResolver,
+    Error, FactorizedModule, LoaderRequest, LoaderRunner, MatchedLoader, Module, ModuleGraph,
+    ModuleHandle, ModuleIdentity, ModuleUnsafeCache, NormalModuleFactory, Result, SnapshotStrategy,
+    UnpackResolver,
     cache::{Cache, ModuleBuildRecord},
     cache_facade::{CacheETag, ModuleBuildCache},
     module::BuiltModuleContent,
@@ -37,6 +39,22 @@ pub(crate) struct MakeState {
     pub context_dependencies: HashSet<PathBuf>,
     pub missing_dependencies: HashSet<PathBuf>,
     modules_by_identity: HashMap<ModuleIdentity, ModuleHandle>,
+    unsafe_cache_candidates: Vec<UnsafeCacheCandidate>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct UnsafeModuleCache {
+    entries: Arc<DashMap<UnsafeModuleCacheKey, UnsafeCachedModule>>,
+}
+
+impl UnsafeModuleCache {
+    fn get(&self, key: &UnsafeModuleCacheKey) -> Option<UnsafeCachedModule> {
+        self.entries.get(key).map(|entry| entry.clone())
+    }
+
+    fn store(&self, key: UnsafeModuleCacheKey, module: UnsafeCachedModule) {
+        self.entries.insert(key, module);
+    }
 }
 
 #[derive(Clone)]
@@ -52,6 +70,8 @@ struct MakeServices {
     metrics: Arc<MakeMetrics>,
     semaphore: Arc<Semaphore>,
     module_types: ModuleTypeRegistry,
+    unsafe_module_cache: Option<UnsafeModuleCache>,
+    module_unsafe_cache: ModuleUnsafeCache,
 }
 
 #[derive(Debug)]
@@ -113,6 +133,7 @@ impl MakeMetrics {
 #[derive(Debug, Clone)]
 enum MakeTask {
     Factorize(FactorizeTask),
+    ReuseModule(ReuseModuleTask),
     Add(AddTask),
     Build(BuildTask),
     ProcessDependencies(ProcessDependenciesTask),
@@ -127,11 +148,19 @@ struct FactorizeTask {
 }
 
 #[derive(Debug, Clone)]
+struct ReuseModuleTask {
+    origin_module: Option<ModuleHandle>,
+    dependencies: Vec<QueuedDependency>,
+    cached: UnsafeCachedModule,
+}
+
+#[derive(Debug, Clone)]
 struct AddTask {
     origin_module: Option<ModuleHandle>,
     context: PathBuf,
     dependencies: Vec<QueuedDependency>,
     result: FactorizeTaskResult,
+    unsafe_cache_candidate: Option<UnsafeCacheCandidate>,
 }
 
 #[derive(Debug, Clone)]
@@ -186,12 +215,51 @@ struct FactorizeGroupKey {
     resource_identifier: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct UnsafeModuleCacheKey {
+    context: PathBuf,
+    group: FactorizeGroupKey,
+}
+
+#[derive(Debug, Clone)]
+struct UnsafeCachedModule {
+    module: Module,
+    factory_metadata: UnsafeModuleFactoryMetadata,
+}
+
+#[derive(Debug, Clone)]
+struct UnsafeCacheCandidate {
+    key: UnsafeModuleCacheKey,
+    identity: ModuleIdentity,
+    factory_metadata: UnsafeModuleFactoryMetadata,
+}
+
+#[derive(Debug, Clone)]
+struct UnsafeModuleFactoryMetadata {
+    loader: Option<MatchedLoader>,
+    file_dependencies: HashSet<PathBuf>,
+    context_dependencies: HashSet<PathBuf>,
+    missing_dependencies: HashSet<PathBuf>,
+}
+
+impl UnsafeModuleFactoryMetadata {
+    fn from_factorized(module: &FactorizedModule) -> Self {
+        Self {
+            loader: module.loader.clone(),
+            file_dependencies: module.file_dependencies.clone(),
+            context_dependencies: module.context_dependencies.clone(),
+            missing_dependencies: module.missing_dependencies.clone(),
+        }
+    }
+}
+
 type BackgroundMakeTask = JoinHandle<Result<Vec<MakeTask>>>;
 
 pub(crate) async fn run(
     options: &CompilerOptions,
     resolver: UnpackResolver,
     cache: Cache,
+    unsafe_module_cache: Option<UnsafeModuleCache>,
     file_system_info: FileSystemInfo,
     module_types: ModuleTypeRegistry,
     parser_hooks: JavascriptParserHookSet,
@@ -219,6 +287,8 @@ pub(crate) async fn run(
         metrics: Arc::new(MakeMetrics::new()),
         semaphore: Arc::new(Semaphore::new(options.parallelism.max(1))),
         module_types,
+        unsafe_module_cache,
+        module_unsafe_cache: options.module_unsafe_cache,
     };
 
     let mut main_queue = VecDeque::new();
@@ -265,6 +335,9 @@ pub(crate) async fn run(
         }
 
         if background_queue.is_empty() {
+            if let Some(cache) = &services.unsafe_module_cache {
+                state.lock().await.populate_unsafe_cache(cache);
+            }
             services.metrics.emit();
             return Ok(());
         }
@@ -289,12 +362,25 @@ pub(crate) async fn run(
 }
 
 fn schedule_make_task(
-    task: MakeTask,
+    mut task: MakeTask,
     services: MakeServices,
     state: Arc<Mutex<MakeState>>,
     main_queue: &mut VecDeque<MakeTask>,
     background_queue: &mut FuturesUnordered<BackgroundMakeTask>,
 ) {
+    // Webpack checks unsafeCache while processing dependencies, before work is
+    // admitted to the factorize queue.
+    if let MakeTask::Factorize(factorize) = &task
+        && let Some(cache) = &services.unsafe_module_cache
+        && let Some(key) = factorize.unsafe_cache_key()
+        && let Some(cached) = cache.get(&key)
+    {
+        task = MakeTask::ReuseModule(ReuseModuleTask {
+            origin_module: factorize.origin_module,
+            dependencies: factorize.dependencies.clone(),
+            cached,
+        });
+    }
     if task.is_background() {
         background_queue.push(spawn_make_task(task, services, state));
     } else {
@@ -336,11 +422,12 @@ impl MakeTask {
         let metric = match &self {
             Self::Factorize(_) => Some(MakeTaskMetric::Factorize),
             Self::Build(_) => Some(MakeTaskMetric::Build),
-            Self::Add(_) | Self::ProcessDependencies(_) => None,
+            Self::ReuseModule(_) | Self::Add(_) | Self::ProcessDependencies(_) => None,
         };
         let started = metric.and_then(|_| metrics.started());
         let result = match self {
             Self::Factorize(task) => task.run(services).await,
+            Self::ReuseModule(task) => task.run(state).await,
             Self::Add(task) => task.run(state).await,
             Self::Build(task) => task.run(services, state).await,
             Self::ProcessDependencies(task) => Ok(task.run()),
@@ -353,6 +440,14 @@ impl MakeTask {
 }
 
 impl FactorizeTask {
+    fn unsafe_cache_key(&self) -> Option<UnsafeModuleCacheKey> {
+        let dependency = self.dependencies.first()?;
+        Some(UnsafeModuleCacheKey {
+            context: self.context.clone(),
+            group: FactorizeGroupKey::for_dependency(&dependency.dependency)?,
+        })
+    }
+
     async fn run(self, services: MakeServices) -> Result<Vec<MakeTask>> {
         let _permit = services
             .semaphore
@@ -377,11 +472,60 @@ impl FactorizeTask {
             Err(error) => return Err(error),
         };
 
+        let unsafe_cache_candidate = match &result {
+            FactorizeTaskResult::Success(factorized)
+                if services.unsafe_module_cache.is_some()
+                    && services
+                        .module_unsafe_cache
+                        .allows(&factorized.identity.resource) =>
+            {
+                self.unsafe_cache_key().map(|key| UnsafeCacheCandidate {
+                    key,
+                    identity: factorized.identity.clone(),
+                    factory_metadata: UnsafeModuleFactoryMetadata::from_factorized(factorized),
+                })
+            }
+            _ => None,
+        };
+
         Ok(vec![MakeTask::Add(AddTask {
             origin_module: self.origin_module,
             context: self.context,
             dependencies: self.dependencies,
             result,
+            unsafe_cache_candidate,
+        })])
+    }
+}
+
+impl ReuseModuleTask {
+    async fn run(self, state: Arc<Mutex<MakeState>>) -> Result<Vec<MakeTask>> {
+        let UnsafeCachedModule {
+            module,
+            factory_metadata,
+        } = self.cached;
+        let mut state = state.lock().await;
+        state
+            .file_dependencies
+            .extend(factory_metadata.file_dependencies.iter().cloned());
+        state
+            .context_dependencies
+            .extend(factory_metadata.context_dependencies.iter().cloned());
+        state
+            .missing_dependencies
+            .extend(factory_metadata.missing_dependencies.iter().cloned());
+        let add_result =
+            state.add_cached_or_connect(self.origin_module, self.dependencies, &module);
+        if !add_result.is_new {
+            return Ok(Vec::new());
+        }
+        // unsafeCache skips factory work, but webpack still sends the restored
+        // Module through Build so its ordinary snapshot validation remains active.
+        Ok(vec![MakeTask::Build(BuildTask {
+            module_handle: add_result.module_handle,
+            identity: module.identity().clone(),
+            resource: module.identity().resource.clone(),
+            loader: factory_metadata.loader,
         })])
     }
 }
@@ -390,6 +534,9 @@ impl AddTask {
     async fn run(self, state: Arc<Mutex<MakeState>>) -> Result<Vec<MakeTask>> {
         match self.result {
             FactorizeTaskResult::Success(factorized) => {
+                if let Some(candidate) = self.unsafe_cache_candidate {
+                    state.lock().await.unsafe_cache_candidates.push(candidate);
+                }
                 let identity = factorized.identity;
                 let resource = factorized.resource;
                 let loader = factorized.loader;
@@ -783,6 +930,49 @@ fn normalize_missing_resource(path: PathBuf) -> PathBuf {
 }
 
 impl MakeState {
+    fn populate_unsafe_cache(&self, cache: &UnsafeModuleCache) {
+        for candidate in &self.unsafe_cache_candidates {
+            let Some(module_handle) = self.modules_by_identity.get(&candidate.identity) else {
+                continue;
+            };
+            let Some(module) = self.module_graph.module(*module_handle) else {
+                continue;
+            };
+            if module.build_error().is_some() {
+                continue;
+            }
+            cache.store(
+                candidate.key.clone(),
+                UnsafeCachedModule {
+                    module: module.clone(),
+                    factory_metadata: candidate.factory_metadata.clone(),
+                },
+            );
+        }
+    }
+
+    fn add_cached_or_connect(
+        &mut self,
+        origin_module: Option<ModuleHandle>,
+        dependencies: Vec<QueuedDependency>,
+        cached: &Module,
+    ) -> AddModuleResult {
+        let identity = cached.identity().clone();
+        let (module_handle, is_new) =
+            if let Some(module_handle) = self.modules_by_identity.get(&identity).copied() {
+                (module_handle, false)
+            } else {
+                let module_handle = self.module_graph.add_module_from_unsafe_cache(cached);
+                self.modules_by_identity.insert(identity, module_handle);
+                (module_handle, true)
+            };
+        self.connect_dependencies(origin_module, dependencies, module_handle);
+        AddModuleResult {
+            module_handle,
+            is_new,
+        }
+    }
+
     fn add_or_connect(
         &mut self,
         origin_module: Option<ModuleHandle>,
@@ -802,6 +992,20 @@ impl MakeState {
                 (module_handle, true)
             };
 
+        self.connect_dependencies(origin_module, dependencies, module_handle);
+
+        AddModuleResult {
+            module_handle,
+            is_new,
+        }
+    }
+
+    fn connect_dependencies(
+        &mut self,
+        origin_module: Option<ModuleHandle>,
+        dependencies: Vec<QueuedDependency>,
+        module_handle: ModuleHandle,
+    ) {
         for dependency in dependencies {
             if let Some(entry_index) = dependency.entry_index {
                 self.entries.insert(entry_index, module_handle);
@@ -813,11 +1017,6 @@ impl MakeState {
                 dependency.dependency,
                 module_handle,
             );
-        }
-
-        AddModuleResult {
-            module_handle,
-            is_new,
         }
     }
 
@@ -880,6 +1079,7 @@ mod tests {
             &options,
             resolver,
             cache.clone(),
+            None,
             FileSystemInfo::new(),
             crate::compiler::test_compilation_hooks().normal_module_factory_hooks,
             JavascriptParserHookSet::default(),

--- a/crates/unpack_core/src/module.rs
+++ b/crates/unpack_core/src/module.rs
@@ -137,6 +137,12 @@ impl Module {
         }
     }
 
+    pub(crate) fn from_unsafe_cache(handle: ModuleHandle, cached: &Self) -> Self {
+        let mut module = cached.clone();
+        module.handle = handle;
+        module
+    }
+
     pub fn handle(&self) -> ModuleHandle {
         self.handle
     }

--- a/crates/unpack_core/src/module_graph.rs
+++ b/crates/unpack_core/src/module_graph.rs
@@ -47,7 +47,18 @@ impl AsyncDependenciesBlockIndex {
 impl ModuleGraph {
     pub(crate) fn add_module(&mut self, identity: ModuleIdentity) -> ModuleHandle {
         let handle = ModuleHandle::new(self.modules.len());
-        self.modules.push(Module::new(handle, identity));
+        self.push_module(Module::new(handle, identity))
+    }
+
+    pub(crate) fn add_module_from_unsafe_cache(&mut self, cached: &Module) -> ModuleHandle {
+        let handle = ModuleHandle::new(self.modules.len());
+        self.push_module(Module::from_unsafe_cache(handle, cached))
+    }
+
+    fn push_module(&mut self, module: Module) -> ModuleHandle {
+        let handle = module.handle();
+        debug_assert_eq!(handle.index(), self.modules.len());
+        self.modules.push(module);
         let outgoing_handle = self.outgoing.push(Vec::new());
         let incoming_handle = self.incoming.push(Vec::new());
         let location_handle = self.outgoing_by_location.push(HashMap::new());

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -75,6 +75,8 @@ pub struct NativeCompilerOptions {
     pub side_effects: String,
     #[napi(js_name = "moduleRules")]
     pub module_rules: Vec<NativeModuleRule>,
+    #[napi(js_name = "moduleUnsafeCache")]
+    pub module_unsafe_cache: String,
 }
 
 #[napi(object)]
@@ -912,6 +914,16 @@ impl NativeCompiler {
             value => {
                 return Err(napi::Error::from_reason(format!(
                     "options.optimization.sideEffects: unknown normalized value {value:?}"
+                )));
+            }
+        };
+        compiler_options.module_unsafe_cache = match options.module_unsafe_cache.as_str() {
+            "disabled" => unpack_core::ModuleUnsafeCache::Disabled,
+            "node_modules" => unpack_core::ModuleUnsafeCache::NodeModules,
+            "all" => unpack_core::ModuleUnsafeCache::All,
+            value => {
+                return Err(napi::Error::from_reason(format!(
+                    "options.module.unsafeCache: unknown normalized value {value:?}"
                 )));
             }
         };

--- a/docs/adr/0142-use-a-compiler-owned-unsafe-module-cache.md
+++ b/docs/adr/0142-use-a-compiler-owned-unsafe-module-cache.md
@@ -1,0 +1,28 @@
+# Use a compiler-owned unsafe module cache
+
+Unpack will implement webpack's `module.unsafeCache` responsibility with a
+Compiler-owned, process-local Unsafe Module Cache. The cache is enabled only
+when the ordinary Build Cache is enabled. Omitted `module.unsafeCache` follows
+webpack by selecting modules under `node_modules`; explicit `true` selects all
+factorized modules and explicit `false` disables reuse. Predicate functions are
+rejected until the JavaScript Module predicate can be evaluated without moving
+Module ownership out of Rust.
+
+Entries are keyed by the factorize grouping inputs: issuer context, module
+factory, dependency category, and dependency resource identifier. Each entry
+stores the factorized Module together with the loader and resolve dependency
+metadata needed to restore its factory result. A hit is checked before work is
+admitted to the factorize queue. The cached Module receives a fresh Graph Handle
+in the new Compilation, current dependencies are connected to it, and it still
+enters the ordinary Build stage so Module Build Record and Snapshot validation
+remain active. Compilations and their Module Graphs therefore remain fresh under
+ADR 0064.
+
+The Unsafe Module Cache is distinct from the validated, record-oriented Cache
+and Cache Facades in ADRs 0085 and 0131, and from the unaffected computation
+memos in ADR 0139. This is a staged Rust representation of webpack's dependency
+weak references and `Compilation/modules` cache. Entries are not published to
+PackFile, so a new Compiler process falls back to the validated Resolve and
+Module Build caches. Persistent unsafe-module restoration and the predicate
+function form should be added together with the Module serialization and public
+predicate boundary needed to preserve webpack's observable behavior.

--- a/docs/implementation/webpack-architecture-deviation-register.md
+++ b/docs/implementation/webpack-architecture-deviation-register.md
@@ -87,6 +87,23 @@ documented deviations or staged webpack scope.
   `BuildCache`, whole-Compilation cache, or whole-project fingerprint during the
   refactor.
 
+### DEV-004: Unsafe Module Cache is process-local
+
+- **Status**: Confirmed deviation.
+- **Performance-driven**: No. This is staged `module.unsafeCache` scope.
+- **Webpack shape**: webpack combines dependency weak references with its
+  `Compilation/modules` Cache Facade, allowing serializable Modules to be
+  restored through the configured cache.
+- **Current shape**: Unpack keeps Compiler-owned in-memory entries keyed by
+  factorize grouping inputs. It restores Modules into fresh Compilation graphs
+  and still runs Build validation, but does not publish entries to PackFile.
+- **Confirmation**: ADR 0142 and
+  `docs/implementation/webpack-implementation-differences.md` document the
+  boundary.
+- **Refactor when**: predicate-function support or cross-process unsafe Module
+  reuse is implemented. Preserve the pre-factorize lookup and fresh Graph
+  Handle contract.
+
 ## Resolved violations and alignment gaps
 
 ### RES-001: Whole-Compilation warm cache shortcut

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -110,6 +110,20 @@ asynchronous callbacks. Matching modules remain
 `JavaScriptAuto`; the loader path participates in module identity, file
 dependencies, watch dependencies, and Module Build Record validation.
 
+The Compiler-owned Unsafe Module Cache follows webpack's `module.unsafeCache`
+boundary. A cache hit restores the previously factorized Module into the fresh
+Compilation Module Graph, reconnects the current dependency, and enters the
+normal Build stage without calling the Normal Module Factory. Build snapshot
+validation remains active, so this cache is unsafe specifically because request
+resolution and factory work are not repeated. Boolean `module.unsafeCache` is
+exposed; webpack's predicate-function form is rejected until the JavaScript
+Module predicate can be supported without moving Module ownership out of Rust.
+When the option is omitted, an enabled build cache applies the webpack default
+predicate to modules under `node_modules`. As in webpack, `cache: false`
+disables cross-Compilation module reuse even when `module.unsafeCache` is true.
+Unlike webpack's Cache-Facade-backed Module restoration, these entries are
+currently process-local and are not published to PackFile.
+
 The public TypeScript package keeps a small `LoaderRuntime` transport helper in
 `LoaderRuntime.ts`. Loader functions must execute on the JavaScript thread while
 the Normal Module Factory and compilation remain Rust-owned, so this helper
@@ -122,12 +136,14 @@ Webpack's `NormalModuleFactory` owns a large part of public configurability: hoo
 Necessity:
 
 - The minimal Unpack factory and loader rule schema are staged scope reductions.
+- Supporting boolean Unsafe Module Cache selection while rejecting predicate
+  functions is a staged public-option reduction.
 - The current `ModuleIdentity` shape is still useful because loaders, layers, module types, and query/fragment behavior can be added without redefining graph identity.
 - Webpack's factory hook surface should be introduced when plugin and loader API work starts, using webpack names and ordering as the reference.
 
 ## Make phase and errors
 
-Unpack uses `FuturesUnordered` plus a semaphore to factorize, read, parse, and connect modules. Module-attributable make errors are recorded in `Compilation::errors`; infrastructure failures still return `Err` and stop the run.
+Unpack uses `FuturesUnordered` plus a semaphore to factorize, read, parse, and connect modules. Unsafe Module Cache hits enter a foreground reuse task that adds the cached Module to the fresh graph before scheduling its Build task, so they consume neither factorize work nor a factorize concurrency permit. Module-attributable make errors are recorded in `Compilation::errors`; infrastructure failures still return `Err` and stop the run.
 
 Webpack uses separate async queues for factorize, add, build, rebuild, and
 process-dependencies. Unpack uses Rust-native tasks but now follows the same

--- a/packages/unpack/src/config/normalization.ts
+++ b/packages/unpack/src/config/normalization.ts
@@ -36,7 +36,8 @@ export interface OptimizationOptions {
 }
 
 export interface ModuleOptions {
-  rules: ModuleRule[];
+  rules?: ModuleRule[];
+  unsafeCache?: boolean;
 }
 
 export interface ModuleRule {
@@ -133,6 +134,7 @@ export interface NormalizedOptions {
   snapshot: NormalizedSnapshotOptions;
   infrastructureLogging: NormalizedInfrastructureLoggingOptions;
   moduleRules: NormalizedModuleRule[];
+  moduleUnsafeCache: "disabled" | "node_modules" | "all";
   providedExports: boolean;
   usedExports: boolean;
   sideEffects: "disabled" | "flag" | "analyze";
@@ -245,7 +247,18 @@ export function normalizeOptions(options: UnpackOptions): NormalizedOptions {
   const sourcemap = options.sourcemap === undefined
     ? true
     : assertBoolean(options.sourcemap, "options.sourcemap");
-  const moduleRules = normalizeModuleOptions(options.module);
+  const cache = normalizeCacheOptions(
+    options.cache,
+    normalizedContext,
+    mode,
+    name,
+    cacheUnaffectedExperiment
+  );
+  const normalizedModule = normalizeModuleOptions(
+    options.module,
+    cache.type !== "disabled"
+  );
+  const moduleRules = normalizedModule.rules;
   const optimization = normalizeOptimizationOptions(options.optimization, mode);
   if (moduleRules.some((rule) => rule.loader !== undefined) && sourcemap) {
     throw new TypeError("options.sourcemap must be false when options.module.rules is configured");
@@ -255,16 +268,11 @@ export function normalizeOptions(options: UnpackOptions): NormalizedOptions {
     entries: normalizeEntry(options.entry),
     outputPath,
     sourcemap,
-    cache: normalizeCacheOptions(
-      options.cache,
-      normalizedContext,
-      mode,
-      name,
-      cacheUnaffectedExperiment
-    ),
+    cache,
     snapshot: normalizeSnapshotOptions(options.snapshot, mode),
     infrastructureLogging: normalizeInfrastructureLoggingOptions(options.infrastructureLogging),
     moduleRules,
+    moduleUnsafeCache: normalizedModule.unsafeCache,
     providedExports: optimization.providedExports,
     usedExports: optimization.usedExports,
     sideEffects: optimization.sideEffects
@@ -317,14 +325,34 @@ export function normalizeOptimizationOptions(
   };
 }
 
-export function normalizeModuleOptions(module: ModuleOptions | undefined): NormalizedModuleRule[] {
-  if (module === undefined) return [];
+export function normalizeModuleOptions(
+  module: ModuleOptions | undefined,
+  cacheEnabled: boolean
+): {
+  rules: NormalizedModuleRule[];
+  unsafeCache: "disabled" | "node_modules" | "all";
+} {
+  if (module === undefined) {
+    return {
+      rules: [],
+      unsafeCache: cacheEnabled ? "node_modules" : "disabled"
+    };
+  }
   assertPlainObject(module, "options.module");
-  assertKnownKeys(module, ["rules"], "options.module");
-  if (!Array.isArray(module.rules)) {
+  assertKnownKeys(module, ["rules", "unsafeCache"], "options.module");
+  const rules = module.rules ?? [];
+  if (!Array.isArray(rules)) {
     throw new TypeError("options.module.rules must be an array");
   }
-  return module.rules.map((rule, index) => {
+  const requestedUnsafeCache = module.unsafeCache === undefined
+    ? undefined
+    : assertBoolean(module.unsafeCache, "options.module.unsafeCache");
+  const unsafeCache = !cacheEnabled
+    ? "disabled"
+    : requestedUnsafeCache === undefined
+      ? "node_modules"
+      : requestedUnsafeCache ? "all" : "disabled";
+  const normalizedRules = rules.map((rule, index) => {
     const name = `options.module.rules[${index}]`;
     assertPlainObject(rule, name);
     assertKnownKeys(rule, ["test", "loader", "type", "options", "sideEffects"], name);
@@ -356,6 +384,7 @@ export function normalizeModuleOptions(module: ModuleOptions | undefined): Norma
       : assertBoolean(rule.sideEffects, `${name}.sideEffects`);
     return { test: rule.test.source, loader, type, options: serializedOptions, sideEffects };
   });
+  return { rules: normalizedRules, unsafeCache };
 }
 
 export function assertModuleRuleType(value: unknown, name: string): ModuleRuleType {

--- a/packages/unpack/test/api.test.ts
+++ b/packages/unpack/test/api.test.ts
@@ -7,6 +7,7 @@ import assert from "node:assert/strict";
 import unpack from "@unpack-js/core";
 import webpack from "webpack";
 import type { Compiler, Stats } from "@unpack-js/core";
+import type { Compiler as WebpackCompiler } from "webpack";
 
 test("emits assets through the ESM default API", async () => {
   const fixture = await createFixture({
@@ -750,6 +751,128 @@ test("cache false disables module build cache reuse", async () => {
     assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /after/);
   } finally {
     await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("module.unsafeCache reuses modules without repeating factorization", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export { value } from './dep';",
+    "src/dep.js": "export const value = 'js';"
+  });
+  const unpackOutputPath = join(fixture, "dist-unpack");
+  const webpackOutputPath = join(fixture, "dist-webpack");
+  const compiler = unpack({
+    context: fixture,
+    mode: "none",
+    entry: "./src/index.js",
+    output: { path: unpackOutputPath },
+    cache: true,
+    module: { unsafeCache: true }
+  });
+  const webpackCompiler = webpack({
+    context: fixture,
+    mode: "none",
+    entry: "./src/index.js",
+    output: { path: webpackOutputPath },
+    cache: { type: "memory" },
+    devtool: false,
+    module: { unsafeCache: true },
+    resolve: { extensions: [".ts", ".js"] },
+    optimization: { concatenateModules: false, minimize: false }
+  });
+
+  try {
+    assert.equal((await runExistingCompiler(compiler)).err, null);
+    await runWebpack(webpackCompiler);
+    assert.match(await readFile(join(unpackOutputPath, "main.js"), "utf8"), /'js'/);
+    assert.match(await readFile(join(webpackOutputPath, "main.js"), "utf8"), /'js'/);
+
+    await writeFile(join(fixture, "src/dep.ts"), "export const value = 'ts';", {
+      encoding: "utf8"
+    });
+
+    assert.equal((await runExistingCompiler(compiler)).err, null);
+    await runWebpack(webpackCompiler);
+    const unpackSource = await readFile(join(unpackOutputPath, "main.js"), "utf8");
+    const webpackSource = await readFile(join(webpackOutputPath, "main.js"), "utf8");
+    const observe = (source: string) => ({
+      retainedOriginalResolution: source.includes("'js'"),
+      skippedNewResolution: !source.includes("'ts'")
+    });
+    assert.deepEqual(observe(unpackSource), observe(webpackSource));
+    assert.deepEqual(observe(unpackSource), {
+      retainedOriginalResolution: true,
+      skippedNewResolution: true
+    });
+
+    await writeFile(join(fixture, "src/dep.js"), "export const value = 'js-updated';", {
+      encoding: "utf8"
+    });
+    assert.equal((await runExistingCompiler(compiler)).err, null);
+    await runWebpack(webpackCompiler);
+    assert.match(await readFile(join(unpackOutputPath, "main.js"), "utf8"), /'js-updated'/);
+    assert.match(await readFile(join(webpackOutputPath, "main.js"), "utf8"), /'js-updated'/);
+  } finally {
+    await closeCompiler(compiler);
+    await closeWebpack(webpackCompiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("module.unsafeCache rejects unsupported predicates synchronously", () => {
+  assert.throws(
+    () => unpack({
+      entry: "./src/index.js",
+      module: { unsafeCache: (() => true) as unknown as boolean }
+    }),
+    /options\.module\.unsafeCache must be a boolean/
+  );
+});
+
+test("cache false disables module.unsafeCache reuse", async () => {
+  const fixture = await createFixture({
+    "src/index.js": "export { value } from './dep';",
+    "src/dep.js": "export const value = 'js';"
+  });
+  const unpackOutputPath = join(fixture, "dist-unpack");
+  const webpackOutputPath = join(fixture, "dist-webpack");
+  const compiler = unpack({
+    context: fixture,
+    mode: "none",
+    entry: "./src/index.js",
+    output: { path: unpackOutputPath },
+    cache: false,
+    module: { unsafeCache: true }
+  });
+  const webpackCompiler = webpack({
+    context: fixture,
+    mode: "none",
+    entry: "./src/index.js",
+    output: { path: webpackOutputPath },
+    cache: false,
+    devtool: false,
+    module: { unsafeCache: true },
+    resolve: { extensions: [".ts", ".js"] },
+    optimization: { concatenateModules: false, minimize: false }
+  });
+
+  try {
+    assert.equal((await runExistingCompiler(compiler)).err, null);
+    await runWebpack(webpackCompiler);
+    await writeFile(join(fixture, "src/dep.ts"), "export const value = 'ts';", {
+      encoding: "utf8"
+    });
+
+    assert.equal((await runExistingCompiler(compiler)).err, null);
+    await runWebpack(webpackCompiler);
+    const unpackSource = await readFile(join(unpackOutputPath, "main.js"), "utf8");
+    const webpackSource = await readFile(join(webpackOutputPath, "main.js"), "utf8");
+    assert.equal(unpackSource.includes("'ts'"), webpackSource.includes("'ts'"));
+    assert.match(unpackSource, /'ts'/);
+  } finally {
+    await closeCompiler(compiler);
+    await closeWebpack(webpackCompiler);
     await rm(fixture, { recursive: true, force: true });
   }
 });
@@ -2242,6 +2365,7 @@ async function assertSameTimestampPackageExportsEditEmits(
     context: fixture,
     entry: "./src/index.js",
     cache: true,
+    module: { unsafeCache: false },
     snapshot: {
       unmanagedPaths: [packageRoot]
     },
@@ -2350,6 +2474,23 @@ async function runExistingCompiler(compiler: ReturnType<typeof unpack>) {
       });
     }
   );
+}
+
+async function runWebpack(compiler: WebpackCompiler) {
+  return new Promise<import("webpack").Stats>((resolve, reject) => {
+    compiler.run((error, stats) => {
+      if (error) reject(error);
+      else if (!stats) reject(new Error("webpack completed without Stats"));
+      else if (stats.hasErrors()) reject(new Error(stats.toString()));
+      else resolve(stats);
+    });
+  });
+}
+
+async function closeWebpack(compiler: WebpackCompiler) {
+  await new Promise<void>((resolve, reject) => {
+    compiler.close((error) => (error ? reject(error) : resolve()));
+  });
 }
 
 async function closeCompiler(compiler: ReturnType<typeof unpack>) {


### PR DESCRIPTION
## Summary

- add a Compiler-owned unsafe module cache that restores factorized modules before Make admits work to the factorize queue
- assign restored modules fresh graph handles and continue through the normal Build stage so snapshot validation remains active
- expose boolean `module.unsafeCache`, including webpack-aligned `node_modules` defaults and `cache: false` behavior
- add pinned-webpack comparison coverage and document the process-local cache boundary in ADR 0142

## Tests

- `pnpm test`
