### PR TITLE
Remove Make parallelism configuration

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -149,7 +149,7 @@ The webpack-shaped cache of successful resolver results, controlled by `resolve.
 _Avoid_: Resolver filesystem cache, unsafe resolver cache
 
 **Serial Rebuild Make**:
-The default Make scheduling mode for rebuilds, in which Factorize and Build futures are polled directly by the Make queue instead of being wrapped in Tokio tasks. It changes scheduling only; the Make task model remains intact, and an explicitly configured finite parallelism limit still applies.
+The default Make scheduling mode for rebuilds, in which Factorize and Build futures are polled directly by the Make queue instead of being wrapped in Tokio tasks. It changes scheduling only; the Make task model remains intact.
 _Avoid_: Single-threaded rebuild, disabled concurrency
 
 **Code Generation Phase**:

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -57,7 +57,6 @@ pub struct CompilerOptions {
     pub module_rules: Vec<ModuleRule>,
     pub loader_runner: Option<Arc<dyn LoaderRunner>>,
     pub compilation_hooks: Option<Arc<dyn CompilationHooks>>,
-    pub parallelism: Option<usize>,
     pub sourcemap: bool,
     pub provided_exports: bool,
     pub used_exports: bool,
@@ -79,7 +78,6 @@ impl CompilerOptions {
             module_rules: Vec::new(),
             loader_runner: None,
             compilation_hooks: None,
-            parallelism: None,
             sourcemap: true,
             provided_exports: true,
             used_exports: true,
@@ -892,9 +890,8 @@ mod tests {
     }
 
     #[test]
-    fn make_defaults_to_unbounded_parallelism_and_serial_rebuild_scheduling() {
+    fn make_defaults_to_serial_rebuild_scheduling() {
         let options = CompilerOptions::new(".", Vec::new());
-        assert_eq!(options.parallelism, None);
         assert!(options.serial_rebuild_make);
     }
 

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use futures::{FutureExt, StreamExt, future::BoxFuture, stream::FuturesUnordered};
-use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
+use tokio::sync::Mutex;
 
 use crate::{
     AsyncDependenciesBlockIndex, CompilerOptions, Dependency, DependencyIndex, EntryDependency,
@@ -47,7 +47,6 @@ struct MakeServices {
     snapshot_cache: SnapshotCache,
     loader_runner: Option<Arc<dyn LoaderRunner>>,
     metrics: Arc<MakeMetrics>,
-    semaphore: Option<Arc<Semaphore>>,
     module_types: ModuleTypeRegistry,
     unsafe_watch_cache: Option<crate::unsafe_watch_cache::UnsafeWatchCache>,
     watch_change_set: Option<crate::WatchChangeSet>,
@@ -238,9 +237,6 @@ pub(crate) async fn run(
         snapshot_cache,
         loader_runner: options.loader_runner.clone(),
         metrics: Arc::new(MakeMetrics::new()),
-        semaphore: options
-            .parallelism
-            .map(|parallelism| Arc::new(Semaphore::new(parallelism.max(1)))),
         module_types,
         unsafe_watch_cache,
         watch_change_set: make_options.watch_change_set.clone(),
@@ -364,17 +360,6 @@ async fn next_background_make_task(
         .expect("background queue should not be empty")
 }
 
-async fn acquire_make_permit(semaphore: &Option<Arc<Semaphore>>) -> Option<OwnedSemaphorePermit> {
-    let semaphore = semaphore.as_ref()?;
-    Some(
-        semaphore
-            .clone()
-            .acquire_owned()
-            .await
-            .expect("make semaphore should stay open"),
-    )
-}
-
 impl MakeTask {
     fn is_background(&self) -> bool {
         matches!(self, Self::Factorize(_) | Self::Build(_))
@@ -407,8 +392,6 @@ impl MakeTask {
 
 impl FactorizeTask {
     async fn run(self, services: MakeServices) -> Result<Vec<MakeTask>> {
-        let _permit = acquire_make_permit(&services.semaphore).await;
-
         let dependency = self
             .dependencies
             .first()
@@ -496,8 +479,6 @@ impl BuildTask {
         services: MakeServices,
         state: Arc<Mutex<MakeState>>,
     ) -> Result<Vec<MakeTask>> {
-        let _permit = acquire_make_permit(&services.semaphore).await;
-
         let issuer_context = self
             .resource
             .parent()
@@ -943,19 +924,6 @@ mod tests {
 
     use super::*;
     use crate::{Entry, UnpackResolver};
-
-    #[tokio::test]
-    async fn make_permits_are_optional_and_enforce_finite_parallelism() {
-        assert!(acquire_make_permit(&None).await.is_none());
-
-        let semaphore = Arc::new(Semaphore::new(1));
-        let permit = acquire_make_permit(&Some(Arc::clone(&semaphore)))
-            .await
-            .expect("finite parallelism should acquire a permit");
-        assert!(semaphore.try_acquire().is_err());
-        drop(permit);
-        assert!(semaphore.try_acquire().is_ok());
-    }
 
     #[tokio::test]
     async fn process_dependencies_groups_factorization_by_resource_identifier()

--- a/docs/adr/0143-configure-serial-rebuild-make-scheduling.md
+++ b/docs/adr/0143-configure-serial-rebuild-make-scheduling.md
@@ -2,6 +2,6 @@
 
 Unpack will directly poll rebuild Factorize and Build futures in the Make Phase `FuturesUnordered` queue by default instead of wrapping each future in `tokio::spawn`. The `experiments.serialRebuildMake` option controls this scheduling choice: its default is `true`, while an explicit `false` restores Tokio task spawning for rebuilds. Initial compilations continue to use Tokio tasks in either mode.
 
-Make parallelism is unbounded by default, so the default Make queue does not acquire semaphore permits. Rust callers may configure a finite parallelism value, in which case a semaphore enforces that limit for Factorize and Build work in both scheduling modes.
+Make parallelism is unbounded. The former finite parallelism configuration described here was removed by ADR 0144.
 
 This is a scheduling performance experiment, not a different compilation model. Factorize, Add, Build, and Process Dependencies responsibilities, task ordering constraints, errors, and observable JavaScript lifecycle behavior remain unchanged. The name describes direct in-queue rebuild scheduling and does not imply single-threaded execution.

--- a/docs/adr/0144-remove-make-parallelism-configuration.md
+++ b/docs/adr/0144-remove-make-parallelism-configuration.md
@@ -1,0 +1,5 @@
+# Remove Make parallelism configuration
+
+Unpack will not expose a finite Make parallelism setting through Rust `CompilerOptions`. Factorize and Build work remains unbounded in both Make scheduling modes.
+
+The setting was an Unpack-specific compiler surface with no JavaScript API counterpart and no equivalent public webpack option. Removing it also removes the Make semaphore and its per-task permit acquisition. This supersedes the finite parallelism portion of ADR 0143; the serial rebuild scheduling decision remains unchanged.

--- a/docs/implementation/webpack-architecture-deviation-register.md
+++ b/docs/implementation/webpack-architecture-deviation-register.md
@@ -120,9 +120,8 @@ documented deviations or staged webpack scope.
 - **Approved shape**: ADR 0143 makes direct polling of rebuild Factorize and
   Build futures in Make's `FuturesUnordered` queue the default and permits an
   explicit `experiments.serialRebuildMake: false` to restore Tokio spawning.
-  Initial compilations retain Tokio task spawning. Make parallelism is unbounded
-  by default; an explicitly configured finite limit uses a semaphore in both
-  scheduling modes.
+  Initial compilations retain Tokio task spawning. Make parallelism is unbounded;
+  ADR 0144 removes the former Rust-only finite parallelism setting.
 - **Disable or refactor when**: direct polling changes Make phase ordering,
   error delivery, lifecycle behavior, or task responsibilities; the experiment
   must remain configurable unless measurements and a later decision remove one
@@ -178,7 +177,7 @@ The initial audit explicitly reviewed the following performance-relevant
 techniques. They do not require separate confirmation while their listed
 webpack responsibility remains intact:
 
-- `FuturesUnordered`, Tokio tasks, a semaphore, sharded maps, and atomics in
+- `FuturesUnordered`, Tokio tasks, sharded maps, and atomics in
   Make and Cache preserve factorize, add, build, process-dependencies, Cache,
   and Cache Facade responsibilities.
 - dense `ModuleHandle` storage, `IndexVec`, and `ModuleMask` preserve separate

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -122,9 +122,8 @@ is rejected when the top-level Cache is disabled.
 The Unpack-only `experiments.serialRebuildMake` diagnostic option controls
 whether rebuild Factorize and Build futures are polled directly by Make or
 wrapped in Tokio tasks. It defaults to `true`, affects rebuild scheduling only,
-and preserves the Make task responsibilities and any explicitly configured
-finite parallelism limit described in ADR 0143. Make parallelism itself is
-unbounded by default.
+and preserves the Make task responsibilities described in ADR 0143. Make
+parallelism is unbounded, as recorded in ADR 0144.
 
 This layout change covers the cache-category alignment tracked by issue #217.
 The first serialization-layout slice moves generic Serializer identity,
@@ -162,7 +161,7 @@ Necessity:
 
 ## Make phase and errors
 
-Unpack uses `FuturesUnordered` to factorize, read, parse, and connect modules. Make parallelism is unbounded by default; Rust callers may configure a finite limit enforced by a semaphore. Module-attributable make errors are recorded in `Compilation::errors`; infrastructure failures still return `Err` and stop the run.
+Unpack uses `FuturesUnordered` to factorize, read, parse, and connect modules. Make parallelism is unbounded. Module-attributable make errors are recorded in `Compilation::errors`; infrastructure failures still return `Err` and stop the run.
 
 Webpack uses separate async queues for factorize, add, build, rebuild, and
 process-dependencies. Unpack uses Rust-native tasks but now follows the same


### PR DESCRIPTION
## Summary

- remove the Rust-only `CompilerOptions.parallelism` setting
- remove Make semaphore construction and per-task permit acquisition
- update the domain and implementation documentation to describe unbounded Make parallelism
- add ADR 0144 to supersede the finite-parallelism portion of ADR 0143

This removes an Unpack-specific compiler surface that had no JavaScript API counterpart or equivalent public webpack option. Factorize and Build work now remains unbounded in both Make scheduling modes.
