### PR TITLE
Implement second-stage unaffected module caching

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -284,6 +284,18 @@ _Avoid_: Cache backend, cache implementation
 A Build Cache layer held within one Compiler process for reuse during that Compiler's lifetime.
 _Avoid_: Persistent Cache, module graph reuse
 
+**Module Computation Cache**:
+Compiler-owned in-process memoization for graph-derived computations on unaffected Modules, separate from Build Cache layers and Persistent Cache.
+_Avoid_: Memory Cache, Module Build Record
+
+**Pre-Chunk-Graph Module Computation Entry**:
+The part of one Module Computation Cache entry validated after Module Graph construction and before `finishModules` and Chunk Graph construction, corresponding to webpack's `moduleMemCaches` computations.
+_Avoid_: Post-ID-Assignment Module Computation Entry, Module Build Record
+
+**Post-ID-Assignment Module Computation Entry**:
+The later part of one Module Computation Cache entry validated from assigned Render IDs and Chunk Graph references, corresponding to webpack's `moduleMemCaches2` computations.
+_Avoid_: Pre-Chunk-Graph Module Computation Entry, Code Generation Record
+
 **Cache Facade**:
 A scoped access point to the build cache for one compiler subsystem or cache item family.
 _Avoid_: Specialized cache method, cache store

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -172,6 +172,10 @@ _Avoid_: Asset, rendered bundle, compilation result
 The deterministic phase that assigns readable named Render IDs to modules and chunks, using stable identities and collision handling before code generation.
 _Avoid_: Filename generation, incidental map index
 
+**Module Hash**:
+A per-module digest of output-sensitive build, export, and Chunk Graph inputs recorded after ID Assignment for later compilation phases and in-process reuse.
+_Avoid_: Source hash, Cache ETag
+
 **Export Binding**:
 A generated runtime binding that exposes an ECMAScript module export through a getter so importers observe the current exported value.
 _Avoid_: Export snapshot, CommonJS export assignment

