### PR TITLE
Run CodSpeed benchmarks in simulation mode

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -25,10 +25,10 @@ jobs:
           bins: cargo-codspeed
 
       - name: Build benchmark target
-        run: cargo codspeed build -m walltime -p unpack_core --bench make_phase
+        run: cargo codspeed build -m simulation -p unpack_core --bench make_phase
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v4
         with:
-          mode: walltime
-          run: cargo codspeed run -m walltime -p unpack_core --bench make_phase
+          mode: simulation
+          run: cargo codspeed run -m simulation -p unpack_core --bench make_phase


### PR DESCRIPTION
## Summary

- switch the CodSpeed benchmark build from walltime to simulation mode
- run the CodSpeed action and benchmark command with the same simulation mode
- use deterministic CPU simulation measurements on GitHub-hosted runners

The workflow YAML parses successfully, and the installed `cargo codspeed` CLI recognizes `simulation` for both build and run commands.