### PR TITLE
Use FxHashMap and FxHashSet throughout Rust code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,8 @@ jobs:
       - name: Install JavaScript dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Reject standard hash collections
+        run: cargo clippy --workspace --all-targets -- -D clippy::disallowed-types
+
       - name: Run tests
         run: pnpm test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,6 +1411,7 @@ dependencies = [
  "regex",
  "rspack_resolver",
  "rspack_sources",
+ "rustc-hash",
  "serde",
  "serde_json",
  "simd-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ napi-derive = "3.5.7"
 regex = "1.12.2"
 rspack_resolver = { version = "0.9.3", default-features = false }
 rspack_sources = "0.101.1"
+rustc-hash = "2.1.2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 simd-json = "0.17.0"
@@ -33,3 +34,6 @@ thiserror = "2.0.17"
 tokio = { version = "1.48.0", features = ["fs", "macros", "rt", "rt-multi-thread", "sync", "time"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt"] }
+
+[workspace.lints.clippy]
+disallowed_types = "deny"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-types = [
+  { path = "std::collections::HashMap", reason = "use rustc_hash::FxHashMap" },
+  { path = "std::collections::HashSet", reason = "use rustc_hash::FxHashSet" },
+]

--- a/crates/unpack_core/Cargo.toml
+++ b/crates/unpack_core/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 brotli = { workspace = true }
 dashmap = { workspace = true }
@@ -14,6 +17,7 @@ mime_guess = { workspace = true }
 regex = { workspace = true }
 rspack_resolver = { workspace = true }
 rspack_sources = { workspace = true }
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 simd-json = { workspace = true }

--- a/crates/unpack_core/src/build_chunk_graph.rs
+++ b/crates/unpack_core/src/build_chunk_graph.rs
@@ -1,9 +1,6 @@
 // Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/buildChunkGraph.js
 
-use std::{
-    cmp::Ordering,
-    collections::{HashMap, VecDeque},
-};
+use std::{cmp::Ordering, collections::VecDeque};
 
 use crate::{
     AsyncDependenciesBlockIndex, CompilerOptions, ModuleGraph, ModuleHandle,
@@ -11,11 +8,12 @@ use crate::{
     chunk_group::{AsyncBlockOrigin, ChunkGroupHandle, ChunkGroupKind},
     module_computation_cache::ModuleComputationCache,
 };
+use rustc_hash::FxHashMap;
 
 const MODULES_PER_MASK_WORD: usize = u64::BITS as usize;
 
 // ModuleHandle values are dense arena handles, so webpack's available-module mask
-// maps directly to compact word-indexed storage without an ordinal HashMap.
+// maps directly to compact word-indexed storage without an ordinal FxHashMap.
 #[derive(Clone, PartialEq, Eq)]
 struct ModuleMask {
     words: Box<[u64]>,
@@ -92,7 +90,7 @@ struct AsyncChunkPlan {
     static_modules: Vec<ModuleHandle>,
     min_available_modules: ModuleMask,
     resulting_available_modules: ModuleMask,
-    parents: HashMap<LogicalChunkGroup, AsyncParentPlan>,
+    parents: FxHashMap<LogicalChunkGroup, AsyncParentPlan>,
 }
 
 impl AsyncChunkPlan {
@@ -113,7 +111,7 @@ impl AsyncChunkPlan {
             static_modules,
             min_available_modules,
             resulting_available_modules,
-            parents: HashMap::from([(
+            parents: FxHashMap::from_iter([(
                 parent,
                 AsyncParentPlan {
                     resulting_available_modules: parent_resulting_available_modules.clone(),
@@ -214,7 +212,7 @@ pub(crate) fn build_chunk_graph_with_cache(
     // The implemented staging model reuses one Async Chunk plan per target Module.
     // This is intentionally narrower than webpack's AsyncDependenciesBlock-first
     // ChunkGroupInfo model and is recorded in the implementation differences.
-    let mut async_chunk_plans = HashMap::<ModuleHandle, AsyncChunkPlan>::new();
+    let mut async_chunk_plans = FxHashMap::<ModuleHandle, AsyncChunkPlan>::default();
     let mut pending = (0..entrypoint_plans.len())
         .map(LogicalChunkGroup::Entrypoint)
         .collect::<VecDeque<_>>();
@@ -269,7 +267,7 @@ pub(crate) fn build_chunk_graph_with_cache(
     let mut ordered_targets = async_chunk_plans.keys().copied().collect::<Vec<_>>();
     ordered_targets.sort_by(|left, right| compare_module_identities(module_graph, *left, *right));
 
-    let mut chunk_groups_by_target = HashMap::new();
+    let mut chunk_groups_by_target = FxHashMap::default();
     for target in &ordered_targets {
         let plan = &async_chunk_plans[target];
         let origin = plan

--- a/crates/unpack_core/src/cache/memory_cache_plugin.rs
+++ b/crates/unpack_core/src/cache/memory_cache_plugin.rs
@@ -2,7 +2,7 @@
 
 //! Webpack-aligned in-process Memory Cache Plugin.
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 #[cfg(test)]
 use super::CacheItemFamily;
@@ -11,7 +11,7 @@ use crate::cache_facade::{CacheAddress, CacheETag};
 
 #[derive(Debug, Default)]
 pub(super) struct MemoryCacheLayer {
-    entries: HashMap<CacheAddress, CacheEntry>,
+    entries: FxHashMap<CacheAddress, CacheEntry>,
 }
 
 impl MemoryCacheLayer {

--- a/crates/unpack_core/src/cache/memory_with_gc_cache_plugin.rs
+++ b/crates/unpack_core/src/cache/memory_with_gc_cache_plugin.rs
@@ -2,7 +2,7 @@
 
 //! Webpack-aligned Memory Cache Plugin with generation-based garbage collection.
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use super::{
     CacheItemFamily,
@@ -18,7 +18,7 @@ struct MemoryCacheEntry {
 
 #[derive(Debug)]
 pub(super) struct MemoryWithGcCacheLayer {
-    entries: HashMap<CacheAddress, MemoryCacheEntry>,
+    entries: FxHashMap<CacheAddress, MemoryCacheEntry>,
     max_unused_generations: u64,
     completed_generation: u64,
 }
@@ -26,7 +26,7 @@ pub(super) struct MemoryWithGcCacheLayer {
 impl MemoryWithGcCacheLayer {
     pub(super) fn new(max_unused_generations: u64) -> Self {
         Self {
-            entries: HashMap::new(),
+            entries: FxHashMap::default(),
             max_unused_generations,
             completed_generation: 0,
         }

--- a/crates/unpack_core/src/cache/pack_file.rs
+++ b/crates/unpack_core/src/cache/pack_file.rs
@@ -1883,7 +1883,7 @@ mod tests {
 // boundary exists so the storage contract can be exercised before the backend cutover.
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet},
     fs,
     io::{self, Read, Seek, SeekFrom, Write},
     path::{Component, Path, PathBuf},
@@ -1894,6 +1894,7 @@ use std::{
 use brotli::{CompressorWriter, Decompressor};
 use flate2::{Compression as GzipLevel, read::GzDecoder, write::GzEncoder};
 use rspack_sources::ReplacementEnforce;
+use rustc_hash::FxHashMap;
 
 use crate::{
     AsyncDependenciesBlock, ConstDependency, DependenciesBlock, Dependency, EntryDependency,
@@ -4315,7 +4316,7 @@ pub(crate) struct PackFile {
     index: PackFileIndex,
     access_updates: BTreeMap<PackFileAddress, AccessStamp>,
     allow_collecting_memory: bool,
-    content_buffers: HashMap<PathBuf, RetainedContentPack>,
+    content_buffers: FxHashMap<PathBuf, RetainedContentPack>,
     #[cfg(test)]
     reads: PackFileReadStats,
 }
@@ -4382,7 +4383,7 @@ impl PackFile {
             index,
             access_updates: BTreeMap::new(),
             allow_collecting_memory: options.allow_collecting_memory,
-            content_buffers: HashMap::new(),
+            content_buffers: FxHashMap::default(),
             #[cfg(test)]
             reads: PackFileReadStats {
                 index_reads: usize::from(index_path.exists()),

--- a/crates/unpack_core/src/cache/pack_file_cache_strategy.rs
+++ b/crates/unpack_core/src/cache/pack_file_cache_strategy.rs
@@ -3,7 +3,7 @@
 //! Webpack-aligned Pack File Cache Strategy, including restore, publication, and writer diagnostics.
 
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::BTreeSet,
     fs, io,
     path::{Path, PathBuf},
     sync::{
@@ -27,6 +27,7 @@ use crate::{
     serialization::Serializer,
     snapshot::{FileSystemInfo, Snapshot},
 };
+use rustc_hash::FxHashMap;
 
 #[cfg(test)]
 use super::RestoreBarrier;
@@ -173,7 +174,7 @@ pub(super) struct PackFileCacheLayer {
     open_options: PackFileOpenOptions,
     publication_base: PublicationBase,
     active: bool,
-    pending: HashMap<CacheAddress, CacheEntry>,
+    pending: FxHashMap<CacheAddress, CacheEntry>,
     diagnostics: Arc<CacheDiagnostics>,
     _writer_marker: Option<CacheWriterMarker>,
     #[cfg(test)]
@@ -339,7 +340,7 @@ impl PackFileCacheLayer {
             // work starts.  Standalone cache users have no such guard, and may safely
             // restore the legacy empty-guard PackFile directly.
             active: true,
-            pending: HashMap::new(),
+            pending: FxHashMap::default(),
             diagnostics,
             _writer_marker: writer_marker,
             #[cfg(test)]

--- a/crates/unpack_core/src/chunk_graph.rs
+++ b/crates/unpack_core/src/chunk_graph.rs
@@ -1,6 +1,6 @@
 // Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/ChunkGraph.js
 
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     ModuleGraph, ModuleHandle,
@@ -39,12 +39,12 @@ pub struct ChunkGraph {
     module_chunks: Vec<Vec<ChunkHandle>>,
     module_render_ids: Vec<Option<RenderId>>,
     module_hashes: Vec<Option<ModuleHash>>,
-    block_chunk_groups: HashMap<AsyncBlockOrigin, ChunkGroupHandle>,
+    block_chunk_groups: FxHashMap<AsyncBlockOrigin, ChunkGroupHandle>,
     // Includes logical loading edges omitted from the materialized graph to break cycles.
     runtime_chunk_group_children: Vec<Vec<ChunkGroupHandle>>,
     module_runtime_requirements: Vec<RuntimeRequirements>,
     chunk_runtime_requirements: Vec<RuntimeRequirements>,
-    runtime_tree_requirements: HashMap<ChunkGroupHandle, RuntimeRequirements>,
+    runtime_tree_requirements: FxHashMap<ChunkGroupHandle, RuntimeRequirements>,
     chunk_runtime_modules: Vec<Vec<RuntimeModule>>,
 }
 
@@ -308,7 +308,7 @@ impl ChunkGraph {
         self.runtime_tree_requirements.clear();
         for entrypoint in self.entrypoints.iter().copied() {
             let mut requirements = RuntimeRequirements::default();
-            let mut visited = HashSet::new();
+            let mut visited = FxHashSet::default();
             let mut pending = vec![entrypoint];
             while let Some(group_handle) = pending.pop() {
                 if !visited.insert(group_handle) {

--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -1,11 +1,9 @@
 // Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/CodeGenerationResults.js
 
-use std::{
-    collections::HashMap,
-    hash::{Hash, Hasher},
-};
+use std::hash::{Hash, Hasher};
 
 use rspack_sources::{ConcatSource, RawStringSource, SourceMap};
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -39,8 +37,8 @@ impl Asset {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct CodeGenerationResults {
-    module_render_ids: HashMap<ModuleHandle, RenderId>,
-    results: HashMap<ModuleHandle, CodeGenerationResult>,
+    module_render_ids: FxHashMap<ModuleHandle, RenderId>,
+    results: FxHashMap<ModuleHandle, CodeGenerationResult>,
 }
 
 pub(crate) struct CodeGenerationOutcome {
@@ -284,8 +282,8 @@ fn generate_code_with(
                 .clone();
             (module.handle(), render_id)
         })
-        .collect::<HashMap<_, _>>();
-    let mut results = HashMap::new();
+        .collect::<FxHashMap<_, _>>();
+    let mut results = FxHashMap::default();
     let mut errors = Vec::new();
     for module in module_graph
         .modules()
@@ -623,9 +621,10 @@ fn render_failed_module_content(error: &Error) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, fs};
+    use std::fs;
 
     use rspack_sources::{ConcatSource, OriginalSource, ReplacementEnforce, Source};
+    use rustc_hash::FxHashMap;
 
     use crate::{
         CacheOptions, Compiler, CompilerOptions, ConstDependency, Dependency, Entry, Error,
@@ -859,7 +858,7 @@ mod tests {
             crate::build_chunk_graph::build_chunk_graph(&options, &module_graph, &[module]);
         assign_module_render_ids(&options, &module_graph, &mut chunk_graph);
         assign_chunk_render_ids(&options, &module_graph, &mut chunk_graph);
-        let module_render_ids = HashMap::from([(
+        let module_render_ids = FxHashMap::from_iter([(
             module,
             chunk_graph
                 .module_render_id(module)

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -864,7 +864,7 @@ fn normalize_context(context: PathBuf) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use rustc_hash::FxHashSet;
     use std::{
         collections::BTreeMap,
         fs,
@@ -1063,7 +1063,7 @@ mod tests {
                 CacheIdleReason::Ordinary,
                 true,
                 Some(crate::WatchChangeSet {
-                    modified_files: HashSet::from([std::fs::canonicalize(changed_path)?]),
+                    modified_files: FxHashSet::from_iter([std::fs::canonicalize(changed_path)?]),
                     ..Default::default()
                 }),
             )

--- a/crates/unpack_core/src/dependency_template.rs
+++ b/crates/unpack_core/src/dependency_template.rs
@@ -1,6 +1,6 @@
 // Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/DependencyTemplate.js
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use rspack_sources::ReplaceSource;
 
@@ -32,7 +32,7 @@ pub(crate) struct DependencyTemplateContext<'a> {
     pub(crate) module_graph: &'a ModuleGraph,
     pub(crate) chunk_graph: &'a ChunkGraph,
     pub(crate) exports_info: &'a ExportsInfo,
-    pub(crate) module_render_ids: &'a HashMap<ModuleHandle, RenderId>,
+    pub(crate) module_render_ids: &'a FxHashMap<ModuleHandle, RenderId>,
     pub(crate) runtime_requirements: &'a mut RuntimeRequirements,
     pub(crate) init_fragments: &'a mut Vec<InitFragment>,
 }

--- a/crates/unpack_core/src/flag_dependency_usage_plugin.rs
+++ b/crates/unpack_core/src/flag_dependency_usage_plugin.rs
@@ -1,11 +1,12 @@
 // Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/FlagDependencyUsagePlugin.js
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 
 use crate::{
     Compilation, Dependency, ModuleHandle, compilation::CompilationHookSet,
     compiler::CompilerHookSet,
 };
+use rustc_hash::FxHashMap;
 
 pub(crate) struct FlagDependencyUsagePlugin;
 
@@ -23,7 +24,7 @@ impl FlagDependencyUsagePlugin {
 }
 
 fn flag_dependency_usage(compilation: &mut Compilation) {
-    let mut used: HashMap<ModuleHandle, (bool, BTreeSet<String>)> = compilation
+    let mut used: FxHashMap<ModuleHandle, (bool, BTreeSet<String>)> = compilation
         .module_graph()
         .modules()
         .iter()

--- a/crates/unpack_core/src/id_assignment.rs
+++ b/crates/unpack_core/src/id_assignment.rs
@@ -1,12 +1,13 @@
 // Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/ids/IdHelpers.js
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::BTreeMap,
     fmt,
     path::{Path, PathBuf},
 };
 
 use crate::{ChunkGraph, CompilerOptions, ModuleGraph, cache_hash::stable_hash};
+use rustc_hash::FxHashSet;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum RenderId {
@@ -140,12 +141,12 @@ fn assign_named_ids<K>(candidates: Vec<NamedIdCandidate<K>>) -> Vec<(K, RenderId
 where
     K: Copy + Ord,
 {
-    assign_named_ids_with_reserved(candidates, HashSet::new())
+    assign_named_ids_with_reserved(candidates, FxHashSet::default())
 }
 
 fn assign_named_ids_with_reserved<K>(
     candidates: Vec<NamedIdCandidate<K>>,
-    mut used: HashSet<String>,
+    mut used: FxHashSet<String>,
 ) -> Vec<(K, RenderId)>
 where
     K: Copy + Ord,

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -1,7 +1,7 @@
 // Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/Compilation.js
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, VecDeque},
     path::{Path, PathBuf},
     sync::{
         Arc,
@@ -11,6 +11,7 @@ use std::{
 };
 
 use futures::{FutureExt, StreamExt, future::BoxFuture, stream::FuturesUnordered};
+use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
 
 use crate::{
@@ -30,10 +31,10 @@ pub(crate) struct MakeState {
     pub module_graph: ModuleGraph,
     pub entries: BTreeMap<usize, ModuleHandle>,
     pub errors: Vec<Error>,
-    pub file_dependencies: HashSet<PathBuf>,
-    pub context_dependencies: HashSet<PathBuf>,
-    pub missing_dependencies: HashSet<PathBuf>,
-    modules_by_identity: HashMap<ModuleIdentity, ModuleHandle>,
+    pub file_dependencies: FxHashSet<PathBuf>,
+    pub context_dependencies: FxHashSet<PathBuf>,
+    pub missing_dependencies: FxHashSet<PathBuf>,
+    modules_by_identity: FxHashMap<ModuleIdentity, ModuleHandle>,
 }
 
 #[derive(Clone)]

--- a/crates/unpack_core/src/module_computation_cache.rs
+++ b/crates/unpack_core/src/module_computation_cache.rs
@@ -5,7 +5,7 @@
 //! and live only as long as the Compiler.
 
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::VecDeque,
     sync::{Arc, Mutex},
 };
 
@@ -14,6 +14,7 @@ use crate::{
     chunk_graph::{ChunkGraphModuleReferences, ModuleHash},
     runtime::RuntimeRequirements,
 };
+use rustc_hash::{FxHashMap, FxHashSet};
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ModuleComputationCache {
@@ -22,8 +23,8 @@ pub(crate) struct ModuleComputationCache {
 
 #[derive(Debug, Default)]
 struct ModuleComputationCacheState {
-    modules: HashMap<ModuleIdentity, ModuleComputationEntry>,
-    current_handles: HashMap<ModuleIdentity, ModuleHandle>,
+    modules: FxHashMap<ModuleIdentity, ModuleComputationEntry>,
+    current_handles: FxHashMap<ModuleIdentity, ModuleHandle>,
     stats: ModuleComputationCacheStats,
 }
 
@@ -101,7 +102,7 @@ impl ModuleComputationCache {
         let current_identities = signatures
             .iter()
             .map(|(identity, _, _)| identity.clone())
-            .collect::<HashSet<_>>();
+            .collect::<FxHashSet<_>>();
         let mut state = self
             .state
             .lock()
@@ -123,7 +124,7 @@ impl ModuleComputationCache {
                     .is_some_and(|entry| entry.pre_chunk_graph.signature == *signature);
                 (!unchanged).then_some(*handle)
             })
-            .collect::<HashSet<_>>();
+            .collect::<FxHashSet<_>>();
         let mut queue = affected.iter().copied().collect::<VecDeque<_>>();
         while let Some(handle) = queue.pop_front() {
             for connection in module_graph.incoming_connections(handle) {

--- a/crates/unpack_core/src/module_graph.rs
+++ b/crates/unpack_core/src/module_graph.rs
@@ -1,6 +1,6 @@
 // Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/ModuleGraph.js
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use crate::index_vec::IndexVec;
 use crate::{
@@ -15,7 +15,7 @@ pub struct ModuleGraph {
     outgoing: IndexVec<ModuleHandle, Vec<ModuleGraphConnectionHandle>>,
     incoming: IndexVec<ModuleHandle, Vec<ModuleGraphConnectionHandle>>,
     outgoing_by_location:
-        IndexVec<ModuleHandle, HashMap<DependencyLocation, ModuleGraphConnectionHandle>>,
+        IndexVec<ModuleHandle, FxHashMap<DependencyLocation, ModuleGraphConnectionHandle>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -50,7 +50,7 @@ impl ModuleGraph {
         self.modules.push(Module::new(handle, identity));
         let outgoing_handle = self.outgoing.push(Vec::new());
         let incoming_handle = self.incoming.push(Vec::new());
-        let location_handle = self.outgoing_by_location.push(HashMap::new());
+        let location_handle = self.outgoing_by_location.push(FxHashMap::default());
         debug_assert_eq!(outgoing_handle, handle);
         debug_assert_eq!(incoming_handle, handle);
         debug_assert_eq!(location_handle, handle);

--- a/crates/unpack_core/src/normal_module_factory.rs
+++ b/crates/unpack_core/src/normal_module_factory.rs
@@ -1,12 +1,13 @@
 // Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/NormalModuleFactory.js
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
     sync::Arc,
 };
 
 use dashmap::DashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::OnceCell;
 
 use crate::{
@@ -53,7 +54,7 @@ pub(crate) struct ModuleGeneratorContext<'a> {
     pub module: &'a Module,
     pub module_graph: &'a ModuleGraph,
     pub chunk_graph: &'a crate::ChunkGraph,
-    pub module_render_ids: &'a HashMap<ModuleHandle, RenderId>,
+    pub module_render_ids: &'a FxHashMap<ModuleHandle, RenderId>,
 }
 
 #[derive(Clone, Default)]
@@ -428,9 +429,9 @@ impl NormalModuleFactory {
 pub struct FactorizedModule {
     pub identity: ModuleIdentity,
     pub resource: PathBuf,
-    pub file_dependencies: HashSet<PathBuf>,
-    pub context_dependencies: HashSet<PathBuf>,
-    pub missing_dependencies: HashSet<PathBuf>,
+    pub file_dependencies: FxHashSet<PathBuf>,
+    pub context_dependencies: FxHashSet<PathBuf>,
+    pub missing_dependencies: FxHashSet<PathBuf>,
     pub loader: Option<MatchedLoader>,
     pub side_effect_free: Option<bool>,
 }

--- a/crates/unpack_core/src/optimize/side_effects_flag_plugin.rs
+++ b/crates/unpack_core/src/optimize/side_effects_flag_plugin.rs
@@ -154,7 +154,7 @@ fn connection_rewrite(
                     Dependency::HarmonyImportSpecifier(dependency) => dependency.ids.first(),
                     _ => None,
                 })
-                .collect::<std::collections::HashSet<_>>();
+                .collect::<rustc_hash::FxHashSet<_>>();
             if imported_names.len() != 1 {
                 return None;
             }
@@ -177,7 +177,7 @@ fn resolve_reexport_target(
 ) -> Option<(ModuleHandle, String)> {
     let mut export_name = export_name.to_string();
     let mut moved = false;
-    let mut visited = std::collections::HashSet::new();
+    let mut visited = rustc_hash::FxHashSet::default();
     while visited.insert(module) && module_is_side_effect_free(module_graph, module) {
         let outgoing = module_graph
             .outgoing_connections(module)
@@ -271,7 +271,7 @@ fn module_is_side_effect_free(module_graph: &ModuleGraph, handle: ModuleHandle) 
     fn visit(
         module_graph: &ModuleGraph,
         handle: ModuleHandle,
-        visiting: &mut std::collections::HashSet<ModuleHandle>,
+        visiting: &mut rustc_hash::FxHashSet<ModuleHandle>,
     ) -> bool {
         let Some(module) = module_graph.module(handle) else {
             return false;
@@ -292,7 +292,7 @@ fn module_is_side_effect_free(module_graph: &ModuleGraph, handle: ModuleHandle) 
         dependencies_are_free
     }
 
-    visit(module_graph, handle, &mut std::collections::HashSet::new())
+    visit(module_graph, handle, &mut rustc_hash::FxHashSet::default())
 }
 
 fn glob_matches(module_name: &str, pattern: &str) -> bool {

--- a/crates/unpack_core/src/parser.rs
+++ b/crates/unpack_core/src/parser.rs
@@ -1,7 +1,6 @@
 // Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/javascript/JavascriptParser.js
 
 use std::{
-    collections::{HashMap, HashSet},
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
     sync::Arc,
@@ -14,6 +13,7 @@ use crate::{
     HarmonyImportSideEffectDependency, HarmonyImportSpecifierDependency, ImportDependency,
     ModuleType, Result, SourceRange,
 };
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use swc_experimental_allocator::Allocator;
 use swc_experimental_allocator::atom::Wtf8Atom;
@@ -274,7 +274,7 @@ pub(crate) fn source_is_side_effect_free(path: &Path, source: &str) -> bool {
 
 struct PureAnalysis<'comments, 'arena> {
     comments: &'comments Comments<'arena>,
-    pure_function_calls: HashSet<u32>,
+    pure_function_calls: FxHashSet<u32>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -793,8 +793,8 @@ fn span_end(span: swc_experimental_ecma_ast::Span) -> usize {
     span.end.saturating_sub(1) as usize
 }
 
-fn no_side_effects_functions(comments: &Comments<'_>, module: &Module<'_>) -> HashSet<String> {
-    let mut candidates = HashSet::new();
+fn no_side_effects_functions(comments: &Comments<'_>, module: &Module<'_>) -> FxHashSet<String> {
+    let mut candidates = FxHashSet::default();
     let mut comments_start = 0;
     for item in module.body.iter() {
         let statement_start = span_start(item.span());
@@ -843,7 +843,7 @@ fn no_side_effects_functions(comments: &Comments<'_>, module: &Module<'_>) -> Ha
 
     let mut nested_var_collector = AnnotatedTopLevelVarCollector {
         comments,
-        names: HashSet::new(),
+        names: FxHashSet::default(),
     };
     module.visit_with(&mut nested_var_collector);
     candidates.extend(nested_var_collector.names);
@@ -856,7 +856,7 @@ fn collect_no_side_effects_declaration(
     declaration: &Decl<'_>,
     comments_start: usize,
     statement_start: usize,
-    candidates: &mut HashSet<String>,
+    candidates: &mut FxHashSet<String>,
 ) {
     match declaration {
         Decl::Fn(function) => {
@@ -897,7 +897,7 @@ fn collect_no_side_effects_declaration(
 
 struct AnnotatedTopLevelVarCollector<'comments, 'arena> {
     comments: &'comments Comments<'arena>,
-    names: HashSet<String>,
+    names: FxHashSet<String>,
 }
 
 impl<'a> Visit<'a> for AnnotatedTopLevelVarCollector<'_, '_> {
@@ -971,25 +971,25 @@ fn compiler_hint_matches(comment: &str, hint: &str) -> bool {
 
 struct PureFunctionCallCollector<'comments, 'arena, 'functions> {
     comments: &'comments Comments<'arena>,
-    pure_functions: &'functions HashSet<String>,
-    scopes: Vec<HashMap<String, bool>>,
-    calls: HashSet<u32>,
+    pure_functions: &'functions FxHashSet<String>,
+    scopes: Vec<FxHashMap<String, bool>>,
+    calls: FxHashSet<u32>,
 }
 
 impl<'comments, 'arena, 'functions> PureFunctionCallCollector<'comments, 'arena, 'functions> {
     fn new(
         comments: &'comments Comments<'arena>,
-        pure_functions: &'functions HashSet<String>,
+        pure_functions: &'functions FxHashSet<String>,
     ) -> Self {
         Self {
             comments,
             pure_functions,
             scopes: Vec::new(),
-            calls: HashSet::new(),
+            calls: FxHashSet::default(),
         }
     }
 
-    fn push_scope(&mut self, bindings: HashMap<String, bool>) {
+    fn push_scope(&mut self, bindings: FxHashMap<String, bool>) {
         self.scopes.push(bindings);
     }
 
@@ -1024,7 +1024,7 @@ impl<'a> Visit<'a> for PureFunctionCallCollector<'_, '_, '_> {
     fn visit_arrow_expr(&mut self, _: &ArrowExpr<'a>) {}
 
     fn visit_class_expr(&mut self, node: &ClassExpr<'a>) {
-        let mut bindings = HashMap::new();
+        let mut bindings = FxHashMap::default();
         if let Some(identifier) = &node.ident {
             bindings.insert(ident_to_string(identifier), false);
         }
@@ -1041,7 +1041,7 @@ impl<'a> Visit<'a> for PureFunctionCallCollector<'_, '_, '_> {
                 span_start(node.span),
                 span_start(declaration.span),
             ),
-            _ => HashMap::new(),
+            _ => FxHashMap::default(),
         };
         self.push_scope(bindings);
         node.visit_children_with(self);
@@ -1057,7 +1057,7 @@ impl<'a> Visit<'a> for PureFunctionCallCollector<'_, '_, '_> {
     }
 
     fn visit_switch_stmt(&mut self, node: &swc_experimental_ecma_ast::SwitchStmt<'a>) {
-        let mut bindings = HashMap::new();
+        let mut bindings = FxHashMap::default();
         for case in node.cases.iter() {
             bindings.extend(direct_statement_bindings(
                 self.comments,
@@ -1087,7 +1087,7 @@ impl PureFunctionCallCollector<'_, '_, '_> {
         head: &swc_experimental_ecma_ast::ForHead<'a>,
         visit: impl FnOnce(&mut Self),
     ) {
-        let mut bindings = HashMap::new();
+        let mut bindings = FxHashMap::default();
         match head {
             swc_experimental_ecma_ast::ForHead::VarDecl(declaration) => {
                 bindings.extend(variable_scope_bindings(
@@ -1098,13 +1098,13 @@ impl PureFunctionCallCollector<'_, '_, '_> {
                 ));
             }
             swc_experimental_ecma_ast::ForHead::Pat(pattern) => {
-                let mut names = HashSet::new();
+                let mut names = FxHashSet::default();
                 add_pat_bindings(pattern, &mut names);
                 bindings.extend(names.into_iter().map(|name| (name, false)));
             }
             swc_experimental_ecma_ast::ForHead::UsingDecl(declaration) => {
                 for declarator in declaration.decls.iter() {
-                    let mut names = HashSet::new();
+                    let mut names = FxHashSet::default();
                     add_pat_bindings(&declarator.name, &mut names);
                     bindings.extend(names.into_iter().map(|name| (name, false)));
                 }
@@ -1120,8 +1120,8 @@ fn direct_statement_bindings<'a>(
     comments: &Comments<'_>,
     statements: impl Iterator<Item = &'a Stmt<'a>>,
     mut comments_start: usize,
-) -> HashMap<String, bool> {
-    let mut bindings = HashMap::new();
+) -> FxHashMap<String, bool> {
+    let mut bindings = FxHashMap::default();
     for statement in statements {
         if let Stmt::Decl(declaration) = statement {
             match &**declaration {
@@ -1149,7 +1149,7 @@ fn direct_statement_bindings<'a>(
                 }
                 Decl::Using(declaration) => {
                     for declarator in declaration.decls.iter() {
-                        let mut names = HashSet::new();
+                        let mut names = FxHashSet::default();
                         add_pat_bindings(&declarator.name, &mut names);
                         bindings.extend(names.into_iter().map(|name| (name, false)));
                     }
@@ -1166,13 +1166,13 @@ fn variable_scope_bindings(
     declaration: &swc_experimental_ecma_ast::VarDecl<'_>,
     comments_start: usize,
     statement_start: usize,
-) -> HashMap<String, bool> {
-    let mut bindings = HashMap::new();
+) -> FxHashMap<String, bool> {
+    let mut bindings = FxHashMap::default();
     if declaration.kind == VarDeclKind::Var {
         return bindings;
     }
     for declarator in declaration.decls.iter() {
-        let mut names = HashSet::new();
+        let mut names = FxHashSet::default();
         add_pat_bindings(&declarator.name, &mut names);
         bindings.extend(names.into_iter().map(|name| (name, false)));
 
@@ -1228,7 +1228,7 @@ fn parse_module_dependencies_sync(
         pure_analysis: pure_analysis.as_ref(),
     };
     hooks.program.call(&parser_context, &module, &mut parsed);
-    let mut import_bindings = HashMap::new();
+    let mut import_bindings = FxHashMap::default();
     collect_module_decl_dependencies(path, &module, &mut parsed, &mut import_bindings)?;
     collect_import_usages(
         &module,
@@ -1255,7 +1255,7 @@ fn collect_module_decl_dependencies(
     path: &Path,
     module: &Module<'_>,
     parsed: &mut ParsedModule,
-    import_bindings: &mut HashMap<String, ImportBinding>,
+    import_bindings: &mut FxHashMap<String, ImportBinding>,
 ) -> Result<()> {
     let mut source_order = 0;
 
@@ -1563,7 +1563,7 @@ impl<'a> Visit<'a> for DynamicImportVisitor<'_> {
 
 fn collect_import_usages(
     module: &Module<'_>,
-    import_bindings: &HashMap<String, ImportBinding>,
+    import_bindings: &FxHashMap<String, ImportBinding>,
     dependencies: &mut Vec<Dependency>,
 ) {
     if import_bindings.is_empty() {
@@ -1573,16 +1573,16 @@ fn collect_import_usages(
     let mut visitor = ImportUsageVisitor {
         imports: import_bindings,
         dependencies: Vec::new(),
-        scopes: vec![HashSet::new()],
+        scopes: vec![FxHashSet::default()],
     };
     module.visit_with(&mut visitor);
     dependencies.extend(visitor.dependencies);
 }
 
 struct ImportUsageVisitor<'imports> {
-    imports: &'imports HashMap<String, ImportBinding>,
+    imports: &'imports FxHashMap<String, ImportBinding>,
     dependencies: Vec<Dependency>,
-    scopes: Vec<HashSet<String>>,
+    scopes: Vec<FxHashSet<String>>,
 }
 
 impl ImportUsageVisitor<'_> {
@@ -1597,7 +1597,7 @@ impl ImportUsageVisitor<'_> {
     }
 
     fn push_scope(&mut self) {
-        self.scopes.push(HashSet::new());
+        self.scopes.push(FxHashSet::default());
     }
 
     fn pop_scope(&mut self) {
@@ -1757,7 +1757,7 @@ trait BindingCollector {
     fn collect_binding(&mut self, name: String);
 }
 
-impl BindingCollector for HashSet<String> {
+impl BindingCollector for FxHashSet<String> {
     fn collect_binding(&mut self, name: String) {
         self.insert(name);
     }

--- a/crates/unpack_core/src/resolver.rs
+++ b/crates/unpack_core/src/resolver.rs
@@ -1,12 +1,12 @@
 // Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/ResolverFactory.js
 
 use std::{
-    collections::HashSet,
     path::{Path, PathBuf},
     sync::Arc,
 };
 
 use crate::{Error, ModuleIdentity, Result};
+use rustc_hash::FxHashSet;
 
 pub use rspack_resolver::ResolveOptions;
 
@@ -44,13 +44,13 @@ impl UnpackResolver {
             .file_dependencies
             .into_iter()
             .map(|path| normalize_resolver_dependency(path.as_path()))
-            .collect::<HashSet<_>>();
+            .collect::<FxHashSet<_>>();
         let missing_dependencies = context
             .missing_dependencies
             .into_iter()
             .map(|path| normalize_resolver_dependency(path.as_path()))
-            .collect::<HashSet<_>>();
-        let context_dependencies = HashSet::new();
+            .collect::<FxHashSet<_>>();
+        let context_dependencies = FxHashSet::default();
 
         Ok(ResolveResult {
             resource: ResolvedResource {
@@ -68,9 +68,9 @@ impl UnpackResolver {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolveResult {
     pub resource: ResolvedResource,
-    pub file_dependencies: HashSet<PathBuf>,
-    pub context_dependencies: HashSet<PathBuf>,
-    pub missing_dependencies: HashSet<PathBuf>,
+    pub file_dependencies: FxHashSet<PathBuf>,
+    pub context_dependencies: FxHashSet<PathBuf>,
+    pub missing_dependencies: FxHashSet<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/unpack_core/src/serialization/serializer.rs
+++ b/crates/unpack_core/src/serialization/serializer.rs
@@ -1,6 +1,8 @@
 //! Rust-native implementation of webpack's reusable Serializer responsibility.
 
-use std::{any::Any, collections::HashMap, fmt, io, sync::Arc};
+use std::{any::Any, fmt, io, sync::Arc};
+
+use rustc_hash::FxHashMap;
 
 pub(crate) const MAX_SERIALIZED_ITEM_BYTES: usize = 16 * 1024 * 1024;
 
@@ -81,7 +83,7 @@ where
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct Serializer {
-    codecs: HashMap<StableTypeId, Arc<dyn ErasedItemCodec>>,
+    codecs: FxHashMap<StableTypeId, Arc<dyn ErasedItemCodec>>,
 }
 
 impl Serializer {

--- a/crates/unpack_core/src/unsafe_watch_cache.rs
+++ b/crates/unpack_core/src/unsafe_watch_cache.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
@@ -9,12 +8,13 @@ use crate::{
     cache::{ModuleBuildRecord, ResolveRecord, ResolveRequest},
     cache_facade::CacheETag,
 };
+use rustc_hash::{FxHashMap, FxHashSet};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct WatchChangeSet {
-    pub modified_files: HashSet<PathBuf>,
-    pub removed_files: HashSet<PathBuf>,
-    pub changed_contexts: HashSet<PathBuf>,
+    pub modified_files: FxHashSet<PathBuf>,
+    pub removed_files: FxHashSet<PathBuf>,
+    pub changed_contexts: FxHashSet<PathBuf>,
 }
 
 impl WatchChangeSet {
@@ -41,10 +41,10 @@ pub(crate) struct UnsafeWatchCache {
 
 #[derive(Debug, Default)]
 struct UnsafeWatchCacheInner {
-    resolves: HashMap<ResolveRequest, Arc<ResolveRecord>>,
-    previous_resolves: HashMap<ResolveRequest, Arc<ResolveRecord>>,
-    module_builds: HashMap<ModuleIdentity, UnsafeModuleBuildRecord>,
-    previous_module_builds: HashMap<ModuleIdentity, UnsafeModuleBuildRecord>,
+    resolves: FxHashMap<ResolveRequest, Arc<ResolveRecord>>,
+    previous_resolves: FxHashMap<ResolveRequest, Arc<ResolveRecord>>,
+    module_builds: FxHashMap<ModuleIdentity, UnsafeModuleBuildRecord>,
+    previous_module_builds: FxHashMap<ModuleIdentity, UnsafeModuleBuildRecord>,
 }
 
 #[derive(Debug)]

--- a/crates/unpack_core/tests/make.rs
+++ b/crates/unpack_core/tests/make.rs
@@ -1,9 +1,9 @@
 use std::{
-    collections::HashSet,
     fs,
     path::{Path, PathBuf},
 };
 
+use rustc_hash::FxHashSet;
 use unpack_core::{Compiler, CompilerOptions, DependencyKind, Entry, Error, MakeOptions};
 
 #[tokio::test]
@@ -95,11 +95,11 @@ async fn make_constructs_static_esm_module_graph() -> Result<(), Box<dyn std::er
                     .expect("dependency should have request"),
             )
         })
-        .collect::<HashSet<_>>();
+        .collect::<FxHashSet<_>>();
 
     assert_eq!(
         outgoing,
-        HashSet::from([
+        FxHashSet::from_iter([
             (DependencyKind::StaticImport, "./side-effect"),
             (DependencyKind::StaticImport, "./dep"),
             (DependencyKind::StaticImport, "./reexport"),
@@ -172,11 +172,11 @@ async fn make_records_dynamic_import_split_points() -> Result<(), Box<dyn std::e
                     .expect("dependency should have request"),
             )
         })
-        .collect::<HashSet<_>>();
+        .collect::<FxHashSet<_>>();
 
     assert_eq!(
         outgoing,
-        HashSet::from([
+        FxHashSet::from_iter([
             (DependencyKind::StaticImport, "./eager"),
             (DependencyKind::DynamicImport, "./feature"),
             (DependencyKind::DynamicImport, "./template"),
@@ -200,11 +200,11 @@ async fn make_records_dynamic_import_split_points() -> Result<(), Box<dyn std::e
                     .expect("dependency should have request"),
             )
         })
-        .collect::<HashSet<_>>();
+        .collect::<FxHashSet<_>>();
 
     assert_eq!(
         feature_outgoing,
-        HashSet::from([(DependencyKind::StaticImport, "./shared")])
+        FxHashSet::from_iter([(DependencyKind::StaticImport, "./shared")])
     );
 
     Ok(())
@@ -275,12 +275,12 @@ async fn make_deduplicates_mixed_import_identity() -> Result<(), Box<dyn std::er
     let incoming = graph
         .incoming_connections(feature)
         .map(|connection| connection.dependency.kind())
-        .collect::<HashSet<_>>();
+        .collect::<FxHashSet<_>>();
 
     assert_eq!(graph.modules().len(), 2);
     assert_eq!(
         incoming,
-        HashSet::from([DependencyKind::StaticImport, DependencyKind::DynamicImport])
+        FxHashSet::from_iter([DependencyKind::StaticImport, DependencyKind::DynamicImport])
     );
 
     Ok(())
@@ -415,7 +415,7 @@ fn write(path: PathBuf, source: &str) -> std::io::Result<()> {
     fs::write(path, source)
 }
 
-fn relative_resources(root: &Path, graph: &unpack_core::ModuleGraph) -> HashSet<String> {
+fn relative_resources(root: &Path, graph: &unpack_core::ModuleGraph) -> FxHashSet<String> {
     let root = fs::canonicalize(root).expect("fixture root should exist");
     graph
         .modules()

--- a/crates/unpack_node/Cargo.toml
+++ b/crates/unpack_node/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/docs/adr/0145-use-fx-hash-collections.md
+++ b/docs/adr/0145-use-fx-hash-collections.md
@@ -1,0 +1,9 @@
+# Use Fx hash collections throughout Rust code
+
+Unpack will use `rustc_hash::FxHashMap` and `rustc_hash::FxHashSet` for Rust-owned hash maps and hash sets instead of `std::collections::HashMap` and `std::collections::HashSet`. This applies to production code, tests, and future Rust crates in the workspace.
+
+The compiler creates and queries hash collections throughout graph construction, parsing, caching, code generation, and watch rebuilds. Standardizing these collections on the fast non-cryptographic hasher used by rustc supports Unpack's performance goal and avoids paying for per-instance randomized hashing where Unpack does not require denial-of-service-resistant hash tables. Code must not rely on Fx collection iteration order; output that requires stable ordering must continue to sort explicitly or use an ordered representation.
+
+This decision does not replace collections whose semantics are different. `BTreeMap` and `BTreeSet` remain appropriate when key order is part of the algorithm or output, and concurrent maps such as `DashMap` remain appropriate when shared concurrent access is required. Dense indexed storage, bit sets, and other specialized representations should also remain in use where they better express the owning webpack responsibility.
+
+The workspace Clippy configuration disallows the standard-library hash map and hash set types, and CI runs that lint across all Rust targets. Introducing another hash collection implementation requires a concrete semantic or performance reason and a deliberate update to this decision and its enforcement configuration.


### PR DESCRIPTION
## Summary

- replace Rust standard-library `HashMap` and `HashSet` usage with `rustc_hash::FxHashMap` and `FxHashSet`
- add workspace Clippy rules that reject reintroducing the standard hash collections
- run the guard across all Rust targets in CI

This standardizes hashing on the fast, deterministic hasher used by rustc while retaining ordered and concurrent collection types where their semantics are required.

Checked with `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D clippy::disallowed-types`, and `cargo fmt --all -- --check`.
