### PR TITLE
Implement async split chunks extraction

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -136,6 +136,10 @@ _Avoid_: Module graph chunks, output graph
 A loading relationship that groups one or more chunks and connects parent and child loading paths.
 _Avoid_: Chunk collection, chunk set
 
+**Split Chunks**:
+The optimization that extracts modules shared by eligible Chunks into a separate Chunk and inserts it into each affected Chunk Group. The implemented first slice applies to Async Chunks and uses `optimization.splitChunks`.
+_Avoid_: Duplicate-module removal, shared bundle
+
 **Entrypoint**:
 An initial chunk group created from a configured entry.
 _Avoid_: Entry chunk, main chunk

--- a/crates/unpack_core/src/build_chunk_graph.rs
+++ b/crates/unpack_core/src/build_chunk_graph.rs
@@ -4,6 +4,7 @@ use std::{cmp::Ordering, collections::VecDeque};
 
 use crate::{
     AsyncDependenciesBlockIndex, CompilerOptions, ModuleGraph, ModuleHandle,
+    chunk::ChunkHandle,
     chunk_graph::ChunkGraph,
     chunk_group::{AsyncBlockOrigin, ChunkGroupHandle, ChunkGroupKind},
     module_computation_cache::ModuleComputationCache,
@@ -311,7 +312,77 @@ pub(crate) fn build_chunk_graph_with_cache(
         }
     }
 
+    if let Some(split_chunks) = &options.split_chunks {
+        apply_split_chunks(
+            &mut chunk_graph,
+            split_chunks.min_chunks,
+            split_chunks.name.as_deref(),
+        );
+    }
+
     chunk_graph
