### PR TITLE
Report module counts in benchmark summaries

### DIFF
--- a/packages/benchmarks/src/adapters.mjs
+++ b/packages/benchmarks/src/adapters.mjs
@@ -89,6 +89,7 @@ export const adapters = {
           : false
       });
 
+      let moduleCount;
       try {
         const { err, stats } = await runUnpackCompiler(compiler);
         if (err) {
@@ -98,11 +99,12 @@ export const adapters = {
           const errors = stats.toJson().errors.map((error) => error.message).join("\n");
           throw new Error(errors || "Unpack reported compilation errors");
         }
+        moduleCount = stats?.compilation.modules.size;
       } finally {
         await closeUnpackCompiler(compiler);
       }
 
-      return { entryFile: join(outputDir, "main.js") };
+      return { entryFile: join(outputDir, "main.js"), moduleCount };
     }
   },
 
@@ -168,14 +170,16 @@ export const adapters = {
         plugins: [tracing.plugin]
       });
 
+      let moduleCount;
       try {
         const stats = await runWebpackCompiler(compiler);
         assertWebpackStats(stats, "webpack");
+        moduleCount = stats.compilation.modules.size;
       } finally {
         await tracing.close(compiler);
       }
 
-      return { entryFile: join(outputDir, "main.js") };
+      return { entryFile: join(outputDir, "main.js"), moduleCount };
     }
   },
 
@@ -246,14 +250,16 @@ export const adapters = {
         plugins: [tracing.plugin]
       });
 
+      let moduleCount;
       try {
         const stats = await runWebpackCompiler(compiler);
         assertWebpackStats(stats, "Rspack");
+        moduleCount = stats.compilation.modules.size;
       } finally {
         await tracing.close(compiler);
       }
 
-      return { entryFile: join(outputDir, "main.js") };
+      return { entryFile: join(outputDir, "main.js"), moduleCount };
     }
   },
 
@@ -269,8 +275,9 @@ export const adapters = {
         treeshake: false
       });
 