--- a/crates/unpack_core/src/chunk_graph.rs
+++ b/crates/unpack_core/src/chunk_graph.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::{
-    ModuleHandle,
+    ModuleGraph, ModuleHandle,
     chunk::{Chunk, ChunkHandle},
     chunk_group::{AsyncBlockOrigin, ChunkGroup, ChunkGroupHandle, ChunkGroupKind},
     id_assignment::RenderId,
@@ -13,6 +13,23 @@ use crate::{
     },
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ModuleHash(u64);
+
+impl ModuleHash {
+    pub(crate) const fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ChunkGraphModuleReferences {
+    pub(crate) module_render_id: Option<RenderId>,
+    pub(crate) chunk_render_ids: Vec<RenderId>,
+    pub(crate) outgoing_module_render_ids: Vec<Option<RenderId>>,
+    pub(crate) block_chunk_render_ids: Vec<Option<Vec<RenderId>>>,
+}
+
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct ChunkGraph {
     chunks: Vec<Chunk>,
@@ -21,6 +38,7 @@ pub struct ChunkGraph {
     chunk_modules: Vec<Vec<ModuleHandle>>,
     module_chunks: Vec<Vec<ChunkHandle>>,
     module_render_ids: Vec<Option<RenderId>>,
+    module_hashes: Vec<Option<ModuleHash>>,
     block_chunk_groups: HashMap<AsyncBlockOrigin, ChunkGroupHandle>,
     // Includes logical loading edges omitted from the materialized graph to break cycles.
     runtime_chunk_group_children: Vec<Vec<ChunkGroupHandle>>,
@@ -114,6 +132,7 @@ impl ChunkGraph {
             self.module_chunks.resize_with(module.index() + 1, Vec::new);
             self.module_render_ids
                 .resize_with(module.index() + 1, || None);
+            self.module_hashes.resize_with(module.index() + 1, || None);
             self.module_runtime_requirements
                 .resize_with(module.index() + 1, RuntimeRequirements::default);
         }
@@ -154,6 +173,60 @@ impl ChunkGraph {
             .and_then(Option::as_ref)
     }
 
+    pub(crate) fn module_references(
+        &self,
+        module_graph: &ModuleGraph,
+        handle: ModuleHandle,
+    ) -> ChunkGraphModuleReferences {
+        let module = module_graph
+            .module(handle)
+            .expect("a Module Graph handle should address a Module");
+        let mut chunk_render_ids = self
+            .module_chunks(handle)
+            .iter()
+            .map(|chunk| {
+                self.chunk(*chunk)
+                    .expect("a Module Chunk reference must address an existing Chunk")
+                    .render_id()
+                    .clone()
+            })
+            .collect::<Vec<_>>();
+        chunk_render_ids.sort();
+        let outgoing_module_render_ids = module_graph
+            .outgoing_connections(handle)
+            .map(|connection| self.module_render_id(connection.module).cloned())
+            .collect();
+        let block_chunk_render_ids = module
+            .blocks()
+            .iter()
+            .enumerate()
+            .map(|(block_index, _)| {
+                self.block_chunk_group(AsyncBlockOrigin {
+                    module: handle,
+                    block: crate::AsyncDependenciesBlockIndex::new(block_index),
+                })
+                .map(|group| {
+                    self.chunk_groups()[group.index()]
+                        .chunks()
+                        .iter()
+                        .map(|chunk| {
+                            self.chunk(*chunk)
+                                .expect("a Chunk Group must reference an existing Chunk")
+                                .render_id()
+                                .clone()
+                        })
+                        .collect()
+                })
+            })
+            .collect();
+        ChunkGraphModuleReferences {
+            module_render_id: self.module_render_id(handle).cloned(),
+            chunk_render_ids,
+            outgoing_module_render_ids,
+            block_chunk_render_ids,
+        }
+    }
+
     pub fn module_render_id_string(&self, module: ModuleHandle) -> Option<&str> {
         self.module_render_id(module).and_then(RenderId::as_string)
     }
@@ -170,6 +243,18 @@ impl ChunkGraph {
         self.module_render_ids[module.index()] = Some(render_id);
     }
 
+    pub(crate) fn set_module_hash(&mut self, module: ModuleHandle, module_hash: ModuleHash) {
+        if self.module_hashes.len() <= module.index() {
+            self.module_hashes.resize_with(module.index() + 1, || None);
+        }
+        self.module_hashes[module.index()] = Some(module_hash);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn module_hash(&self, module: ModuleHandle) -> Option<ModuleHash> {
+        self.module_hashes.get(module.index()).copied().flatten()
+    }
+
     pub(crate) fn set_chunk_render_id(&mut self, chunk: ChunkHandle, render_id: RenderId) {
         self.chunks[chunk.index()].assign_render_id(render_id);
     }
@@ -182,7 +267,19 @@ impl ChunkGraph {
         self.chunks.get(handle.index())
     }
 
+    #[cfg(test)]
     pub(crate) fn process_runtime_requirements(
+        &mut self,
+        module_requirements: impl IntoIterator<Item = (ModuleHandle, RuntimeRequirements)>,
+    ) {
+        let processed = module_requirements
+            .into_iter()
+            .map(|(module, direct)| (module, resolve_runtime_modules(&direct).0))
+            .collect::<Vec<_>>();
+        self.set_module_runtime_requirements(processed);
+    }
+
+    pub(crate) fn set_module_runtime_requirements(
         &mut self,
         module_requirements: impl IntoIterator<Item = (ModuleHandle, RuntimeRequirements)>,
     ) {
@@ -191,12 +288,11 @@ impl ChunkGraph {
         for requirements in &mut self.module_runtime_requirements {
             *requirements = RuntimeRequirements::default();
         }
-        for (module, direct) in module_requirements {
+        for (module, processed) in module_requirements {
             assert!(
                 module.index() < self.module_runtime_requirements.len(),
                 "Runtime Requirements must reference a Module in the Chunk Graph"
             );
-            let (processed, _) = resolve_runtime_modules(&direct);
             self.module_runtime_requirements[module.index()] = processed;
         }
 

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -194,7 +194,7 @@ impl Compilation {
             if result.is_ok()
                 && let Some(cache) = &self.module_computation_cache
             {
-                cache.prepare(&self.module_graph);
+                cache.prepare_before_chunk_graph(&self.module_graph);
             }
 
             if result.is_ok() {
@@ -247,7 +247,7 @@ impl Compilation {
         self.hooks.clone().optimize_dependencies.call(self);
         self.build_chunk_graph();
         self.assign_render_ids();
-        self.prepare_chunk_graph_computation_cache();
+        self.prepare_post_id_assignment_computation_cache();
         self.create_module_hashes();
         self.code_generation();
         self.process_runtime_requirements();
@@ -262,9 +262,9 @@ impl Compilation {
         assign_chunk_render_ids(&self.options, &self.module_graph, &mut self.chunk_graph);
     }
 
-    fn prepare_chunk_graph_computation_cache(&self) {
+    fn prepare_post_id_assignment_computation_cache(&self) {
         if let Some(cache) = &self.module_computation_cache {
-            cache.prepare_chunk_graph(&self.module_graph, &self.chunk_graph);
+            cache.prepare_after_id_assignment(&self.module_graph, &self.chunk_graph);
         }
     }
 

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -1,6 +1,11 @@
 // Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/Compilation.js
 
-use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
+use std::{
+    collections::BTreeSet,
+    hash::{Hash, Hasher},
+    path::PathBuf,
+    sync::Arc,
+};
 
 use tokio::sync::Mutex;
 
@@ -9,10 +14,13 @@ use crate::{
     ModuleGraph, ModuleHandle, Result, UnpackResolver,
     build_chunk_graph::build_chunk_graph_with_cache,
     cache::Cache,
+    cache_hash::StableHasher,
+    chunk_graph::ModuleHash,
     code_generation::{self, CodeGenerationResults, RenderManifest},
     id_assignment::{assign_chunk_render_ids, assign_module_render_ids},
     make::{self, MakeState},
     module_computation_cache::ModuleComputationCache,
+    runtime::resolve_runtime_modules,
     snapshot::FileSystemInfo,
 };
 use tracing::Instrument;
@@ -239,6 +247,8 @@ impl Compilation {
         self.hooks.clone().optimize_dependencies.call(self);
         self.build_chunk_graph();
         self.assign_render_ids();
+        self.prepare_chunk_graph_computation_cache();
+        self.create_module_hashes();
         self.code_generation();
         self.process_runtime_requirements();
         self.create_assets();
@@ -250,6 +260,39 @@ impl Compilation {
 
     fn assign_chunk_ids(&mut self) {
         assign_chunk_render_ids(&self.options, &self.module_graph, &mut self.chunk_graph);
+    }
+
+    fn prepare_chunk_graph_computation_cache(&self) {
+        if let Some(cache) = &self.module_computation_cache {
+            cache.prepare_chunk_graph(&self.module_graph, &self.chunk_graph);
+        }
+    }
+
+    fn create_module_hashes(&mut self) {
+        let hashes = self
+            .module_graph
+            .modules()
+            .iter()
+            .filter(|module| !self.chunk_graph.module_chunks(module.handle()).is_empty())
+            .map(|module| {
+                let module_hash = if let Some(cache) = &self.module_computation_cache {
+                    if let Some(module_hash) = cache.get_module_hash(module.identity()) {
+                        module_hash
+                    } else {
+                        let module_hash =
+                            compute_module_hash(module, &self.module_graph, &self.chunk_graph);
+                        cache.store_module_hash(module.identity(), module_hash);
+                        module_hash
+                    }
+                } else {
+                    compute_module_hash(module, &self.module_graph, &self.chunk_graph)
+                };
+                (module.handle(), module_hash)
+            })
+            .collect::<Vec<_>>();
+        for (module, module_hash) in hashes {
+            self.chunk_graph.set_module_hash(module, module_hash);
+        }
     }
 
     pub fn create_assets(&mut self) {
@@ -322,9 +365,28 @@ impl Compilation {
             .as_ref()
             .expect("code generation results should exist before Runtime Requirements processing")
             .runtime_requirements()
-            .map(|(module, requirements)| (module, *requirements))
+            .map(|(module, requirements)| {
+                let processed = if let Some(cache) = &self.module_computation_cache {
+                    let identity = self
+                        .module_graph
+                        .module(module)
+                        .expect("a Code Generation Result must reference an existing Module")
+                        .identity();
+                    if let Some(processed) = cache.get_runtime_requirements(identity) {
+                        processed
+                    } else {
+                        let processed = resolve_runtime_modules(requirements).0;
+                        cache.store_runtime_requirements(identity, processed);
+                        processed
+                    }
+                } else {
+                    resolve_runtime_modules(requirements).0
+                };
+                (module, processed)
+            })
             .collect::<Vec<_>>();
-        self.chunk_graph.process_runtime_requirements(requirements);
+        self.chunk_graph
+            .set_module_runtime_requirements(requirements);
     }
 
     fn log_infrastructure(
@@ -338,6 +400,43 @@ impl Compilation {
                 .push(InfrastructureLogEvent::new(level, name, message));
         }
     }
+}
+
+fn compute_module_hash(
+    module: &crate::Module,
+    module_graph: &ModuleGraph,
+    chunk_graph: &ChunkGraph,
+) -> ModuleHash {
+    let mut hasher = StableHasher::default();
+    hasher.write(b"unpack/module/hash/1");
+    module.identity().module_type.hash(&mut hasher);
+    module.source_hash().hash(&mut hasher);
+    module
+        .build_error()
+        .map(ToString::to_string)
+        .hash(&mut hasher);
+    module.is_harmony().hash(&mut hasher);
+    module
+        .code_generation_local_input_digest()
+        .hash(&mut hasher);
+    for dependency in module
+        .presentational_dependencies()
+        .iter()
+        .chain(module.dependencies())
+        .chain(
+            module
+                .blocks()
+                .iter()
+                .flat_map(|block| block.dependencies()),
+        )
+    {
+        dependency.update_code_generation_hash(module.exports_info(), &mut hasher);
+    }
+    let references = chunk_graph.module_references(module_graph, module.handle());
+    references.module_render_id.hash(&mut hasher);
+    references.outgoing_module_render_ids.hash(&mut hasher);
+    references.block_chunk_render_ids.hash(&mut hasher);
+    ModuleHash::new(hasher.finish())
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -1030,6 +1030,11 @@ mod tests {
                 invalidated_modules: 0,
                 static_reachable_hits: 0,
                 static_reachable_misses: 1,
+                runtime_requirements_hits: 0,
+                runtime_requirements_misses: 3,
+                module_hash_hits: 0,
+                module_hash_misses: 3,
+                chunk_graph_invalidated_modules: 0,
             }
         );
 
@@ -1046,6 +1051,11 @@ mod tests {
                 invalidated_modules: 0,
                 static_reachable_hits: 1,
                 static_reachable_misses: 1,
+                runtime_requirements_hits: 3,
+                runtime_requirements_misses: 3,
+                module_hash_hits: 3,
+                module_hash_misses: 3,
+                chunk_graph_invalidated_modules: 0,
             }
         );
 
@@ -1069,8 +1079,224 @@ mod tests {
                 invalidated_modules: 2,
                 static_reachable_hits: 1,
                 static_reachable_misses: 2,
+                runtime_requirements_hits: 4,
+                runtime_requirements_misses: 5,
+                module_hash_hits: 4,
+                module_hash_misses: 5,
+                chunk_graph_invalidated_modules: 0,
             }
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cache_unaffected_reuses_chunk_graph_dependent_module_computations()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write(
+            temp.path().join("index.js"),
+            "import { value } from './dep'; export const result = value;",
+        )?;
+        write(temp.path().join("dep.js"), "export const value = 1;")?;
+
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache.cache_unaffected = true;
+        let compiler = Compiler::new(options);
+
+        let first = compiler.run().await?;
+        let first_hashes = module_hashes_by_identity(&first);
+        assert_eq!(first_hashes.len(), 2);
+        assert_eq!(
+            compiler
+                .module_computation_cache
+                .as_ref()
+                .expect("cacheUnaffected should create a Module Computation Cache")
+                .stats(),
+            crate::module_computation_cache::ModuleComputationCacheStats {
+                provided_exports_hits: 0,
+                provided_exports_misses: 2,
+                invalidated_modules: 0,
+                static_reachable_hits: 0,
+                static_reachable_misses: 1,
+                runtime_requirements_hits: 0,
+                runtime_requirements_misses: 2,
+                module_hash_hits: 0,
+                module_hash_misses: 2,
+                chunk_graph_invalidated_modules: 0,
+            }
+        );
+
+        let second = compiler.run().await?;
+        assert_eq!(module_hashes_by_identity(&second), first_hashes);
+        assert_eq!(asset_sources(&second), asset_sources(&first));
+        assert_eq!(
+            compiler
+                .module_computation_cache
+                .as_ref()
+                .expect("the Module Computation Cache should remain Compiler-owned")
+                .stats(),
+            crate::module_computation_cache::ModuleComputationCacheStats {
+                provided_exports_hits: 2,
+                provided_exports_misses: 2,
+                invalidated_modules: 0,
+                static_reachable_hits: 1,
+                static_reachable_misses: 1,
+                runtime_requirements_hits: 2,
+                runtime_requirements_misses: 2,
+                module_hash_hits: 2,
+                module_hash_misses: 2,
+                chunk_graph_invalidated_modules: 0,
+            }
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cache_unaffected_invalidates_second_stage_memos_when_async_chunk_ids_change()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let entry_path = temp.path().join("index.js");
+        write(
+            &entry_path,
+            "import { load } from './stable'; export const result = load;",
+        )?;
+        write(
+            temp.path().join("stable.js"),
+            "export const load = () => import('./a-b');",
+        )?;
+        write(temp.path().join("a-b.js"), "export const value = 'first';")?;
+        write(temp.path().join("a_b.js"), "export const value = 'second';")?;
+
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache.cache_unaffected = true;
+        options.snapshot.module = crate::SnapshotStrategy::hash();
+        let cold_options = options.clone();
+        let compiler = Compiler::new(options);
+
+        let first = compiler.run().await?;
+        let first_hashes = module_hashes_by_identity(&first);
+        let stable_hash = hash_for_filename(&first_hashes, "stable.js");
+        let async_module_hash = hash_for_filename(&first_hashes, "a-b.js");
+
+        write(
+            &entry_path,
+            "import { load } from './stable'; import('./a_b'); export const result = load;",
+        )?;
+        let second = compiler.run().await?;
+        let second_hashes = module_hashes_by_identity(&second);
+
+        assert_ne!(
+            hash_for_filename(&second_hashes, "stable.js"),
+            stable_hash,
+            "the stable Module Hash must change when its async block receives a new Chunk ID"
+        );
+        assert_eq!(
+            hash_for_filename(&second_hashes, "a-b.js"),
+            async_module_hash,
+            "the async target's Module Hash remains stable when only its containing Chunk changes"
+        );
+        let stats = compiler
+            .module_computation_cache
+            .as_ref()
+            .expect("cacheUnaffected should create a Module Computation Cache")
+            .stats();
+        assert_eq!(stats.chunk_graph_invalidated_modules, 2);
+        assert_eq!(stats.runtime_requirements_hits, 0);
+        assert_eq!(stats.runtime_requirements_misses, 7);
+        assert_eq!(stats.module_hash_hits, 0);
+        assert_eq!(stats.module_hash_misses, 7);
+        assert_eq!(second.errors(), []);
+        let cold = Compiler::new(cold_options).run().await?;
+        assert_eq!(asset_sources(&second), asset_sources(&cold));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cache_unaffected_invalidates_second_stage_memos_when_used_exports_change()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let entry_path = temp.path().join("index.js");
+        write(
+            &entry_path,
+            "import { a } from './dep'; export const result = a;",
+        )?;
+        write(
+            temp.path().join("dep.js"),
+            "export const a = 'a'; export const b = 'b';",
+        )?;
+
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache.cache_unaffected = true;
+        options.snapshot.module = crate::SnapshotStrategy::hash();
+        let cold_options = options.clone();
+        let compiler = Compiler::new(options);
+
+        let first = compiler.run().await?;
+        let first_hashes = module_hashes_by_identity(&first);
+        let dep_hash = hash_for_filename(&first_hashes, "dep.js");
+
+        write(
+            &entry_path,
+            "import { b } from './dep'; export const result = b;",
+        )?;
+        let second = compiler.run().await?;
+        let second_hashes = module_hashes_by_identity(&second);
+
+        assert_ne!(
+            hash_for_filename(&second_hashes, "dep.js"),
+            dep_hash,
+            "a Module Hash must cover the Exports Info that changes generated code"
+        );
+        let stats = compiler
+            .module_computation_cache
+            .as_ref()
+            .expect("cacheUnaffected should create a Module Computation Cache")
+            .stats();
+        assert_eq!(stats.chunk_graph_invalidated_modules, 1);
+        assert_eq!(stats.module_hash_hits, 0);
+        assert_eq!(stats.module_hash_misses, 4);
+        assert_eq!(second.errors(), []);
+        let cold = Compiler::new(cold_options).run().await?;
+        assert_eq!(asset_sources(&second), asset_sources(&cold));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cache_unaffected_invalidates_second_stage_memos_when_chunk_membership_changes()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let entry_path = temp.path().join("index.js");
+        write(&entry_path, "import('./stable');")?;
+        write(temp.path().join("stable.js"), "console.log('stable');")?;
+
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.cache.cache_unaffected = true;
+        options.snapshot.module = crate::SnapshotStrategy::hash();
+        options.used_exports = false;
+        let cold_options = options.clone();
+        let compiler = Compiler::new(options);
+
+        compiler.run().await?;
+        write(&entry_path, "import './stable';")?;
+        let second = compiler.run().await?;
+
+        let stats = compiler
+            .module_computation_cache
+            .as_ref()
+            .expect("cacheUnaffected should create a Module Computation Cache")
+            .stats();
+        assert_eq!(stats.chunk_graph_invalidated_modules, 1);
+        assert_eq!(stats.runtime_requirements_hits, 0);
+        assert_eq!(stats.runtime_requirements_misses, 4);
+        assert_eq!(stats.module_hash_hits, 0);
+        assert_eq!(stats.module_hash_misses, 4);
+        assert_eq!(second.errors(), []);
+        let cold = Compiler::new(cold_options).run().await?;
+        assert_eq!(asset_sources(&second), asset_sources(&cold));
 
         Ok(())
     }
@@ -1107,6 +1333,11 @@ mod tests {
                 invalidated_modules: 0,
                 static_reachable_hits: 1,
                 static_reachable_misses: 1,
+                runtime_requirements_hits: 2,
+                runtime_requirements_misses: 2,
+                module_hash_hits: 2,
+                module_hash_misses: 2,
+                chunk_graph_invalidated_modules: 0,
             }
         );
         assert_eq!(compiler.cache.stats().module_entries, 0);
@@ -1140,6 +1371,11 @@ mod tests {
                 invalidated_modules: 0,
                 static_reachable_hits: 0,
                 static_reachable_misses: 1,
+                runtime_requirements_hits: 0,
+                runtime_requirements_misses: 2,
+                module_hash_hits: 0,
+                module_hash_misses: 2,
+                chunk_graph_invalidated_modules: 0,
             },
             "Module Computation memos must not be restored from PackFile"
         );
@@ -1817,6 +2053,35 @@ mod tests {
             .iter()
             .map(|asset| (asset.filename.clone(), asset.source.clone()))
             .collect()
+    }
+
+    fn module_hashes_by_identity(
+        compilation: &Compilation,
+    ) -> BTreeMap<String, crate::chunk_graph::ModuleHash> {
+        compilation
+            .module_graph()
+            .modules()
+            .iter()
+            .map(|module| {
+                (
+                    module.identity().resource.display().to_string(),
+                    compilation
+                        .chunk_graph()
+                        .module_hash(module.handle())
+                        .expect("every built Module should have a Module Hash"),
+                )
+            })
+            .collect()
+    }
+
+    fn hash_for_filename(
+        hashes: &BTreeMap<String, crate::chunk_graph::ModuleHash>,
+        filename: &str,
+    ) -> crate::chunk_graph::ModuleHash {
+        hashes
+            .iter()
+            .find_map(|(identity, hash)| identity.ends_with(filename).then_some(*hash))
+            .unwrap_or_else(|| panic!("expected a Module Hash for {filename}"))
     }
 
     fn directory_snapshot(root: &Path) -> std::io::Result<BTreeMap<PathBuf, Vec<u8>>> {

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -1027,14 +1027,14 @@ mod tests {
             crate::module_computation_cache::ModuleComputationCacheStats {
                 provided_exports_hits: 0,
                 provided_exports_misses: 3,
-                invalidated_modules: 0,
+                pre_chunk_graph_invalidated_modules: 0,
                 static_reachable_hits: 0,
                 static_reachable_misses: 1,
                 runtime_requirements_hits: 0,
                 runtime_requirements_misses: 3,
                 module_hash_hits: 0,
                 module_hash_misses: 3,
-                chunk_graph_invalidated_modules: 0,
+                post_id_assignment_invalidated_modules: 0,
             }
         );
 
@@ -1048,14 +1048,14 @@ mod tests {
             crate::module_computation_cache::ModuleComputationCacheStats {
                 provided_exports_hits: 3,
                 provided_exports_misses: 3,
-                invalidated_modules: 0,
+                pre_chunk_graph_invalidated_modules: 0,
                 static_reachable_hits: 1,
                 static_reachable_misses: 1,
                 runtime_requirements_hits: 3,
                 runtime_requirements_misses: 3,
                 module_hash_hits: 3,
                 module_hash_misses: 3,
-                chunk_graph_invalidated_modules: 0,
+                post_id_assignment_invalidated_modules: 0,
             }
         );
 
@@ -1076,14 +1076,14 @@ mod tests {
             crate::module_computation_cache::ModuleComputationCacheStats {
                 provided_exports_hits: 4,
                 provided_exports_misses: 5,
-                invalidated_modules: 2,
+                pre_chunk_graph_invalidated_modules: 2,
                 static_reachable_hits: 1,
                 static_reachable_misses: 2,
                 runtime_requirements_hits: 4,
                 runtime_requirements_misses: 5,
                 module_hash_hits: 4,
                 module_hash_misses: 5,
-                chunk_graph_invalidated_modules: 0,
+                post_id_assignment_invalidated_modules: 0,
             }
         );
 
@@ -1116,14 +1116,14 @@ mod tests {
             crate::module_computation_cache::ModuleComputationCacheStats {
                 provided_exports_hits: 0,
                 provided_exports_misses: 2,
-                invalidated_modules: 0,
+                pre_chunk_graph_invalidated_modules: 0,
                 static_reachable_hits: 0,
                 static_reachable_misses: 1,
                 runtime_requirements_hits: 0,
                 runtime_requirements_misses: 2,
                 module_hash_hits: 0,
                 module_hash_misses: 2,
-                chunk_graph_invalidated_modules: 0,
+                post_id_assignment_invalidated_modules: 0,
             }
         );
 
@@ -1139,14 +1139,14 @@ mod tests {
             crate::module_computation_cache::ModuleComputationCacheStats {
                 provided_exports_hits: 2,
                 provided_exports_misses: 2,
-                invalidated_modules: 0,
+                pre_chunk_graph_invalidated_modules: 0,
                 static_reachable_hits: 1,
                 static_reachable_misses: 1,
                 runtime_requirements_hits: 2,
                 runtime_requirements_misses: 2,
                 module_hash_hits: 2,
                 module_hash_misses: 2,
-                chunk_graph_invalidated_modules: 0,
+                post_id_assignment_invalidated_modules: 0,
             }
         );
 
@@ -1154,7 +1154,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cache_unaffected_invalidates_second_stage_memos_when_async_chunk_ids_change()
+    async fn cache_unaffected_invalidates_post_id_assignment_memos_when_async_chunk_ids_change()
     -> std::result::Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
         let entry_path = temp.path().join("index.js");
@@ -1202,7 +1202,7 @@ mod tests {
             .as_ref()
             .expect("cacheUnaffected should create a Module Computation Cache")
             .stats();
-        assert_eq!(stats.chunk_graph_invalidated_modules, 2);
+        assert_eq!(stats.post_id_assignment_invalidated_modules, 2);
         assert_eq!(stats.runtime_requirements_hits, 0);
         assert_eq!(stats.runtime_requirements_misses, 7);
         assert_eq!(stats.module_hash_hits, 0);
@@ -1215,7 +1215,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cache_unaffected_invalidates_second_stage_memos_when_used_exports_change()
+    async fn cache_unaffected_invalidates_post_id_assignment_memos_when_used_exports_change()
     -> std::result::Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
         let entry_path = temp.path().join("index.js");
@@ -1255,7 +1255,7 @@ mod tests {
             .as_ref()
             .expect("cacheUnaffected should create a Module Computation Cache")
             .stats();
-        assert_eq!(stats.chunk_graph_invalidated_modules, 1);
+        assert_eq!(stats.post_id_assignment_invalidated_modules, 1);
         assert_eq!(stats.module_hash_hits, 0);
         assert_eq!(stats.module_hash_misses, 4);
         assert_eq!(second.errors(), []);
@@ -1266,7 +1266,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cache_unaffected_invalidates_second_stage_memos_when_chunk_membership_changes()
+    async fn cache_unaffected_invalidates_post_id_assignment_memos_when_chunk_membership_changes()
     -> std::result::Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
         let entry_path = temp.path().join("index.js");
@@ -1289,7 +1289,7 @@ mod tests {
             .as_ref()
             .expect("cacheUnaffected should create a Module Computation Cache")
             .stats();
-        assert_eq!(stats.chunk_graph_invalidated_modules, 1);
+        assert_eq!(stats.post_id_assignment_invalidated_modules, 1);
         assert_eq!(stats.runtime_requirements_hits, 0);
         assert_eq!(stats.runtime_requirements_misses, 4);
         assert_eq!(stats.module_hash_hits, 0);
@@ -1330,14 +1330,14 @@ mod tests {
             crate::module_computation_cache::ModuleComputationCacheStats {
                 provided_exports_hits: 2,
                 provided_exports_misses: 2,
-                invalidated_modules: 0,
+                pre_chunk_graph_invalidated_modules: 0,
                 static_reachable_hits: 1,
                 static_reachable_misses: 1,
                 runtime_requirements_hits: 2,
                 runtime_requirements_misses: 2,
                 module_hash_hits: 2,
                 module_hash_misses: 2,
-                chunk_graph_invalidated_modules: 0,
+                post_id_assignment_invalidated_modules: 0,
             }
         );
         assert_eq!(compiler.cache.stats().module_entries, 0);
@@ -1368,14 +1368,14 @@ mod tests {
             crate::module_computation_cache::ModuleComputationCacheStats {
                 provided_exports_hits: 0,
                 provided_exports_misses: 2,
-                invalidated_modules: 0,
+                pre_chunk_graph_invalidated_modules: 0,
                 static_reachable_hits: 0,
                 static_reachable_misses: 1,
                 runtime_requirements_hits: 0,
                 runtime_requirements_misses: 2,
                 module_hash_hits: 0,
                 module_hash_misses: 2,
-                chunk_graph_invalidated_modules: 0,
+                post_id_assignment_invalidated_modules: 0,
             },
             "Module Computation memos must not be restored from PackFile"
         );

--- a/crates/unpack_core/src/module_computation_cache.rs
+++ b/crates/unpack_core/src/module_computation_cache.rs
@@ -9,7 +9,11 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::{ExportsInfo, ModuleGraph, ModuleHandle, ModuleIdentity};
+use crate::{
+    ChunkGraph, ExportsInfo, ModuleGraph, ModuleHandle, ModuleIdentity,
+    chunk_graph::{ChunkGraphModuleReferences, ModuleHash},
+    runtime::RuntimeRequirements,
+};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ModuleComputationCache {
@@ -42,6 +46,20 @@ struct ModuleComputationEntry {
     signature: ModuleSignature,
     provided_exports: Option<ExportsInfo>,
     static_reachable: Option<Vec<ModuleIdentity>>,
+    chunk_graph: Option<ChunkGraphComputationEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ChunkGraphSignature {
+    references: ChunkGraphModuleReferences,
+    exports_info: ExportsInfo,
+}
+
+#[derive(Debug)]
+struct ChunkGraphComputationEntry {
+    signature: ChunkGraphSignature,
+    runtime_requirements: Option<RuntimeRequirements>,
+    module_hash: Option<ModuleHash>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -51,6 +69,11 @@ pub(crate) struct ModuleComputationCacheStats {
     pub(crate) invalidated_modules: usize,
     pub(crate) static_reachable_hits: usize,
     pub(crate) static_reachable_misses: usize,
+    pub(crate) runtime_requirements_hits: usize,
+    pub(crate) runtime_requirements_misses: usize,
+    pub(crate) module_hash_hits: usize,
+    pub(crate) module_hash_misses: usize,
+    pub(crate) chunk_graph_invalidated_modules: usize,
 }
 
 impl ModuleComputationCache {
@@ -114,11 +137,15 @@ impl ModuleComputationCache {
                             signature: signature.clone(),
                             provided_exports: None,
                             static_reachable: None,
+                            chunk_graph: None,
                         });
                 if is_affected {
                     let provided_exports_invalidated = entry.provided_exports.take().is_some();
                     let static_reachable_invalidated = entry.static_reachable.take().is_some();
-                    let invalidated = provided_exports_invalidated || static_reachable_invalidated;
+                    let chunk_graph_invalidated = entry.chunk_graph.take().is_some();
+                    let invalidated = provided_exports_invalidated
+                        || static_reachable_invalidated
+                        || chunk_graph_invalidated;
                     entry.signature = signature;
                     invalidated
                 } else {
@@ -127,6 +154,43 @@ impl ModuleComputationCache {
             };
             if invalidated {
                 state.stats.invalidated_modules += 1;
+            }
+        }
+    }
+
+    pub(crate) fn prepare_chunk_graph(&self, module_graph: &ModuleGraph, chunk_graph: &ChunkGraph) {
+        let signatures = module_graph
+            .modules()
+            .iter()
+            .map(|module| {
+                (
+                    module.identity().clone(),
+                    chunk_graph_signature(module_graph, chunk_graph, module.handle()),
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut state = self
+            .state
+            .lock()
+            .expect("module computation cache mutex should not be poisoned");
+        for (identity, signature) in signatures {
+            let entry = state
+                .modules
+                .get_mut(&identity)
+                .expect("Module Computation Cache must be prepared after Make");
+            let changed = entry
+                .chunk_graph
+                .as_ref()
+                .is_some_and(|cached| cached.signature != signature);
+            if entry.chunk_graph.is_none() || changed {
+                entry.chunk_graph = Some(ChunkGraphComputationEntry {
+                    signature,
+                    runtime_requirements: None,
+                    module_hash: None,
+                });
+            }
+            if changed {
+                state.stats.chunk_graph_invalidated_modules += 1;
             }
         }
     }
@@ -213,12 +277,91 @@ impl ModuleComputationCache {
             .static_reachable = Some(identities);
     }
 
+    pub(crate) fn get_runtime_requirements(
+        &self,
+        identity: &ModuleIdentity,
+    ) -> Option<RuntimeRequirements> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("module computation cache mutex should not be poisoned");
+        let result = state
+            .modules
+            .get(identity)
+            .and_then(|entry| entry.chunk_graph.as_ref())
+            .and_then(|entry| entry.runtime_requirements);
+        if result.is_some() {
+            state.stats.runtime_requirements_hits += 1;
+        } else {
+            state.stats.runtime_requirements_misses += 1;
+        }
+        result
+    }
+
+    pub(crate) fn store_runtime_requirements(
+        &self,
+        identity: &ModuleIdentity,
+        runtime_requirements: RuntimeRequirements,
+    ) {
+        self.state
+            .lock()
+            .expect("module computation cache mutex should not be poisoned")
+            .modules
+            .get_mut(identity)
+            .and_then(|entry| entry.chunk_graph.as_mut())
+            .expect("Chunk Graph computation cache must be prepared before storing a memo")
+            .runtime_requirements = Some(runtime_requirements);
+    }
+
+    pub(crate) fn get_module_hash(&self, identity: &ModuleIdentity) -> Option<ModuleHash> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("module computation cache mutex should not be poisoned");
+        let result = state
+            .modules
+            .get(identity)
+            .and_then(|entry| entry.chunk_graph.as_ref())
+            .and_then(|entry| entry.module_hash);
+        if result.is_some() {
+            state.stats.module_hash_hits += 1;
+        } else {
+            state.stats.module_hash_misses += 1;
+        }
+        result
+    }
+
+    pub(crate) fn store_module_hash(&self, identity: &ModuleIdentity, module_hash: ModuleHash) {
+        self.state
+            .lock()
+            .expect("module computation cache mutex should not be poisoned")
+            .modules
+            .get_mut(identity)
+            .and_then(|entry| entry.chunk_graph.as_mut())
+            .expect("Chunk Graph computation cache must be prepared before storing a memo")
+            .module_hash = Some(module_hash);
+    }
+
     #[cfg(test)]
     pub(crate) fn stats(&self) -> ModuleComputationCacheStats {
         self.state
             .lock()
             .expect("module computation cache mutex should not be poisoned")
             .stats
+    }
+}
+
+fn chunk_graph_signature(
+    module_graph: &ModuleGraph,
+    chunk_graph: &ChunkGraph,
+    handle: ModuleHandle,
+) -> ChunkGraphSignature {
+    let module = module_graph
+        .module(handle)
+        .expect("a Module Graph handle should address a Module");
+    ChunkGraphSignature {
+        references: chunk_graph.module_references(module_graph, handle),
+        exports_info: module.exports_info().clone(),
     }
 }
 

--- a/crates/unpack_core/src/module_computation_cache.rs
+++ b/crates/unpack_core/src/module_computation_cache.rs
@@ -28,14 +28,14 @@ struct ModuleComputationCacheState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct ModuleSignature {
+struct PreChunkGraphSignature {
     source_hash: u64,
     build_error: Option<String>,
-    references: Vec<ModuleReference>,
+    references: Vec<PreChunkGraphModuleReference>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct ModuleReference {
+struct PreChunkGraphModuleReference {
     block: Option<usize>,
     dependency: Option<usize>,
     target: ModuleIdentity,
@@ -43,21 +43,30 @@ struct ModuleReference {
 
 #[derive(Debug)]
 struct ModuleComputationEntry {
-    signature: ModuleSignature,
+    pre_chunk_graph: PreChunkGraphModuleComputationEntry,
+    post_id_assignment: Option<PostIdAssignmentModuleComputationEntry>,
+}
+
+// Corresponds to webpack's `moduleMemCaches`: these memos are validated after
+// Module Graph construction and before `finishModules` and Chunk Graph work.
+#[derive(Debug)]
+struct PreChunkGraphModuleComputationEntry {
+    signature: PreChunkGraphSignature,
     provided_exports: Option<ExportsInfo>,
     static_reachable: Option<Vec<ModuleIdentity>>,
-    chunk_graph: Option<ChunkGraphComputationEntry>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct ChunkGraphSignature {
+struct PostIdAssignmentSignature {
     references: ChunkGraphModuleReferences,
     exports_info: ExportsInfo,
 }
 
+// Corresponds to webpack's `moduleMemCaches2`: these memos are only valid after
+// ID Assignment and use the current Chunk Graph references for validation.
 #[derive(Debug)]
-struct ChunkGraphComputationEntry {
-    signature: ChunkGraphSignature,
+struct PostIdAssignmentModuleComputationEntry {
+    signature: PostIdAssignmentSignature,
     runtime_requirements: Option<RuntimeRequirements>,
     module_hash: Option<ModuleHash>,
 }
@@ -66,18 +75,18 @@ struct ChunkGraphComputationEntry {
 pub(crate) struct ModuleComputationCacheStats {
     pub(crate) provided_exports_hits: usize,
     pub(crate) provided_exports_misses: usize,
-    pub(crate) invalidated_modules: usize,
+    pub(crate) pre_chunk_graph_invalidated_modules: usize,
     pub(crate) static_reachable_hits: usize,
     pub(crate) static_reachable_misses: usize,
     pub(crate) runtime_requirements_hits: usize,
     pub(crate) runtime_requirements_misses: usize,
     pub(crate) module_hash_hits: usize,
     pub(crate) module_hash_misses: usize,
-    pub(crate) chunk_graph_invalidated_modules: usize,
+    pub(crate) post_id_assignment_invalidated_modules: usize,
 }
 
 impl ModuleComputationCache {
-    pub(crate) fn prepare(&self, module_graph: &ModuleGraph) {
+    pub(crate) fn prepare_before_chunk_graph(&self, module_graph: &ModuleGraph) {
         let signatures = module_graph
             .modules()
             .iter()
@@ -85,7 +94,7 @@ impl ModuleComputationCache {
                 (
                     module.identity().clone(),
                     module.handle(),
-                    module_signature(module_graph, module.handle()),
+                    pre_chunk_graph_signature(module_graph, module.handle()),
                 )
             })
             .collect::<Vec<_>>();
@@ -111,7 +120,7 @@ impl ModuleComputationCache {
                 let unchanged = state
                     .modules
                     .get(identity)
-                    .is_some_and(|entry| entry.signature == *signature);
+                    .is_some_and(|entry| entry.pre_chunk_graph.signature == *signature);
                 (!unchanged).then_some(*handle)
             })
             .collect::<HashSet<_>>();
@@ -134,38 +143,47 @@ impl ModuleComputationCache {
                         .modules
                         .entry(identity)
                         .or_insert_with(|| ModuleComputationEntry {
-                            signature: signature.clone(),
-                            provided_exports: None,
-                            static_reachable: None,
-                            chunk_graph: None,
+                            pre_chunk_graph: PreChunkGraphModuleComputationEntry {
+                                signature: signature.clone(),
+                                provided_exports: None,
+                                static_reachable: None,
+                            },
+                            post_id_assignment: None,
                         });
                 if is_affected {
-                    let provided_exports_invalidated = entry.provided_exports.take().is_some();
-                    let static_reachable_invalidated = entry.static_reachable.take().is_some();
-                    let chunk_graph_invalidated = entry.chunk_graph.take().is_some();
+                    let provided_exports_invalidated =
+                        entry.pre_chunk_graph.provided_exports.take().is_some();
+                    let static_reachable_invalidated =
+                        entry.pre_chunk_graph.static_reachable.take().is_some();
+                    // Pre-Chunk-Graph invalidation always dominates the later stage.
+                    let post_id_assignment_invalidated = entry.post_id_assignment.take().is_some();
                     let invalidated = provided_exports_invalidated
                         || static_reachable_invalidated
-                        || chunk_graph_invalidated;
-                    entry.signature = signature;
+                        || post_id_assignment_invalidated;
+                    entry.pre_chunk_graph.signature = signature;
                     invalidated
                 } else {
                     false
                 }
             };
             if invalidated {
-                state.stats.invalidated_modules += 1;
+                state.stats.pre_chunk_graph_invalidated_modules += 1;
             }
         }
     }
 
-    pub(crate) fn prepare_chunk_graph(&self, module_graph: &ModuleGraph, chunk_graph: &ChunkGraph) {
+    pub(crate) fn prepare_after_id_assignment(
+        &self,
+        module_graph: &ModuleGraph,
+        chunk_graph: &ChunkGraph,
+    ) {
         let signatures = module_graph
             .modules()
             .iter()
             .map(|module| {
                 (
                     module.identity().clone(),
-                    chunk_graph_signature(module_graph, chunk_graph, module.handle()),
+                    post_id_assignment_signature(module_graph, chunk_graph, module.handle()),
                 )
             })
             .collect::<Vec<_>>();
@@ -177,20 +195,22 @@ impl ModuleComputationCache {
             let entry = state
                 .modules
                 .get_mut(&identity)
-                .expect("Module Computation Cache must be prepared after Make");
+                .expect("Pre-Chunk-Graph entry must be prepared before ID Assignment");
             let changed = entry
-                .chunk_graph
+                .post_id_assignment
                 .as_ref()
                 .is_some_and(|cached| cached.signature != signature);
-            if entry.chunk_graph.is_none() || changed {
-                entry.chunk_graph = Some(ChunkGraphComputationEntry {
+            if entry.post_id_assignment.is_none() || changed {
+                // A later-only change replaces this entry without clearing
+                // the Pre-Chunk-Graph memos stored beside it.
+                entry.post_id_assignment = Some(PostIdAssignmentModuleComputationEntry {
                     signature,
                     runtime_requirements: None,
                     module_hash: None,
                 });
             }
             if changed {
-                state.stats.chunk_graph_invalidated_modules += 1;
+                state.stats.post_id_assignment_invalidated_modules += 1;
             }
         }
     }
@@ -203,7 +223,7 @@ impl ModuleComputationCache {
         let result = state
             .modules
             .get(identity)
-            .and_then(|entry| entry.provided_exports.clone());
+            .and_then(|entry| entry.pre_chunk_graph.provided_exports.clone());
         if result.is_some() {
             state.stats.provided_exports_hits += 1;
         } else {
@@ -223,6 +243,7 @@ impl ModuleComputationCache {
             .modules
             .get_mut(identity)
             .expect("Module Computation Cache must be prepared before storing a memo")
+            .pre_chunk_graph
             .provided_exports = Some(exports_info);
     }
 
@@ -237,7 +258,7 @@ impl ModuleComputationCache {
         let identities = state
             .modules
             .get(identity)
-            .and_then(|entry| entry.static_reachable.clone());
+            .and_then(|entry| entry.pre_chunk_graph.static_reachable.clone());
         let result = identities.and_then(|identities| {
             identities
                 .iter()
@@ -274,6 +295,7 @@ impl ModuleComputationCache {
             .modules
             .get_mut(identity)
             .expect("Module Computation Cache must be prepared before storing a memo")
+            .pre_chunk_graph
             .static_reachable = Some(identities);
     }
 
@@ -288,7 +310,7 @@ impl ModuleComputationCache {
         let result = state
             .modules
             .get(identity)
-            .and_then(|entry| entry.chunk_graph.as_ref())
+            .and_then(|entry| entry.post_id_assignment.as_ref())
             .and_then(|entry| entry.runtime_requirements);
         if result.is_some() {
             state.stats.runtime_requirements_hits += 1;
@@ -308,8 +330,8 @@ impl ModuleComputationCache {
             .expect("module computation cache mutex should not be poisoned")
             .modules
             .get_mut(identity)
-            .and_then(|entry| entry.chunk_graph.as_mut())
-            .expect("Chunk Graph computation cache must be prepared before storing a memo")
+            .and_then(|entry| entry.post_id_assignment.as_mut())
+            .expect("Post-ID-Assignment cache must be prepared before storing a memo")
             .runtime_requirements = Some(runtime_requirements);
     }
 
@@ -321,7 +343,7 @@ impl ModuleComputationCache {
         let result = state
             .modules
             .get(identity)
-            .and_then(|entry| entry.chunk_graph.as_ref())
+            .and_then(|entry| entry.post_id_assignment.as_ref())
             .and_then(|entry| entry.module_hash);
         if result.is_some() {
             state.stats.module_hash_hits += 1;
@@ -337,8 +359,8 @@ impl ModuleComputationCache {
             .expect("module computation cache mutex should not be poisoned")
             .modules
             .get_mut(identity)
-            .and_then(|entry| entry.chunk_graph.as_mut())
-            .expect("Chunk Graph computation cache must be prepared before storing a memo")
+            .and_then(|entry| entry.post_id_assignment.as_mut())
+            .expect("Post-ID-Assignment cache must be prepared before storing a memo")
             .module_hash = Some(module_hash);
     }
 
@@ -351,21 +373,24 @@ impl ModuleComputationCache {
     }
 }
 
-fn chunk_graph_signature(
+fn post_id_assignment_signature(
     module_graph: &ModuleGraph,
     chunk_graph: &ChunkGraph,
     handle: ModuleHandle,
-) -> ChunkGraphSignature {
+) -> PostIdAssignmentSignature {
     let module = module_graph
         .module(handle)
         .expect("a Module Graph handle should address a Module");
-    ChunkGraphSignature {
+    PostIdAssignmentSignature {
         references: chunk_graph.module_references(module_graph, handle),
         exports_info: module.exports_info().clone(),
     }
 }
 
-fn module_signature(module_graph: &ModuleGraph, handle: ModuleHandle) -> ModuleSignature {
+fn pre_chunk_graph_signature(
+    module_graph: &ModuleGraph,
+    handle: ModuleHandle,
+) -> PreChunkGraphSignature {
     let module = module_graph
         .module(handle)
         .expect("a Module Graph handle should address a Module");
@@ -375,7 +400,7 @@ fn module_signature(module_graph: &ModuleGraph, handle: ModuleHandle) -> ModuleS
             let target = module_graph
                 .module(connection.module)
                 .expect("a Module Graph connection should target a Module");
-            ModuleReference {
+            PreChunkGraphModuleReference {
                 block: connection.origin_block.map(|block| block.index()),
                 dependency: connection
                     .origin_dependency_index
@@ -384,7 +409,7 @@ fn module_signature(module_graph: &ModuleGraph, handle: ModuleHandle) -> ModuleS
             }
         })
         .collect();
-    ModuleSignature {
+    PreChunkGraphSignature {
         source_hash: module.source_hash(),
         build_error: module.build_error().map(ToString::to_string),
         references,

--- a/docs/adr/0139-keep-unaffected-module-computations-separate-from-record-cache.md
+++ b/docs/adr/0139-keep-unaffected-module-computations-separate-from-record-cache.md
@@ -13,17 +13,28 @@ As in webpack, explicitly enabling either cache option requires
 mode defaults the memory `cacheUnaffected` or filesystem
 `memoryCacheUnaffected` option to true; other modes default it to false.
 
-The first typed memos are provided-exports analysis and static-reachability
-collection for Chunk Graph construction. After Make, the cache compares
-stable Module identities, built-source hashes, and outgoing graph references.
-Changed and new modules are marked affected, and affected state propagates
-conservatively through all incoming connections because Unpack does not yet
-model webpack's dependency affect-type classification. Unaffected modules may
-restore their provided-exports memo across Compilations owned by the same
-Compiler; affected modules recompute and replace their memo. Filesystem
-`memoryCacheUnaffected` remains active even when ordinary
-`maxMemoryGenerations` is zero, and Module Computation entries are never
-written to PackFile.
+The pre-Chunk-Graph typed memos are provided-exports analysis and
+static-reachability collection for Chunk Graph construction. After Make, the
+cache compares stable Module identities, built-source hashes, and outgoing
+graph references. Changed and new modules are marked affected, and affected
+state propagates conservatively through all incoming connections because
+Unpack does not yet model webpack's dependency affect-type classification.
+Unaffected modules may restore their provided-exports memo across Compilations
+owned by the same Compiler; affected modules recompute and replace their memo.
+
+After ID Assignment, a second validation stage corresponds to webpack's
+`moduleMemCaches2`. It compares the Module's Render ID, Chunk membership,
+outgoing target Render IDs, Async Block Chunk Render IDs, and Exports Info. The
+second-stage typed memos are processed per-module Runtime Requirements and the
+Module Hash. A first-stage invalidation also discards its second-stage memos,
+while a Chunk-Graph-only change leaves pre-Chunk-Graph memos intact. Unpack
+currently has one effective runtime per Module; if runtime variants are
+introduced, the second-stage memo identities must include the Runtime Spec as
+webpack's do.
+
+Filesystem `memoryCacheUnaffected` remains active even when ordinary
+`maxMemoryGenerations` is zero, and Module Computation entries from either
+stage are never written to PackFile.
 
 This supersedes ADR 0130's exclusion of cache-unaffected behavior and rejects
 the earlier design that represented unaffected computations as an unbounded

--- a/docs/adr/0139-keep-unaffected-module-computations-separate-from-record-cache.md
+++ b/docs/adr/0139-keep-unaffected-module-computations-separate-from-record-cache.md
@@ -13,24 +13,25 @@ As in webpack, explicitly enabling either cache option requires
 mode defaults the memory `cacheUnaffected` or filesystem
 `memoryCacheUnaffected` option to true; other modes default it to false.
 
-The pre-Chunk-Graph typed memos are provided-exports analysis and
-static-reachability collection for Chunk Graph construction. After Make, the
-cache compares stable Module identities, built-source hashes, and outgoing
-graph references. Changed and new modules are marked affected, and affected
-state propagates conservatively through all incoming connections because
-Unpack does not yet model webpack's dependency affect-type classification.
-Unaffected modules may restore their provided-exports memo across Compilations
-owned by the same Compiler; affected modules recompute and replace their memo.
+The Pre-Chunk-Graph Module Computation Entry corresponding to webpack's
+`moduleMemCaches` stores the provided-exports analysis and static-reachability
+collection used for Chunk Graph construction. It is validated after Module
+Graph construction and before `finishModules`. It compares stable Module
+identities, built-source hashes, and outgoing graph references. Changed and
+new modules are marked affected, and affected state propagates conservatively
+through all incoming connections because Unpack does not yet model webpack's
+dependency affect-type classification. Unaffected modules may restore their
+provided-exports memo across Compilations owned by the same Compiler; affected
+modules recompute and replace their memo.
 
-After ID Assignment, a second validation stage corresponds to webpack's
-`moduleMemCaches2`. It compares the Module's Render ID, Chunk membership,
-outgoing target Render IDs, Async Block Chunk Render IDs, and Exports Info. The
-second-stage typed memos are processed per-module Runtime Requirements and the
-Module Hash. A first-stage invalidation also discards its second-stage memos,
-while a Chunk-Graph-only change leaves pre-Chunk-Graph memos intact. Unpack
-currently has one effective runtime per Module; if runtime variants are
-introduced, the second-stage memo identities must include the Runtime Spec as
-webpack's do.
+The Post-ID-Assignment Module Computation Entry corresponding to webpack's
+`moduleMemCaches2` compares the Module's Render ID, Chunk membership, outgoing
+target Render IDs, Async Block Chunk Render IDs, and Exports Info. It stores
+processed per-module Runtime Requirements and the Module Hash. Pre-Chunk-Graph
+invalidation also discards the later entry, while a Post-ID-Assignment-only
+change leaves Pre-Chunk-Graph memos intact. Unpack currently has one effective
+runtime per Module; if runtime variants are introduced, the later entry's memo
+identities must include the Runtime Spec as webpack's do.
 
 Filesystem `memoryCacheUnaffected` remains active even when ordinary
 `maxMemoryGenerations` is zero, and Module Computation entries from either

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -86,6 +86,13 @@ Items, options, and Pack File storage remain Rust-only helpers colocated with
 the webpack responsibility that owns them. There is no separate `BuildCache`
 type, file, or source hierarchy.
 
+Webpack's `moduleMemCaches` and `moduleMemCaches2` use per-Module
+`WeakTupleMap` values. Unpack represents their implemented computations as
+typed slots in one Compiler-owned Module Computation Cache. The second-stage
+slots are validated after ID Assignment from Render IDs, Chunk membership,
+Async Block Chunk references, and Exports Info, and currently have one
+effective runtime rather than webpack's Runtime Spec variants.
+
 Webpack wires these responsibilities through plugins and Tapable hooks. Unpack
 keeps its existing typed layers, explicit lifecycle methods, and closed Cache
 Item families under ADR 0131; the different Rust representation is deliberate,

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -88,10 +88,11 @@ type, file, or source hierarchy.
 
 Webpack's `moduleMemCaches` and `moduleMemCaches2` use per-Module
 `WeakTupleMap` values. Unpack represents their implemented computations as
-typed slots in one Compiler-owned Module Computation Cache. The second-stage
-slots are validated after ID Assignment from Render IDs, Chunk membership,
-Async Block Chunk references, and Exports Info, and currently have one
-effective runtime rather than webpack's Runtime Spec variants.
+typed Pre-Chunk-Graph and Post-ID-Assignment entries in one Compiler-owned Module
+Computation Cache. The later entries are validated after ID Assignment from
+Render IDs, Chunk membership, Async Block Chunk references, and Exports Info,
+and currently have one effective runtime rather than webpack's Runtime Spec
+variants.
 
 Webpack wires these responsibilities through plugins and Tapable hooks. Unpack
 keeps its existing typed layers, explicit lifecycle methods, and closed Cache


### PR DESCRIPTION
## Summary

- add post-ID-assignment validation for Chunk Graph-dependent module computations
- reuse processed Runtime Requirements and Module Hashes across unaffected compilations
- invalidate second-stage memos for Render ID, Chunk membership, async Chunk, and Exports Info changes
- document the Module Hash domain term and the `moduleMemCaches2` alignment

This closes the gap where `cacheUnaffected` only retained pre-Chunk-Graph computations. Warm rebuild tests now compare emitted assets with fresh Compiler builds after each invalidation scenario.

Tested with `pnpm test`.