+}
+
+// Webpack's SplitChunksPlugin is cache-group driven. This first model-backed
+// slice implements its default async boundary: modules shared by the same set
+// of async chunks are moved into one chunk inserted into every affected group.
+fn apply_split_chunks(chunk_graph: &mut ChunkGraph, min_chunks: usize, name: Option<&str>) {
+    let async_chunks = chunk_graph
+        .chunks()
+        .iter()
+        .filter(|chunk| {
+            !chunk.groups().is_empty()
+                && chunk.groups().iter().all(|group| {
+                    matches!(
+                        chunk_graph.chunk_groups()[group.index()].kind(),
+                        ChunkGroupKind::Async
+                    )
+                })
+        })
+        .map(|chunk| chunk.handle())
+        .collect::<Vec<_>>();
+
+    let mut modules_by_chunk_set = FxHashMap::<Vec<ChunkHandle>, Vec<ModuleHandle>>::default();
+    let mut chunks_by_module = FxHashMap::<ModuleHandle, Vec<ChunkHandle>>::default();
+    for chunk in async_chunks {
+        for module in chunk_graph.chunk_modules(chunk) {
+            chunks_by_module.entry(*module).or_default().push(chunk);
+        }
+    }
+    for (module, mut chunks) in chunks_by_module {
+        chunks.sort();
+        chunks.dedup();
+        if chunks.len() >= min_chunks {
+            modules_by_chunk_set.entry(chunks).or_default().push(module);
+        }
+    }
+
+    let mut split_candidates = modules_by_chunk_set.into_iter().collect::<Vec<_>>();
+    split_candidates.sort_by(|(left, _), (right, _)| left.cmp(right));
+    if name.is_some() && split_candidates.len() > 1 {
+        let mut source_chunks = split_candidates
+            .iter()
+            .flat_map(|(chunks, _)| chunks.iter().copied())
+            .collect::<Vec<_>>();
+        source_chunks.sort();
+        source_chunks.dedup();
+        let modules = split_candidates
+            .into_iter()
+            .flat_map(|(_, modules)| modules)
+            .collect();
+        split_candidates = vec![(source_chunks, modules)];
+    }
+    for (source_chunks, mut modules) in split_candidates {
+        modules.sort();
+        let chunk_name = name.map(str::to_string);
+        let shared_chunk = chunk_graph.add_split_chunk(&source_chunks, chunk_name, modules.clone());
+        for module in modules {
+            for chunk in &source_chunks {
+                chunk_graph.disconnect_chunk_and_module(*chunk, module);
+            }
+            chunk_graph.connect_chunk_and_module(shared_chunk, module);
+        }
+    }
 }
 
 fn collect_static_reachable_cached(

--- a/crates/unpack_core/src/chunk_graph.rs
+++ b/crates/unpack_core/src/chunk_graph.rs
@@ -127,6 +127,20 @@ impl ChunkGraph {
         Some(new_chunk)
     }
 
+    pub(crate) fn add_split_chunk(
+        &mut self,
+        source_chunks: &[ChunkHandle],
+        name: Option<String>,
+        root_modules: Vec<ModuleHandle>,
+    ) -> ChunkHandle {
+        let new_chunk = self.add_chunk(name, root_modules);
+        for source_chunk in source_chunks {
+            let original = self.chunks[source_chunk.index()].clone();
+            original.split(&mut self.chunks[new_chunk.index()], &mut self.chunk_groups);
+        }
+        new_chunk
+    }
+
     pub(crate) fn connect_chunk_and_module(&mut self, chunk: ChunkHandle, module: ModuleHandle) {
         if self.module_chunks.len() <= module.index() {
             self.module_chunks.resize_with(module.index() + 1, Vec::new);
@@ -141,6 +155,13 @@ impl ChunkGraph {
         }
         if !self.module_chunks[module.index()].contains(&chunk) {
             self.module_chunks[module.index()].push(chunk);
+        }
+    }
+
+    pub(crate) fn disconnect_chunk_and_module(&mut self, chunk: ChunkHandle, module: ModuleHandle) {
+        self.chunk_modules[chunk.index()].retain(|connected| *connected != module);
+        if let Some(chunks) = self.module_chunks.get_mut(module.index()) {
+            chunks.retain(|connected| *connected != chunk);
         }
     }
 

--- a/crates/unpack_core/src/compiler.rs
+++ b/crates/unpack_core/src/compiler.rs
@@ -61,6 +61,7 @@ pub struct CompilerOptions {
     pub provided_exports: bool,
     pub used_exports: bool,
     pub side_effects: SideEffectsOption,
+    pub split_chunks: Option<SplitChunksOptions>,
     pub serial_rebuild_make: bool,
     pub unsafe_watch_cache_invalidation: bool,
 }
@@ -82,10 +83,17 @@ impl CompilerOptions {
             provided_exports: true,
             used_exports: true,
             side_effects: SideEffectsOption::Flag,
+            split_chunks: None,
             serial_rebuild_make: true,
             unsafe_watch_cache_invalidation: false,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SplitChunksOptions {
+    pub min_chunks: usize,
+    pub name: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/unpack_core/src/dependencies/import_dependency.rs
+++ b/crates/unpack_core/src/dependencies/import_dependency.rs
@@ -64,19 +64,34 @@ impl DependencyTemplate<ImportDependency> for ImportDependencyTemplate {
         let expression = if let Some(group_handle) = context.chunk_graph.block_chunk_group(origin) {
             context.add_runtime_requirement(RuntimeRequirement::EnsureChunk);
             let group = &context.chunk_graph.chunk_groups()[group_handle.index()];
-            let chunk_handle = group
+            let chunk_ids = group
                 .chunks()
-                .first()
-                .copied()
-                .expect("Async Chunk Group must contain a Chunk");
-            let chunk = context
-                .chunk_graph
-                .chunk(chunk_handle)
-                .expect("Async Chunk must exist before Dynamic Import generation");
-            let chunk_id = json_render_id(chunk.render_id());
-            format!(
-                "__webpack_require__.e({chunk_id}).then(__webpack_require__.bind(__webpack_require__, {target_id}))"
-            )
+                .iter()
+                .map(|chunk_handle| {
+                    let chunk = context
+                        .chunk_graph
+                        .chunk(*chunk_handle)
+                        .expect("Async Chunk must exist before Dynamic Import generation");
+                    json_render_id(chunk.render_id())
+                })
+                .collect::<Vec<_>>();
+            assert!(
+                !chunk_ids.is_empty(),
+                "Async Chunk Group must contain a Chunk"
+            );
+            let load = if chunk_ids.len() == 1 {
+                format!("__webpack_require__.e({})", chunk_ids[0])
+            } else {
+                format!(
+                    "Promise.all([{}])",
+                    chunk_ids
+                        .iter()
+                        .map(|chunk_id| format!("__webpack_require__.e({chunk_id})"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            };
+            format!("{load}.then(__webpack_require__.bind(__webpack_require__, {target_id}))")
         } else {
             format!(
                 "Promise.resolve().then(__webpack_require__.bind(__webpack_require__, {target_id}))"

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -54,7 +54,7 @@ pub use code_generation::Asset;
 pub use compilation::{Compilation, WatchDependencies};
 pub use compiler::{
     CacheIdleReason, CacheLifecycleOutcome, Compiler, CompilerOptions, DEFAULT_EXTENSIONS, Entry,
-    PendingCompilation, SideEffectsOption,
+    PendingCompilation, SideEffectsOption, SplitChunksOptions,
 };
 pub use dependencies::{
     ConstDependency, EntryDependency, HarmonyExportExpressionDependency,

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -75,12 +75,21 @@ pub struct NativeCompilerOptions {
     pub used_exports: bool,
     #[napi(js_name = "sideEffects")]
     pub side_effects: String,
+    #[napi(js_name = "splitChunks")]
+    pub split_chunks: Option<NativeSplitChunksOptions>,
     #[napi(js_name = "moduleRules")]
     pub module_rules: Vec<NativeModuleRule>,
     #[napi(js_name = "serialRebuildMake")]
     pub serial_rebuild_make: bool,
     #[napi(js_name = "unsafeWatchCacheInvalidation")]
     pub unsafe_watch_cache_invalidation: bool,
+}
+
+#[napi(object)]
+pub struct NativeSplitChunksOptions {
+    #[napi(js_name = "minChunks")]
+    pub min_chunks: u32,
+    pub name: Option<String>,
 }
 
 #[napi(object)]
@@ -978,6 +987,13 @@ impl NativeCompiler {
                 )));
             }
         };
+        compiler_options.split_chunks =
+            options
+                .split_chunks
+                .map(|split_chunks| unpack_core::SplitChunksOptions {
+                    min_chunks: split_chunks.min_chunks as usize,
+                    name: split_chunks.name,
+                });
         compiler_options.module_rules = options
             .module_rules
             .into_iter()

--- a/docs/adr/0146-start-split-chunks-with-shared-async-modules.md
+++ b/docs/adr/0146-start-split-chunks-with-shared-async-modules.md
@@ -1,0 +1,24 @@
+# Start Split Chunks with shared Async Chunk modules
+
+Unpack will introduce `optimization.splitChunks` with the webpack-shaped
+default boundary of `chunks: "async"`. The first slice groups modules by the
+set of Async Chunks containing them, extracts groups meeting `minChunks` into a
+shared Chunk, and inserts that Chunk into every affected Chunk Group. Dynamic
+import code must ensure every Chunk in its Chunk Group before requiring the
+target Module.
+
+The public option initially accepts `chunks: "async"`, a positive `minChunks`,
+and a string `name`. `minChunks` defaults to `2`; an explicit value of `1`
+retains webpack's valid singleton-extraction behavior. A constant string name
+combines all qualifying candidates into that one Chunk, so it is loaded by the
+union of their affected Chunk Groups, matching webpack's named-chunk reuse.
+Other Split Chunks options are rejected rather than accepted as no-ops.
+Initial/all-chunk extraction is deferred until entry startup can load
+multiple initial Chunks. Cache groups, size thresholds, request limits, module
+tests, priorities, reuseExistingChunk, and per-group filename options remain
+future model-backed slices.
+
+This decision uses the many-to-many Chunk Graph, webpack-like Chunk Groups, and
+Chunk split preparation established by ADRs 0015, 0016, and 0017. It does not
+change the block-first refactoring trigger in DEV-001: per-block chunk options
+still require moving beyond target-Module Async Chunk plan reuse.

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -247,7 +247,10 @@ Necessity:
   async groups, per-block options, or full split-point identity can be claimed.
 - Intersecting parent available-module sets is necessary: excluding a module
   seen on only one path would make the shared payload unusable from another.
-- Split chunks, cache groups, min-size/min-chunks/max-request rules, runtime chunks, and named chunk options are not necessary for the first implementation.
+- Split Chunks now has a first async-only shared-module extraction slice with
+  `minChunks` and a string `name`. Cache groups, size thresholds, max-request
+  rules, initial/all-chunk extraction, runtime chunks, and broader named chunk
+  options remain staged scope.
 - Recursive nested-block processing and available-module back-edge collapse are
   required parts of Unpack's implemented dynamic-import semantics.
 
@@ -339,5 +342,6 @@ Feature work to defer until explicitly chosen:
 - CommonJS parsing and interop.
 - Broader loader rules, loader chains, loader options, async loaders, and plugin API parity.
 - Magic comments, dynamic import modes, import attributes, deferred/source import phases.
-- Split chunks, cache groups, runtime chunks, HMR, browser/ESM/webworker chunk loading.
+- Broader Split Chunks cache groups and sizing/request policies, runtime chunks,
+  HMR, and browser/ESM/webworker chunk loading.
 - Inner Graph, module concatenation, broader export-usage semantics, and deterministic id plugins.

--- a/packages/unpack/src/config/normalization.ts
+++ b/packages/unpack/src/config/normalization.ts
@@ -40,6 +40,13 @@ export interface OptimizationOptions {
   providedExports?: boolean;
   usedExports?: boolean | "global";
   sideEffects?: boolean | "flag";
+  splitChunks?: false | SplitChunksOptions;
+}
+
+export interface SplitChunksOptions {
+  chunks?: "async";
+  minChunks?: number;
+  name?: string;
 }
 
 export interface ModuleOptions {
@@ -143,9 +150,16 @@ export interface NormalizedOptions {
   providedExports: boolean;
   usedExports: boolean;
   sideEffects: "disabled" | "flag" | "analyze";
+  splitChunks?: NormalizedSplitChunksOptions;
   resolveCache: boolean;
   serialRebuildMake: boolean;
   unsafeWatchCacheInvalidation: boolean;
+}
+
+export interface NormalizedSplitChunksOptions {
+  chunks: "async";
+  minChunks: number;
+  name?: string;
 }
 
 export interface NormalizedModuleRule {
@@ -281,6 +295,7 @@ export function normalizeOptions(options: UnpackOptions): NormalizedOptions {
     providedExports: optimization.providedExports,
     usedExports: optimization.usedExports,
     sideEffects: optimization.sideEffects,
+    splitChunks: optimization.splitChunks,
     resolveCache: normalizeResolveOptions(
       options.resolve,
       normalizedCache.type !== "disabled"
@@ -360,16 +375,17 @@ export function normalizeExperimentsOptions(
 export function normalizeOptimizationOptions(
   optimization: OptimizationOptions | undefined,
   mode: Mode
-): { providedExports: boolean; usedExports: boolean; sideEffects: "disabled" | "flag" | "analyze" } {
+): { providedExports: boolean; usedExports: boolean; sideEffects: "disabled" | "flag" | "analyze"; splitChunks?: NormalizedSplitChunksOptions } {
   if (optimization === undefined) {
     return {
       providedExports: true,
       usedExports: mode === "production",
-      sideEffects: mode === "production" ? "analyze" : "flag"
+      sideEffects: mode === "production" ? "analyze" : "flag",
+      splitChunks: undefined
     };
   }
   assertPlainObject(optimization, "options.optimization");
-  assertKnownKeys(optimization, ["providedExports", "usedExports", "sideEffects"], "options.optimization");
+  assertKnownKeys(optimization, ["providedExports", "usedExports", "sideEffects", "splitChunks"], "options.optimization");
   return {
     providedExports: optimization.providedExports === undefined
       ? true
@@ -385,7 +401,33 @@ export function normalizeOptimizationOptions(
         ? "flag"
         : assertBoolean(optimization.sideEffects, "options.optimization.sideEffects")
           ? "analyze"
-          : "disabled"
+          : "disabled",
+    splitChunks: normalizeSplitChunksOptions(optimization.splitChunks)
+  };
+}
+
+function normalizeSplitChunksOptions(
+  splitChunks: unknown
+): NormalizedSplitChunksOptions | undefined {
+  if (splitChunks === undefined || splitChunks === false) return undefined;
+  assertPlainObject(splitChunks, "options.optimization.splitChunks");
+  assertKnownKeys(splitChunks, ["chunks", "minChunks", "name"], "options.optimization.splitChunks");
+  const options = splitChunks as unknown as SplitChunksOptions;
+  if (options.chunks !== undefined && options.chunks !== "async") {
+    throw new TypeError("options.optimization.splitChunks.chunks currently only supports 'async'");
+  }
+  const minChunks = options.minChunks === undefined
+    ? 2
+    : assertNonNegativeInteger(options.minChunks, "options.optimization.splitChunks.minChunks");
+  if (minChunks < 1) {
+    throw new TypeError("options.optimization.splitChunks.minChunks must be at least 1");
+  }
+  return {
+    chunks: "async",
+    minChunks,
+    name: options.name === undefined
+      ? undefined
+      : assertNonEmptyString(options.name, "options.optimization.splitChunks.name")
   };
 }
 

--- a/packages/unpack/test/split-chunks.test.ts
+++ b/packages/unpack/test/split-chunks.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import unpack, { type Stats } from "@unpack-js/core";
+import webpack, { type Configuration, type Stats as WebpackStats } from "webpack";
+
+test("optimization.splitChunks extracts modules shared by async chunks", async () => {
+  const fixture = await mkdtemp(join(tmpdir(), "unpack-split-chunks-"));
+  const outputPath = join(fixture, "dist");
+  let sharedChunkGroupCount = 0;
+  try {
+    await writeFixture(fixture, {
+      "src/index.js": "export default Promise.all([import('./a'), import('./b'), import('./c')]).then(([a, b, c]) => a.value + b.value + c.value);",
+      "src/a.js": "import { sharedAB } from './shared-ab'; export const value = sharedAB + 1;",
+      "src/b.js": "import { sharedAB } from './shared-ab'; import { sharedBC } from './shared-bc'; export const value = sharedAB + sharedBC;",
+      "src/c.js": "import { sharedBC } from './shared-bc'; export const value = sharedBC + 2;",
+      "src/shared-ab.js": `export const sharedAB = 20; // SHARED_AB_SPLIT_CHUNK_MARKER\n/* ${"x".repeat(25_000)} */`,
+      "src/shared-bc.js": `export const sharedBC = 30; // SHARED_BC_SPLIT_CHUNK_MARKER\n/* ${"y".repeat(25_000)} */`
+    });
+
+    const webpackOutputPath = join(fixture, "webpack-dist");
+    const webpackStats = await runWebpack({
+      context: fixture,
+      mode: "none",
+      entry: "./src/index.js",
+      output: { path: webpackOutputPath },
+      devtool: false,
+      optimization: { splitChunks: { chunks: "async", minChunks: 2, name: "shared" } }
+    });
+    assert.equal(webpackStats.hasErrors(), false);
+    assert.ok(webpackStats.toJson({ assets: true }).assets?.some((asset) => asset.name === "shared.js"));
+
+    const stats = await run({
+      context: fixture,
+      mode: "none",
+      entry: "./src/index.js",
+      output: { path: outputPath },
+      sourcemap: false,
+      optimization: { splitChunks: { chunks: "async", minChunks: 2, name: "shared" } },
+      plugins: [{
+        apply(compiler) {
+          let compilation: Parameters<Parameters<typeof compiler.hooks.compilation.tap>[1]>[0];
+          compiler.hooks.compilation.tap("ObserveSplitChunks", (current) => {
+            compilation = current;
+          });
+          compiler.hooks.done.tap("ObserveSplitChunks", () => {
+            sharedChunkGroupCount = compilation.chunkGroups.filter((group) =>
+              group.chunks.some((chunk) => chunk.name === "shared")
+            ).length;
+          });
+        }
+      }]
+    });
+    assert.equal(stats.hasErrors(), false);
+    const javascriptAssets = stats.toJson().assets
+      .map((asset) => asset.name)
+      .filter((name) => name.endsWith(".js"));
+    assert.ok(javascriptAssets.includes("shared.js"));
+    assert.equal(sharedChunkGroupCount, 3);
+    const sources = await Promise.all(
+      javascriptAssets.map((name) => readFile(join(outputPath, name), "utf8"))
+    );
+    assert.equal(sources.filter((source) => source.includes("SHARED_AB_SPLIT_CHUNK_MARKER")).length, 1);
+    assert.equal(sources.filter((source) => source.includes("SHARED_BC_SPLIT_CHUNK_MARKER")).length, 1);
+
+    const require = createRequire(import.meta.url);
+    const entry = require(join(outputPath, "main.js")) as { default: Promise<number> };
+    assert.equal(await entry.default, 103);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("optimization.splitChunks rejects unsupported surfaces synchronously", () => {
+  assert.doesNotThrow(() => unpack({ entry: "./index.js", optimization: { splitChunks: false } }));
+  assert.doesNotThrow(() => unpack({ entry: "./index.js", optimization: { splitChunks: {} } }));
+  assert.throws(
+    () => unpack({ entry: "./index.js", optimization: { splitChunks: { chunks: "all" as "async" } } }),
+    /currently only supports 'async'/
+  );
+  assert.throws(
+    () => unpack({ entry: "./index.js", optimization: { splitChunks: { minChunks: 0 } } }),
+    /minChunks must be at least 1/
+  );
+  assert.throws(
+    () => unpack({
+      entry: "./index.js",
+      optimization: { splitChunks: { cacheGroups: {} } as never }
+    }),
+    /unknown option 'cacheGroups'/
+  );
+  assert.throws(
+    () => unpack({ entry: "./index.js", optimization: { splitChunks: { name: "" } } }),
+    /name must not be empty/
+  );
+});
+
+function run(options: Parameters<typeof unpack>[0]): Promise<Stats> {
+  return new Promise((resolve, reject) => {
+    unpack(options, (error, stats) => {
+      if (error) reject(error);
+      else if (stats) resolve(stats);
+      else reject(new Error("compiler completed without Stats"));
+    });
+  });
+}
+
+function runWebpack(options: Configuration): Promise<WebpackStats> {
+  return new Promise((resolve, reject) => {
+    webpack(options, (error, stats) => {
+      if (error) reject(error);
+      else if (stats) resolve(stats);
+      else reject(new Error("webpack completed without Stats"));
+    });
+  });
+}
+
+async function writeFixture(root: string, files: Record<string, string>): Promise<void> {
+  for (const [name, source] of Object.entries(files)) {
+    const path = join(root, name);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, source);
+  }
+}


### PR DESCRIPTION
## Summary

- add the first model-backed `optimization.splitChunks` surface for async chunks
- extract modules meeting `minChunks` into shared chunks and reuse constant named chunks across candidate sets
- ensure dynamic imports load every chunk in their Chunk Group before requiring the target module
- reject unsupported Split Chunks options instead of accepting no-op configuration
- document the supported boundary and remaining staged scope

The implementation is covered by a pinned webpack comparison, direct Chunk Group assertions, executable bundle behavior, configuration validation, the Rust workspace tests, the public package suite, and benchmark-tool tests.