### PR TITLE
Add resolve cache configuration

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -144,6 +144,10 @@ _Avoid_: Entry chunk, main chunk
 The compilation stage that starts from entry modules, discovers their dependencies, and constructs the module graph before bundling.
 _Avoid_: Build phase, parse phase
 
+**Resolve Cache**:
+The webpack-shaped cache of successful resolver results, controlled by `resolve.cache`; entries remain subject to dependency Snapshot validation and are distinct from the resolver's internal filesystem and package-metadata memoization.
+_Avoid_: Resolver filesystem cache, unsafe resolver cache
+
 **Serial Rebuild Make**:
 The default Make scheduling mode for rebuilds, in which Factorize and Build futures are polled directly by the Make queue instead of being wrapped in Tokio tasks. It changes scheduling only; the Make task model remains intact, and an explicitly configured finite parallelism limit still applies.
 _Avoid_: Single-threaded rebuild, disabled concurrency

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -51,6 +51,7 @@ pub struct CompilerOptions {
     pub entries: Vec<Entry>,
     pub cache: CacheOptions,
     pub resolve: ResolveOptions,
+    pub resolve_cache: bool,
     pub snapshot: SnapshotOptions,
     pub infrastructure_logging: InfrastructureLoggingOptions,
     pub module_rules: Vec<ModuleRule>,
@@ -72,6 +73,7 @@ impl CompilerOptions {
             entries,
             cache: CacheOptions::default(),
             resolve: default_resolve_options(),
+            resolve_cache: true,
             snapshot: SnapshotOptions::default(),
             infrastructure_logging: InfrastructureLoggingOptions::disabled(),
             module_rules: Vec::new(),
@@ -1077,6 +1079,31 @@ mod tests {
         );
         assert_eq!(after.resolve_hits - before.resolve_hits, 0);
         assert_eq!(after.module_hits - before.module_hits, 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn disabled_resolve_cache_skips_resolve_record_storage_and_reuse()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        write(
+            temp.path().join("index.js"),
+            "import './dep'; export const value = 1;",
+        )?;
+        write(temp.path().join("dep.js"), "export const dep = 1;")?;
+
+        let mut options = CompilerOptions::new(temp.path(), vec![Entry::new("main", "./index")]);
+        options.resolve_cache = false;
+        let compiler = Compiler::new(options);
+        compiler.run().await?;
+        let before = compiler.cache.stats();
+        compiler.run().await?;
+        let after = compiler.cache.stats();
+
+        assert_eq!(after.resolve_hits - before.resolve_hits, 0);
+        assert_eq!(after.resolve_misses - before.resolve_misses, 0);
+        assert_eq!(after.resolve_entries - before.resolve_entries, 0);
+        assert!(after.module_hits > before.module_hits);
         Ok(())
     }
 

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -223,6 +223,7 @@ pub(crate) async fn run(
             snapshot_cache.clone(),
             module_types.clone(),
         )
+        .with_resolve_cache(options.resolve_cache)
         .with_module_rules(options.module_rules.clone())
         .with_side_effects(options.side_effects != crate::SideEffectsOption::Disabled)
         .with_unsafe_watch_cache(

--- a/crates/unpack_core/src/normal_module_factory.rs
+++ b/crates/unpack_core/src/normal_module_factory.rs
@@ -153,6 +153,7 @@ pub struct NormalModuleFactory {
     side_effects: bool,
     unsafe_watch_cache: Option<crate::unsafe_watch_cache::UnsafeWatchCache>,
     watch_change_set: Option<crate::WatchChangeSet>,
+    resolve_cache: bool,
 }
 
 // Per-compilation singleflight cache; separate from Cache so cache:false
@@ -189,6 +190,7 @@ impl NormalModuleFactory {
             side_effects: false,
             unsafe_watch_cache: None,
             watch_change_set: None,
+            resolve_cache: true,
         }
     }
 
@@ -199,6 +201,11 @@ impl NormalModuleFactory {
 
     pub(crate) fn with_side_effects(mut self, side_effects: bool) -> Self {
         self.side_effects = side_effects;
+        self
+    }
+
+    pub(crate) fn with_resolve_cache(mut self, enabled: bool) -> Self {
+        self.resolve_cache = enabled;
         self
     }
 
@@ -222,7 +229,9 @@ impl NormalModuleFactory {
             .expect("module dependency should have a request");
         let resolve_request = ResolveRequest::new(context, request);
         let mut skip_ordinary_cache = false;
-        if let (Some(cache), Some(changes)) = (&self.unsafe_watch_cache, &self.watch_change_set) {
+        if self.resolve_cache
+            && let (Some(cache), Some(changes)) = (&self.unsafe_watch_cache, &self.watch_change_set)
+        {
             match cache.get_resolve(&resolve_request, changes) {
                 crate::unsafe_watch_cache::UnsafeWatchCacheLookup::Reusable(record) => {
                     return self.apply_module_rules(
@@ -237,7 +246,10 @@ impl NormalModuleFactory {
                 crate::unsafe_watch_cache::UnsafeWatchCacheLookup::Miss => {}
             }
         }
-        if !skip_ordinary_cache && let Some(record) = self.cache.get(&resolve_request, None) {
+        if self.resolve_cache
+            && !skip_ordinary_cache
+            && let Some(record) = self.cache.get(&resolve_request, None)
+        {
             let valid = if self.resolve_snapshot_strategy.hash {
                 record
                     .is_valid_with_cache(
@@ -263,8 +275,14 @@ impl NormalModuleFactory {
             }
         }
 
-        self.factorize_with_runtime_cache(context, request, resolve_request)
-            .await
+        let factorized = if self.resolve_cache {
+            self.factorize_with_runtime_cache(context, request, resolve_request)
+                .await
+        } else {
+            self.factorize_uncached(context, request, resolve_request)
+                .await
+        };
+        factorized
             .and_then(|factorized| self.apply_factory_metadata(factorized))
             .and_then(|factorized| self.apply_module_rules(factorized))
     }
@@ -301,7 +319,7 @@ impl NormalModuleFactory {
             .await?;
         let identity = ModuleIdentity::from(resolved.resource);
         let resource = identity.resource.clone();
-        if !self.cache.is_enabled() {
+        if !self.resolve_cache || !self.cache.is_enabled() {
             return Ok(FactorizedModule {
                 identity,
                 resource,
@@ -616,6 +634,37 @@ mod tests {
         assert_eq!(cache.stats().resolve_entries, 0);
         assert_eq!(factory.runtime_factorize_cache.len(), 1);
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn disabled_resolve_cache_does_not_retain_completed_factorization()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let temp = tempdir()?;
+        fs::write(temp.path().join("dep.js"), "export const value = 1;")?;
+
+        let mut resolve_options = ResolveOptions::default();
+        resolve_options.extensions = vec![".js".to_string()];
+        let cache = Cache::new(CacheOptions::memory(), crate::SnapshotOptions::default());
+        let factory = NormalModuleFactory::new(
+            UnpackResolver::new(resolve_options),
+            cache.normal_module_factory(),
+            FileSystemInfo::new(),
+            SnapshotStrategy::timestamp(),
+            SnapshotCache::default(),
+            crate::compiler::test_compilation_hooks().normal_module_factory_hooks,
+        )
+        .with_resolve_cache(false);
+        let dependency = Dependency::HarmonyImportSideEffect(
+            HarmonyImportSideEffectDependency::new("./dep", 0, None),
+        );
+
+        let first = factory.factorize(temp.path(), &dependency).await?;
+        let second = factory.factorize(temp.path(), &dependency).await?;
+
+        assert_eq!(first, second);
+        assert!(factory.runtime_factorize_cache.is_empty());
+        assert_eq!(cache.stats().resolve_entries, 0);
         Ok(())
     }
 }

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -63,6 +63,8 @@ pub struct NativeCompilerOptions {
     #[napi(js_name = "outputPath")]
     pub output_path: String,
     pub cache: NativeCacheOptions,
+    #[napi(js_name = "resolveCache")]
+    pub resolve_cache: bool,
     pub snapshot: NativeSnapshotOptions,
     #[napi(js_name = "infrastructureLogging")]
     pub infrastructure_logging: NativeInfrastructureLoggingOptions,
@@ -957,6 +959,7 @@ impl NativeCompiler {
             .collect::<Vec<_>>();
         let mut compiler_options = CompilerOptions::new(context, entries);
         compiler_options.cache = cache_options_from_native(options.cache)?;
+        compiler_options.resolve_cache = options.resolve_cache;
         compiler_options.snapshot = snapshot_options_from_native(options.snapshot)?;
         compiler_options.infrastructure_logging =
             infrastructure_logging_options_from_native(options.infrastructure_logging);

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -110,6 +110,15 @@ Ordinary runs, Persistent Cache restore, later Compiler processes, manual
 invalidations, and rebuilds without a usable Watch Change Set retain Snapshot
 validation.
 
+The implemented `resolve.cache` boolean follows webpack's Resolver Cache
+responsibility: it controls successful Resolve Record lookup, storage, and
+Snapshot revalidation, while leaving resolver-internal filesystem and package
+metadata memoization intact. Its default follows whether the top-level Cache is
+enabled, matching webpack's resolve defaults. Other webpack Resolve Options
+remain unsupported and are rejected by JavaScript option validation. Because
+Unpack does not accept configured no-op options, explicit `resolve.cache: true`
+is rejected when the top-level Cache is disabled.
+
 The Unpack-only `experiments.serialRebuildMake` diagnostic option controls
 whether rebuild Factorize and Build futures are polled directly by Make or
 wrapped in Tokio tasks. It defaults to `true`, affects rebuild scheduling only,

--- a/packages/unpack/src/config/normalization.ts
+++ b/packages/unpack/src/config/normalization.ts
@@ -17,12 +17,17 @@ export interface UnpackOptions {
   };
   sourcemap?: boolean;
   cache?: CacheOptions;
+  resolve?: ResolveOptions;
   snapshot?: SnapshotOptions;
   infrastructureLogging?: InfrastructureLoggingOptions;
   module?: ModuleOptions;
   optimization?: OptimizationOptions;
   experiments?: ExperimentsOptions;
   plugins?: WebpackPlugin[];
+}
+
+export interface ResolveOptions {
+  cache?: boolean;
 }
 
 export interface ExperimentsOptions {
@@ -138,6 +143,7 @@ export interface NormalizedOptions {
   providedExports: boolean;
   usedExports: boolean;
   sideEffects: "disabled" | "flag" | "analyze";
+  resolveCache: boolean;
   serialRebuildMake: boolean;
   unsafeWatchCacheInvalidation: boolean;
 }
@@ -222,7 +228,7 @@ export function normalizeOptions(options: UnpackOptions): NormalizedOptions {
   assertKnownKeys(
     options,
     [
-      "context", "name", "mode", "entry", "output", "sourcemap", "cache",
+      "context", "name", "mode", "entry", "output", "sourcemap", "cache", "resolve",
       "snapshot", "infrastructureLogging", "module", "optimization",
       "experiments", "plugins"
     ],
@@ -255,28 +261,55 @@ export function normalizeOptions(options: UnpackOptions): NormalizedOptions {
   if (moduleRules.some((rule) => rule.loader !== undefined) && sourcemap) {
     throw new TypeError("options.sourcemap must be false when options.module.rules is configured");
   }
+  const normalizedCache = normalizeCacheOptions(
+    options.cache,
+    normalizedContext,
+    mode,
+    name,
+    cacheUnaffectedExperiment,
+    experiments.unsafeWatchCacheInvalidation
+  );
   return {
     context: normalizedContext,
     entries: normalizeEntry(options.entry),
     outputPath,
     sourcemap,
-    cache: normalizeCacheOptions(
-      options.cache,
-      normalizedContext,
-      mode,
-      name,
-      cacheUnaffectedExperiment,
-      experiments.unsafeWatchCacheInvalidation
-    ),
+    cache: normalizedCache,
     snapshot: normalizeSnapshotOptions(options.snapshot, mode),
     infrastructureLogging: normalizeInfrastructureLoggingOptions(options.infrastructureLogging),
     moduleRules,
     providedExports: optimization.providedExports,
     usedExports: optimization.usedExports,
     sideEffects: optimization.sideEffects,
+    resolveCache: normalizeResolveOptions(
+      options.resolve,
+      normalizedCache.type !== "disabled"
+    ),
     serialRebuildMake: experiments.serialRebuildMake,
     unsafeWatchCacheInvalidation: experiments.unsafeWatchCacheInvalidation
   };
+}
+
+export function normalizeResolveOptions(
+  resolveOptions: ResolveOptions | undefined,
+  cacheEnabled: boolean
+): boolean {
+  if (resolveOptions === undefined) {
+    return cacheEnabled;
+  }
+  assertPlainObject(resolveOptions, "options.resolve");
+  assertKnownKeys(resolveOptions, ["cache"], "options.resolve");
+  if (resolveOptions.cache === undefined) {
+    return cacheEnabled;
+  }
+  const resolveCache = assertBoolean(
+    resolveOptions.cache,
+    "options.resolve.cache"
+  );
+  if (resolveCache && !cacheEnabled) {
+    throw new TypeError("options.resolve.cache requires an enabled cache");
+  }
+  return resolveCache;
 }
 
 export function normalizeExperimentsOptions(

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -18,6 +18,7 @@ export type {
   ModuleRule,
   ModuleRuleType,
   OptimizationOptions,
+  ResolveOptions,
   SnapshotOptions,
   SnapshotPathPattern,
   SnapshotStrategyOptions,

--- a/packages/unpack/test/persistent-cache-contract.test.ts
+++ b/packages/unpack/test/persistent-cache-contract.test.ts
@@ -114,6 +114,37 @@ test("cache objects require a type, enforce the unaffected experiment gate, and 
   );
   assert.doesNotThrow(createCompiler({ type: "memory" }));
   assert.doesNotThrow(() =>
+    unpack({ entry: "./src/index.js", cache: true, resolve: { cache: true } })
+  );
+  assert.doesNotThrow(() =>
+    unpack({ entry: "./src/index.js", resolve: { cache: false } })
+  );
+  assert.throws(
+    () =>
+      unpack({
+        entry: "./src/index.js",
+        cache: false,
+        resolve: { cache: true }
+      }),
+    /options\.resolve\.cache requires an enabled cache/
+  );
+  assert.throws(
+    () =>
+      unpack({
+        entry: "./src/index.js",
+        resolve: { cache: "yes" as unknown as boolean }
+      }),
+    /options\.resolve\.cache must be a boolean/
+  );
+  assert.throws(
+    () =>
+      unpack({
+        entry: "./src/index.js",
+        resolve: { unknown: true } as never
+      }),
+    /options\.resolve contains unknown option 'unknown'/
+  );
+  assert.doesNotThrow(() =>
     unpack({
       entry: "./src/index.js",
       mode: "development",


### PR DESCRIPTION
## Summary

- add webpack-aligned `resolve.cache` option normalization and validation
- bypass resolver result storage and reuse when the option is disabled
- document the Resolve Cache boundary and cover enabled and disabled behavior

## Why

Resolver result caching was previously coupled to the top-level cache setting and could not be controlled through webpack’s `resolve.cache` surface. Exposing the option makes the behavior explicit while preserving the existing mode-aware default.

## Impact

`resolve.cache: false` now disables successful resolver result reuse without disabling the other compiler caches. Omitting the option continues to follow the normalized top-level cache setting.