### PR TITLE
Keep compilation handles out of build cache data

### DIFF
--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -390,7 +390,7 @@ impl JavascriptRenderManifest {
 
     fn cache_etag(&self, code_generation_results: &CodeGenerationResults) -> CacheETag {
         let mut hasher = StableHasher::default();
-        hasher.write(b"unpack/asset-render/hash/1");
+        hasher.write(b"unpack/asset-render/hash/2");
         match self {
             Self::InitialChunk {
                 modules,
@@ -422,7 +422,8 @@ fn hash_module_render_inputs(
     modules.len().hash(hasher);
     for module in modules {
         module.render_id.hash(hasher);
-        module.module.hash(hasher);
+        // Module Handles belong to the current Compilation. They may locate the
+        // current result, but must not become Build Cache validation data.
         let result = code_generation_results
             .results
             .get(&module.module)
@@ -637,8 +638,9 @@ mod tests {
 
     use super::{
         AssetRenderKey, AssetRenderKind, CodeGenerationResult, CodeGenerationResults,
-        CodeGenerationSource, JavascriptRenderManifest, ModuleRenderManifest,
-        RenderedRuntimeModule, RenderedSource, emit_asset,
+        CodeGenerationSource, JavascriptRenderManifest, ModuleRenderManifest, RenderManifest,
+        RenderManifestContent, RenderManifestEntry, RenderedRuntimeModule, RenderedSource,
+        emit_asset, render_assets,
     };
     use crate::code_generation_record::{CodeGenerationRecord, CodeGenerationReplacement};
 
@@ -664,6 +666,58 @@ mod tests {
             CacheIdentifier::from_parts([b"initial".to_vec(), b"main".to_vec()])
         );
         assert_ne!(initial.cache_identifier(), asynchronous.cache_identifier());
+    }
+
+    #[test]
+    fn asset_render_cache_reuses_equivalent_inputs_with_different_graph_handles() {
+        let temp = tempfile::tempdir().expect("create asset render cache directory");
+        let mut options = CompilerOptions::new("/project", Vec::new());
+        options.cache = CacheOptions::filesystem();
+        options.cache.cache_location = Some(temp.path().join("cache"));
+        options.sourcemap = false;
+        let cache = Cache::new(options.cache.clone(), SnapshotOptions::default());
+        let render_id = RenderId::String("./src/feature.js".to_string());
+        let chunk_id = RenderId::String("src_feature_js".to_string());
+
+        let render_with_handle = |module_handle| {
+            let manifest = RenderManifest {
+                entries: vec![RenderManifestEntry {
+                    filename: "src_feature_js.js".to_string(),
+                    render: RenderManifestContent::JavaScript(
+                        JavascriptRenderManifest::AsyncChunk {
+                            modules: vec![ModuleRenderManifest {
+                                module: module_handle,
+                                render_id: render_id.clone(),
+                            }],
+                            chunk_id: chunk_id.clone(),
+                        },
+                    ),
+                }],
+            };
+            let mut results = CodeGenerationResults::default();
+            results.results.insert(
+                module_handle,
+                code_generation_result("export const value = 'stable';"),
+            );
+            render_assets(&options, &cache, &manifest, &results)
+        };
+
+        let first = render_with_handle(ModuleHandle::new(0));
+        let second = render_with_handle(ModuleHandle::new(1));
+
+        assert_eq!(first, second);
+        assert_eq!(
+            cache
+                .work_counters()
+                .for_family(CacheItemFamily::AssetRender),
+            CacheItemWork {
+                hits: 1,
+                misses: 1,
+                stores: 1,
+                restores: 0,
+                evictions: 0,
+            }
+        );
     }
 
     #[test]

--- a/docs/adr/0142-keep-compilation-local-handles-out-of-build-cache-data.md
+++ b/docs/adr/0142-keep-compilation-local-handles-out-of-build-cache-data.md
@@ -1,0 +1,22 @@
+# Keep compilation-local handles out of Build Cache data
+
+Build Cache data must not use Compilation-local Graph Handles or other
+allocation-order-derived identifiers as Cache Identifiers, Cache ETag inputs,
+or persisted Cache Item references. This applies to both Memory Cache and
+Persistent Cache because both can reuse Cache Items across fresh Compilations.
+Cache identity and validation must instead use stable domain identities and the
+actual stable inputs that determine the reusable result.
+
+Graph Handles may still index Compilation-owned storage and locate current
+Module Graph, Chunk Graph, or Code Generation results while a cache input is
+being computed. Values reached through those lookups may participate when they
+are stable inputs to the cached result, but the Graph Handle itself must not.
+When a reusable computation cannot be expressed without a Compilation-local
+identifier, it must remain Compilation-local or use a Compiler-owned memo that
+explicitly rebinds stable identities to current handles.
+
+Asset Render Cache ETags therefore include Module Render IDs, rendered module
+sources, Runtime Requirements, Runtime Modules, and chunk or entry Render IDs,
+but not `ModuleHandle`. This extends ADR 0064's fresh Compilation boundary and
+ADR 0131's stable Cache Item identity model without changing the Rust-native
+dense-handle representation permitted by ADR 0113.


### PR DESCRIPTION
## Summary

- stop including Compilation-local `ModuleHandle` values in Asset Render Cache ETags
- preserve handles only for current Compilation result lookup and add cross-handle cache reuse coverage
- record the stable Build Cache identity requirement in ADR 0142

## Why

Asset Render ETags previously included dense graph handles whose values depend on allocation order within one Compilation. Equivalent render inputs could therefore miss the cache across fresh Compilations even though the emitted asset was unchanged.

The ETag format is bumped to version 2 so entries produced by the old hashing rule are not mixed with the corrected rule.

## Tests

- `pnpm test`