+      let output;
       try {
-        await bundle.write({
+        output = await bundle.write({
           dir: outputDir,
           format: "cjs",
           entryFileNames: "main.js",
@@ -282,7 +289,12 @@ export const adapters = {
         await bundle.close?.();
       }
 
-      return { entryFile: join(outputDir, "main.js") };
+      const moduleCount = new Set(
+        output.output.flatMap((item) =>
+          item.type === "chunk" ? Object.keys(item.modules) : []
+        )
+      ).size;
+      return { entryFile: join(outputDir, "main.js"), moduleCount };
     }
   },
 

--- a/packages/benchmarks/src/runner.mjs
+++ b/packages/benchmarks/src/runner.mjs
@@ -60,7 +60,7 @@ export async function runBenchmark(options = {}) {
   }
 
   return {
-    schema_version: 3,
+    schema_version: 4,
     generated_at: new Date().toISOString(),
     results
   };
@@ -86,14 +86,16 @@ export function toSummaryMarkdown(report, baselineReport) {
     : "";
   const watchMeasurementNote =
     "\n\n> `watch_build_ms` measures a development-mode rebuild with memory cache enabled and persistent cache disabled. The initial watch compilation is excluded; timing covers the same fixture mutation used by the warm build through completion of the resulting rebuild.";
+  const moduleCountNote =
+    "\n\n> `modules` is the cold build module count when the bundler exposes it reliably; otherwise it is left empty.";
 
-  return `${summary}${comparisonNote}${watchMeasurementNote}\n`;
+  return `${summary}${comparisonNote}${watchMeasurementNote}${moduleCountNote}\n`;
 }
 
 function toSummaryTable(results, baselines) {
   const lines = [
-    "| fixture | bundler | version/source | cold_build_ms | warm_build_ms | watch_build_ms | no_cache_build_ms | output_bytes | status |",
-    "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |"
+    "| fixture | bundler | version/source | modules | cold_build_ms | warm_build_ms | watch_build_ms | no_cache_build_ms | output_bytes | status |",
+    "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |"
   ];
 
   for (const result of results) {
@@ -103,6 +105,7 @@ function toSummaryTable(results, baselines) {
         result.fixture,
         result.bundler,
         result.version_source ?? "",
+        formatNumber(result.module_count, 0),
         formatMeasurement(result.cold_build_ms, baseline?.cold_build_ms),
         formatMeasurement(result.warm_build_ms, baseline?.warm_build_ms),
         formatMeasurement(result.watch_build_ms, baseline?.watch_build_ms),
@@ -367,10 +370,15 @@ async function timedBuild({
   return {
     status: "success",
     build_ms: buildMs,
+    module_count: normalizeModuleCount(buildResult?.moduleCount),
     output_bytes: await outputBytes(outputDir),
     verify_ms: elapsed(verifyStarted),
     message: null
   };
+}
+
+function normalizeModuleCount(value) {
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
 }
 
 async function verifyBundle({ entryFile, outputDir, expectedChecksum }) {
@@ -438,6 +446,7 @@ function resultFromPhases({ fixture, bundler, versionSource, cold, watch, warm, 
     fixture: fixture.name,
     bundler,
     version_source: versionSource,
+    module_count: cold.status === "success" ? cold.module_count : null,
     cold_build_ms: cold.status === "success" ? cold.build_ms : null,
     warm_build_ms: warm?.status === "success" ? warm.build_ms : null,
     watch_build_ms: watch?.status === "success" ? watch.build_ms : null,
@@ -469,6 +478,7 @@ function emptyResult({ fixture, bundler, versionSource, status, message }) {
     fixture: fixture.name,
     bundler,
     version_source: versionSource,
+    module_count: null,
     cold_build_ms: null,
     warm_build_ms: null,
     watch_build_ms: null,

--- a/packages/benchmarks/test/runner.test.mjs
+++ b/packages/benchmarks/test/runner.test.mjs
@@ -41,6 +41,7 @@ test("summary renders loader results before a separate non-loader table", () => 
     summary,
     /watch_build_ms.*development-mode rebuild with memory cache enabled and persistent cache disabled/
   );
+  assert.match(summary, /`modules` is the cold build module count/);
 });
 
 test("summary compares measurements with matching latest main results", () => {
@@ -60,7 +61,7 @@ test("summary compares measurements with matching latest main results", () => {
   assert.doesNotMatch(summary, /delta_vs_main/);
   assert.match(
     summary,
-    /\| 10\.0 \(\+25\.0%\) \| 5\.0 \(\+100\.0%\) \| 3\.0 \(\+0\.0%\) \| 8\.0 \(-20\.0%\) \| 100 \(-50\.0%\) \| success \|/
+    /\| 42 \| 10\.0 \(\+25\.0%\) \| 5\.0 \(\+100\.0%\) \| 3\.0 \(\+0\.0%\) \| 8\.0 \(-20\.0%\) \| 100 \(-50\.0%\) \| success \|/
   );
   assert.match(summary, /`\+` means slower or larger; `−` means faster or smaller/);
 });
@@ -71,8 +72,17 @@ test("summary omits inline deltas when main has no matching result", () => {
     { results: [summaryResult({ fixture: "loader", bundler: "unpack" })] }
   );
 
-  assert.match(summary, /\| 10\.0 \| 5\.0 \| 3\.0 \| 8\.0 \| 100 \| success \|/);
+  assert.match(summary, /\| 42 \| 10\.0 \| 5\.0 \| 3\.0 \| 8\.0 \| 100 \| success \|/);
   assert.doesNotMatch(summary, /\([+-][\d.]+%\)/);
+});
+
+test("summary leaves modules empty when the adapter cannot report them", () => {
+  const result = summaryResult({ fixture: "large", bundler: "metro" });
+  result.module_count = null;
+
+  const summary = toSummaryMarkdown({ results: [result] });
+
+  assert.match(summary, /\| large \| metro \| metro@1\.0\.0 \|  \| 10\.0 \|/);
 });
 
 test("runner emits persistent-cache and no-cache measurements for a verified bundle", async () => {
@@ -89,7 +99,7 @@ test("runner emits persistent-cache and no-cache measurements for a verified bun
       }
     });
 
-    assert.equal(report.schema_version, 3);
+    assert.equal(report.schema_version, 4);
     assert.equal(report.results.length, 1);
     assert.equal(report.results[0].fixture, "large");
     assert.equal(report.results[0].bundler, "fake");
@@ -104,6 +114,7 @@ test("runner emits persistent-cache and no-cache measurements for a verified bun
     assert.equal(typeof report.results[0].watch_build_ms, "number");
     assert.equal(typeof report.results[0].no_cache_build_ms, "number");
     assert.ok(report.results[0].output_bytes > 0);
+    assert.equal(report.results[0].module_count, 42);
     assert.deepEqual(
       calls.map(({ phase, persistentCache, cacheReadonly }) => ({
         phase,
@@ -143,6 +154,7 @@ test("runner emits persistent-cache and no-cache measurements for a verified bun
     const summary = toSummaryMarkdown(report);
     assert.match(summary, /watch_build_ms/);
     assert.match(summary, /no_cache_build_ms/);
+    assert.match(summary, /\| modules \|/);
     assert.match(summary, /\\| large \\| fake \\| fake@1\\.0\\.0 \\|/);
   } finally {
     await rm(workspace, { recursive: true, force: true });
@@ -298,6 +310,7 @@ test("webpack-compatible adapters build the loader benchmark fixture", async () 
       assert.ok(result.watch_build_ms > 0);
       assert.equal(result.no_cache_status, "success");
       assert.equal(result.verify_status, "success");
+      assert.ok(result.module_count > 0);
     }
 
     const loaderEntry = await readFile(
@@ -848,6 +861,7 @@ function summaryResult({ fixture, bundler }) {
     watch_build_ms: 3,
     no_cache_build_ms: 8,
     output_bytes: 100,
+    module_count: 42,
     status: "success"
   };
 }
@@ -868,7 +882,7 @@ function fakeAdapter({ checksumOffset = 0, error, calls, staleWarmChecksum = fal
         expectedChecksum: fixture.expectedChecksum
       });
       await writeFile(entryFile, `exports.checksum = ${fixture.expectedChecksum};\n`, "utf8");
-      return { entryFile, rebuildMs: 1 };
+      return { entryFile, rebuildMs: 1, moduleCount: 99 };
     },
     async build({ fixture, outputDir, phase, persistentCache, cacheReadonly }) {
       calls?.push({
@@ -893,7 +907,7 @@ function fakeAdapter({ checksumOffset = 0, error, calls, staleWarmChecksum = fal
         `exports.checksum = ${checksum + checksumOffset};\n`,
         "utf8"
       );
-      return { entryFile };
+      return { entryFile, moduleCount: 42 };
     }
   };
 }


### PR DESCRIPTION
## Summary

- report cold-build module counts from Unpack, webpack, Rspack, and Rolldown adapters
- include the optional module count in benchmark JSON and issue comment tables
- leave the table cell empty when a bundler cannot expose a reliable count

## Tests

- `pnpm --filter @unpack-js/benchmarks test`
- ran the large Rolldown fixture and confirmed the generated summary reports 481 modules