### PR TITLE
Freeze modules after make

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -148,6 +148,10 @@ _Avoid_: Entry chunk, main chunk
 The compilation stage that starts from entry modules, discovers their dependencies, and constructs the module graph before bundling.
 _Avoid_: Build phase, parse phase
 
+**Finished Modules Boundary**:
+The compilation boundary reached after Make has produced the Module Graph and all `finishModules` work has completed. Make-owned Building Modules become immutable Modules before this boundary; later graph analysis and sealing may mutate Module Graph metadata such as Exports Info, but not Module build state.
+_Avoid_: Module freeze hook, immutable compilation
+
 **Resolve Cache**:
 The webpack-shaped cache of successful resolver results, controlled by `resolve.cache`; entries remain subject to dependency Snapshot validation and are distinct from the resolver's internal filesystem and package-metadata memoization.
 _Avoid_: Resolver filesystem cache, unsafe resolver cache

--- a/crates/unpack_core/src/code_generation.rs
+++ b/crates/unpack_core/src/code_generation.rs
@@ -80,7 +80,7 @@ fn code_generation_etag(input: &ModuleGeneratorContext<'_>) -> CacheETag {
     module
         .code_generation_local_input_digest()
         .hash(&mut hasher);
-    hash_used_export_names(module, &mut hasher);
+    hash_used_export_names(module, module_graph, &mut hasher);
     module_render_ids.get(&module.handle()).hash(&mut hasher);
 
     for dependency_index in 0..module.dependencies().len() {
@@ -123,7 +123,7 @@ fn code_generation_etag(input: &ModuleGeneratorContext<'_>) -> CacheETag {
     CacheETag::new(hasher.finish().to_le_bytes())
 }
 
-fn hash_used_export_names(module: &Module, hasher: &mut StableHasher) {
+fn hash_used_export_names(module: &Module, module_graph: &ModuleGraph, hasher: &mut StableHasher) {
     for dependency in module
         .presentational_dependencies()
         .iter()
@@ -135,7 +135,7 @@ fn hash_used_export_names(module: &Module, hasher: &mut StableHasher) {
                 .flat_map(|block| block.dependencies()),
         )
     {
-        dependency.update_code_generation_hash(module.exports_info(), hasher);
+        dependency.update_code_generation_hash(module_graph.exports_info(module.handle()), hasher);
     }
 }
 
@@ -628,7 +628,7 @@ mod tests {
 
     use crate::{
         CacheOptions, Compiler, CompilerOptions, ConstDependency, Dependency, Entry, Error,
-        ModuleGraph, ModuleHandle, ModuleIdentity, SnapshotOptions, SourceRange,
+        ModuleHandle, ModuleIdentity, SnapshotOptions, SourceRange,
         cache::{Cache, CacheItemFamily, CacheItemWork},
         cache_facade::{CacheIdentifier, CacheKey, CacheNamespace},
         id_assignment::{RenderId, assign_chunk_render_ids, assign_module_render_ids},
@@ -787,21 +787,25 @@ mod tests {
     fn code_generation_cache_invalidates_template_inputs_when_source_is_unchanged() {
         let options = CompilerOptions::new("/project", vec![Entry::new("main", "./index")]);
         let build = |expression: &str| {
-            let mut module_graph = ModuleGraph::default();
-            let module = module_graph.add_module(ModuleIdentity::new("/project/index.js"));
-            module_graph
-                .module_mut(module)
-                .expect("fixture Module should exist")
-                .finish_build(
-                    Vec::new(),
-                    Vec::new(),
-                    vec![Dependency::Const(ConstDependency::new(
-                        expression,
-                        SourceRange::new(0, 5),
-                    ))],
-                    "value".to_string(),
-                    1,
-                );
+            let mut building_module_graph = crate::module_graph::BuildingModuleGraph::default();
+            let module =
+                building_module_graph.add_module(ModuleIdentity::new("/project/index.js"), None);
+            building_module_graph
+                .finish_module_build(
+                    module,
+                    crate::module::BuiltModuleContent::from_test_parts(
+                        Vec::new(),
+                        Vec::new(),
+                        vec![Dependency::Const(ConstDependency::new(
+                            expression,
+                            SourceRange::new(0, 5),
+                        ))],
+                        "value".to_string(),
+                        1,
+                    ),
+                )
+                .expect("fixture Module should exist");
+            let module_graph = building_module_graph.finish();
             let mut chunk_graph =
                 crate::build_chunk_graph::build_chunk_graph(&options, &module_graph, &[module]);
             assign_module_render_ids(&options, &module_graph, &mut chunk_graph);
@@ -848,12 +852,22 @@ mod tests {
     #[test]
     fn incompatible_cached_replacement_recipe_is_regenerated() {
         let options = CompilerOptions::new("/project", vec![Entry::new("main", "./index")]);
-        let mut module_graph = ModuleGraph::default();
-        let module = module_graph.add_module(ModuleIdentity::new("/project/index.js"));
-        module_graph
-            .module_mut(module)
-            .expect("fixture Module should exist")
-            .finish_build(Vec::new(), Vec::new(), Vec::new(), "éx".to_string(), 1);
+        let mut building_module_graph = crate::module_graph::BuildingModuleGraph::default();
+        let module =
+            building_module_graph.add_module(ModuleIdentity::new("/project/index.js"), None);
+        building_module_graph
+            .finish_module_build(
+                module,
+                crate::module::BuiltModuleContent::from_test_parts(
+                    Vec::new(),
+                    Vec::new(),
+                    Vec::new(),
+                    "éx".to_string(),
+                    1,
+                ),
+            )
+            .expect("fixture Module should exist");
+        let module_graph = building_module_graph.finish();
         let mut chunk_graph =
             crate::build_chunk_graph::build_chunk_graph(&options, &module_graph, &[module]);
         assign_module_render_ids(&options, &module_graph, &mut chunk_graph);
@@ -919,21 +933,25 @@ mod tests {
     #[test]
     fn module_attributable_generation_errors_become_throwing_results() {
         let options = CompilerOptions::new("/project", vec![Entry::new("main", "./index")]);
-        let mut module_graph = ModuleGraph::default();
-        let module = module_graph.add_module(ModuleIdentity::new("/project/index.js"));
-        module_graph
-            .module_mut(module)
-            .expect("fixture Module should exist")
-            .finish_build(
-                Vec::new(),
-                Vec::new(),
-                vec![Dependency::Const(ConstDependency::new(
-                    "replacement",
-                    SourceRange::new(0, 99),
-                ))],
-                "value".to_string(),
-                1,
-            );
+        let mut building_module_graph = crate::module_graph::BuildingModuleGraph::default();
+        let module =
+            building_module_graph.add_module(ModuleIdentity::new("/project/index.js"), None);
+        building_module_graph
+            .finish_module_build(
+                module,
+                crate::module::BuiltModuleContent::from_test_parts(
+                    Vec::new(),
+                    Vec::new(),
+                    vec![Dependency::Const(ConstDependency::new(
+                        "replacement",
+                        SourceRange::new(0, 99),
+                    ))],
+                    "value".to_string(),
+                    1,
+                ),
+            )
+            .expect("fixture Module should exist");
+        let module_graph = building_module_graph.finish();
         let mut chunk_graph =
             crate::build_chunk_graph::build_chunk_graph(&options, &module_graph, &[module]);
         assign_module_render_ids(&options, &module_graph, &mut chunk_graph);

--- a/crates/unpack_core/src/compilation.rs
+++ b/crates/unpack_core/src/compilation.rs
@@ -181,7 +181,7 @@ impl Compilation {
             .await;
 
             let mut state = state.lock().await;
-            self.module_graph = std::mem::take(&mut state.module_graph);
+            self.module_graph = std::mem::take(&mut state.module_graph).finish();
             self.entries = std::mem::take(&mut state.entries).into_values().collect();
             self.errors = std::mem::take(&mut state.errors);
             self.watch_dependencies = WatchDependencies {
@@ -435,7 +435,8 @@ fn compute_module_hash(
                 .flat_map(|block| block.dependencies()),
         )
     {
-        dependency.update_code_generation_hash(module.exports_info(), &mut hasher);
+        dependency
+            .update_code_generation_hash(module_graph.exports_info(module.handle()), &mut hasher);
     }
     let references = chunk_graph.module_references(module_graph, module.handle());
     references.module_render_id.hash(&mut hasher);

--- a/crates/unpack_core/src/flag_dependency_exports_plugin.rs
+++ b/crates/unpack_core/src/flag_dependency_exports_plugin.rs
@@ -28,18 +28,21 @@ fn flag_dependency_exports(compilation: &mut Compilation) {
         .map(|module| module.handle())
         .collect::<Vec<_>>();
     for handle in handles {
-        if let Some(module) = compilation.module_graph_mut().module_mut(handle) {
-            if let Some(exports_info) = module_computation_cache
-                .as_ref()
-                .and_then(|cache| cache.get_provided_exports(module.identity()))
-            {
-                *module.exports_info_mut() = exports_info;
-                continue;
-            }
-            module.analyze_provided_exports();
+        let module = compilation
+            .module_graph()
+            .module(handle)
+            .expect("a Module Graph handle should address a Module");
+        let identity = module.identity().clone();
+        let cached_exports_info = module_computation_cache
+            .as_ref()
+            .and_then(|cache| cache.get_provided_exports(&identity));
+        let exports_info = cached_exports_info.unwrap_or_else(|| {
+            let exports_info = module.provided_exports();
             if let Some(cache) = &module_computation_cache {
-                cache.store_provided_exports(module.identity(), module.exports_info().clone());
+                cache.store_provided_exports(&identity, exports_info.clone());
             }
-        }
+            exports_info
+        });
+        *compilation.module_graph_mut().exports_info_mut(handle) = exports_info;
     }
 }

--- a/crates/unpack_core/src/flag_dependency_usage_plugin.rs
+++ b/crates/unpack_core/src/flag_dependency_usage_plugin.rs
@@ -33,8 +33,8 @@ fn flag_dependency_usage(compilation: &mut Compilation) {
     for entry in compilation.entries() {
         let provided = compilation
             .module_graph()
-            .module(*entry)
-            .and_then(|module| module.exports_info().provided_exports())
+            .exports_info(*entry)
+            .provided_exports()
             .map(|exports| exports.map(str::to_string).collect::<Vec<_>>());
         let entry_usage = used.entry(*entry).or_default();
         if let Some(provided) = provided {
@@ -88,8 +88,8 @@ fn flag_dependency_usage(compilation: &mut Compilation) {
                     let previous_len = target.1.len();
                     let provided = compilation
                         .module_graph()
-                        .module(connection.module)
-                        .and_then(|module| module.exports_info().provided_exports())
+                        .exports_info(connection.module)
+                        .provided_exports()
                         .map(|exports| exports.map(str::to_string).collect::<BTreeSet<_>>());
                     target.1.extend(origin_usage.1.into_iter().filter(|name| {
                         name != "default"
@@ -107,12 +107,11 @@ fn flag_dependency_usage(compilation: &mut Compilation) {
     }
 
     for (handle, (all, names)) in used {
-        if let Some(module) = compilation.module_graph_mut().module_mut(handle) {
-            if all {
-                module.exports_info_mut().set_all_exports_used();
-            } else {
-                module.exports_info_mut().set_used_exports(Some(names));
-            }
+        let exports_info = compilation.module_graph_mut().exports_info_mut(handle);
+        if all {
+            exports_info.set_all_exports_used();
+        } else {
+            exports_info.set_used_exports(Some(names));
         }
     }
 }

--- a/crates/unpack_core/src/id_assignment.rs
+++ b/crates/unpack_core/src/id_assignment.rs
@@ -304,7 +304,7 @@ fn normalize_path(path: &Path) -> String {
 mod tests {
     use super::*;
     use crate::{
-        CacheOptions, CompilerOptions, Entry, ModuleGraph, ModuleIdentity, SnapshotOptions,
+        CacheOptions, CompilerOptions, Entry, ModuleIdentity, SnapshotOptions,
         cache::Cache,
         code_generation::{create_render_manifest, generate_code, render_assets},
     };
@@ -375,8 +375,13 @@ mod tests {
     fn emitted_unnamed_module_consumes_numeric_fallback() {
         let context = Path::new("/project");
         let options = CompilerOptions::new(context, vec![Entry::new("main", "./index")]);
-        let mut module_graph = ModuleGraph::default();
-        let module = add_built_module(&mut module_graph, ModuleIdentity::new(context), "unnamed");
+        let mut building_module_graph = crate::module_graph::BuildingModuleGraph::default();
+        let module = add_built_module(
+            &mut building_module_graph,
+            ModuleIdentity::new(context),
+            "unnamed",
+        );
+        let module_graph = building_module_graph.finish();
         let mut chunk_graph =
             crate::build_chunk_graph::build_chunk_graph(&options, &module_graph, &[module]);
         assign_module_render_ids(&options, &module_graph, &mut chunk_graph);
@@ -423,17 +428,18 @@ mod tests {
                 .map(|name| Entry::new(*name, format!("./{name}")))
                 .collect(),
         );
-        let mut module_graph = ModuleGraph::default();
+        let mut building_module_graph = crate::module_graph::BuildingModuleGraph::default();
         let mut modules_by_name = BTreeMap::new();
         for name in insertion_order {
             let identity = ModuleIdentity::new(context.join(format!("{name}.js")));
-            let module = add_built_module(&mut module_graph, identity, name);
+            let module = add_built_module(&mut building_module_graph, identity, name);
             modules_by_name.insert(*name, module);
         }
         let entries = entry_names
             .iter()
             .map(|name| modules_by_name[name])
             .collect::<Vec<_>>();
+        let module_graph = building_module_graph.finish();
         let mut chunk_graph =
             crate::build_chunk_graph::build_chunk_graph(&options, &module_graph, &entries);
         assign_module_render_ids(&options, &module_graph, &mut chunk_graph);
@@ -460,22 +466,24 @@ mod tests {
     }
 
     fn add_built_module(
-        module_graph: &mut ModuleGraph,
+        module_graph: &mut crate::module_graph::BuildingModuleGraph,
         identity: ModuleIdentity,
         value: &str,
     ) -> crate::ModuleHandle {
-        let module = module_graph.add_module(identity);
+        let module = module_graph.add_module(identity, None);
         let source = format!("const value = {value:?};");
         module_graph
-            .module_mut(module)
-            .expect("synthetic module should exist")
-            .finish_build(
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-                source.clone(),
-                stable_hash(&source),
-            );
+            .finish_module_build(
+                module,
+                crate::module::BuiltModuleContent::from_test_parts(
+                    Vec::new(),
+                    Vec::new(),
+                    Vec::new(),
+                    source.clone(),
+                    stable_hash(&source),
+                ),
+            )
+            .expect("synthetic module should exist");
         module
     }
 }

--- a/crates/unpack_core/src/javascript/javascript_generator.rs
+++ b/crates/unpack_core/src/javascript/javascript_generator.rs
@@ -49,7 +49,7 @@ pub(crate) fn generate(context: ModuleGeneratorContext<'_>) -> Result<CodeGenera
                     dependency_index,
                     module_graph,
                     chunk_graph,
-                    exports_info: module.exports_info(),
+                    exports_info: module_graph.exports_info(module_handle),
                     module_render_ids,
                     runtime_requirements: &mut runtime_requirements,
                     init_fragments: &mut init_fragments,

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -16,11 +16,12 @@ use tokio::sync::Mutex;
 
 use crate::{
     AsyncDependenciesBlockIndex, CompilerOptions, Dependency, DependencyIndex, EntryDependency,
-    Error, FactorizedModule, LoaderRequest, LoaderRunner, MatchedLoader, ModuleGraph, ModuleHandle,
+    Error, FactorizedModule, LoaderRequest, LoaderRunner, MatchedLoader, ModuleHandle,
     ModuleIdentity, NormalModuleFactory, Result, SnapshotStrategy, UnpackResolver,
     cache::{Cache, ModuleBuildRecord},
     cache_facade::{CacheETag, ModuleBuildCache},
     module::BuiltModuleContent,
+    module_graph::BuildingModuleGraph,
     normal_module_factory::{ModuleParserContext, ModuleSourceKind, ModuleTypeRegistry},
     parser::{JavascriptParserHookSet, ParsedModule},
     snapshot::{FileSystemInfo, SnapshotCache},
@@ -28,7 +29,7 @@ use crate::{
 
 #[derive(Debug, Default)]
 pub(crate) struct MakeState {
-    pub module_graph: ModuleGraph,
+    pub module_graph: BuildingModuleGraph,
     pub entries: BTreeMap<usize, ModuleHandle>,
     pub errors: Vec<Error>,
     pub file_dependencies: FxHashSet<PathBuf>,
@@ -862,10 +863,9 @@ impl MakeState {
             if let Some(module_handle) = self.modules_by_identity.get(&identity).copied() {
                 (module_handle, false)
             } else {
-                let module_handle = self.module_graph.add_module(identity.clone());
-                if let Some(module) = self.module_graph.module_mut(module_handle) {
-                    module.set_factory_side_effect_free(side_effect_free);
-                }
+                let module_handle = self
+                    .module_graph
+                    .add_module(identity.clone(), side_effect_free);
                 self.modules_by_identity.insert(identity, module_handle);
                 (module_handle, true)
             };
@@ -894,12 +894,8 @@ impl MakeState {
         module_handle: ModuleHandle,
         built_content: Arc<BuiltModuleContent>,
     ) -> Result<()> {
-        let module = self
-            .module_graph
-            .module_mut(module_handle)
-            .ok_or(Error::MissingModule(module_handle))?;
-        module.finish_build_content(built_content);
-        Ok(())
+        self.module_graph
+            .finish_module_build(module_handle, built_content)
     }
 
     fn fail_module(
@@ -908,11 +904,8 @@ impl MakeState {
         error: Error,
         source: String,
     ) -> Result<()> {
-        let module = self
-            .module_graph
-            .module_mut(module_handle)
-            .ok_or(Error::MissingModule(module_handle))?;
-        module.fail_build(error.clone(), source);
+        self.module_graph
+            .fail_module(module_handle, error.clone(), source)?;
         self.errors.push(error);
         Ok(())
     }
@@ -959,7 +952,7 @@ mod tests {
 
         let cache = cache.stats();
         let state = state.lock().await;
-        let graph = &state.module_graph;
+        let graph = state.module_graph.clone().finish();
         let dep = graph
             .modules()
             .iter()

--- a/crates/unpack_core/src/module.rs
+++ b/crates/unpack_core/src/module.rs
@@ -39,10 +39,19 @@ impl crate::index_vec::Idx for ModuleHandle {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Module {
+    data: ModuleData,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BuildingModule {
+    data: ModuleData,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ModuleData {
     handle: ModuleHandle,
     identity: ModuleIdentity,
     built_content: Arc<BuiltModuleContent>,
-    exports_info: ExportsInfo,
     build_error: Option<Error>,
     harmony: bool,
     factory_side_effect_free: Option<bool>,
@@ -76,6 +85,26 @@ impl BuiltModuleContent {
         source_hash: u64,
     ) -> Self {
         Self::from_persistent_parts_with_binary(parsed, source, None, source_hash)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_test_parts(
+        dependencies: Vec<Dependency>,
+        blocks: Vec<AsyncDependenciesBlock>,
+        presentational_dependencies: Vec<Dependency>,
+        source: String,
+        source_hash: u64,
+    ) -> Arc<Self> {
+        Arc::new(Self::from_persistent_parts(
+            ParsedModule {
+                dependencies_block: crate::DependenciesBlock::new(dependencies, blocks),
+                presentational_dependencies,
+                data: crate::parser::ParsedModuleData::JavaScript,
+                build_meta: Default::default(),
+            },
+            source,
+            source_hash,
+        ))
     }
 
     pub(crate) fn from_persistent_parts_with_binary(
@@ -120,137 +149,132 @@ impl BuiltModuleContent {
     }
 }
 
-impl Module {
+impl BuildingModule {
     pub(crate) fn new(handle: ModuleHandle, identity: ModuleIdentity) -> Self {
         Self {
-            handle,
-            identity,
-            built_content: Arc::new(BuiltModuleContent::new(
-                ParsedModule::default(),
-                String::new(),
-            )),
-            exports_info: ExportsInfo::default(),
-            build_error: None,
-            harmony: false,
-            factory_side_effect_free: None,
-            build_side_effect_free: None,
+            data: ModuleData {
+                handle,
+                identity,
+                built_content: Arc::new(BuiltModuleContent::new(
+                    ParsedModule::default(),
+                    String::new(),
+                )),
+                build_error: None,
+                harmony: false,
+                factory_side_effect_free: None,
+                build_side_effect_free: None,
+            },
         }
     }
 
-    pub fn handle(&self) -> ModuleHandle {
-        self.handle
-    }
-
-    pub fn identity(&self) -> &ModuleIdentity {
-        &self.identity
-    }
-
-    pub fn dependencies(&self) -> &[Dependency] {
-        self.built_content.parsed.dependencies_block.dependencies()
-    }
-
-    pub fn blocks(&self) -> &[AsyncDependenciesBlock] {
-        self.built_content.parsed.dependencies_block.blocks()
-    }
-
-    pub fn presentational_dependencies(&self) -> &[Dependency] {
-        &self.built_content.parsed.presentational_dependencies
-    }
-
-    pub fn exports_info(&self) -> &ExportsInfo {
-        &self.exports_info
-    }
-
-    pub(crate) fn exports_info_mut(&mut self) -> &mut ExportsInfo {
-        &mut self.exports_info
-    }
-
-    pub fn source(&self) -> &str {
-        self.built_content.source()
-    }
-
-    pub fn source_len(&self) -> usize {
-        self.built_content.source.len()
-    }
-
-    pub fn source_hash(&self) -> u64 {
-        self.built_content.source_hash()
-    }
-
-    pub(crate) fn source_bytes(&self) -> &[u8] {
-        self.built_content
-            .binary_source()
-            .unwrap_or_else(|| self.source().as_bytes())
-    }
-
-    pub(crate) fn code_generation_local_input_digest(&self) -> u64 {
-        self.built_content.code_generation_local_input_digest()
-    }
-
-    pub(crate) fn parsed_data(&self) -> &crate::parser::ParsedModuleData {
-        &self.built_content.parsed().data
-    }
-
-    #[cfg(test)]
-    pub(crate) fn built_content(&self) -> &Arc<BuiltModuleContent> {
-        &self.built_content
-    }
-
-    pub fn build_error(&self) -> Option<&Error> {
-        self.build_error.as_ref()
-    }
-
-    pub(crate) fn is_harmony(&self) -> bool {
-        self.harmony
-    }
-
-    pub(crate) fn is_side_effect_free(&self) -> bool {
-        self.factory_side_effect_free
-            .or(self.build_side_effect_free)
-            .unwrap_or(false)
+    pub(crate) fn handle(&self) -> ModuleHandle {
+        self.data.handle
     }
 
     pub(crate) fn set_factory_side_effect_free(&mut self, side_effect_free: Option<bool>) {
-        self.factory_side_effect_free = side_effect_free;
-    }
-
-    #[cfg(test)]
-    pub(crate) fn finish_build(
-        &mut self,
-        dependencies: Vec<Dependency>,
-        blocks: Vec<AsyncDependenciesBlock>,
-        presentational_dependencies: Vec<Dependency>,
-        source: String,
-        source_hash: u64,
-    ) {
-        self.finish_build_content(Arc::new(BuiltModuleContent::from_persistent_parts(
-            ParsedModule {
-                dependencies_block: crate::DependenciesBlock::new(dependencies, blocks),
-                presentational_dependencies,
-                data: crate::parser::ParsedModuleData::JavaScript,
-                build_meta: Default::default(),
-            },
-            source,
-            source_hash,
-        )));
+        self.data.factory_side_effect_free = side_effect_free;
     }
 
     pub(crate) fn finish_build_content(&mut self, content: Arc<BuiltModuleContent>) {
-        self.exports_info = ExportsInfo::default();
-        self.build_side_effect_free = content.parsed.build_meta.side_effect_free;
-        self.harmony = content
+        self.data.build_side_effect_free = content.parsed.build_meta.side_effect_free;
+        self.data.harmony = content
             .parsed
             .dependencies_block
             .dependencies()
             .iter()
             .chain(&content.parsed.presentational_dependencies)
             .any(Dependency::is_harmony_dependency);
-        self.built_content = content;
-        self.build_error = None;
+        self.data.built_content = content;
+        self.data.build_error = None;
     }
 
-    pub(crate) fn analyze_provided_exports(&mut self) {
-        self.exports_info = match self.parsed_data() {
+    pub(crate) fn fail_build(&mut self, error: Error, source: String) {
+        self.data.built_content =
+            Arc::new(BuiltModuleContent::new(ParsedModule::default(), source));
+        self.data.build_error = Some(error);
+        self.data.build_side_effect_free = None;
+        self.data.harmony = false;
+    }
+
+    pub(crate) fn finish(self) -> Module {
+        Module { data: self.data }
+    }
+}
+
+impl Module {
+    pub fn handle(&self) -> ModuleHandle {
+        self.data.handle
+    }
+
+    pub fn identity(&self) -> &ModuleIdentity {
+        &self.data.identity
+    }
+
+    pub fn dependencies(&self) -> &[Dependency] {
+        self.data
+            .built_content
+            .parsed
+            .dependencies_block
+            .dependencies()
+    }
+
+    pub fn blocks(&self) -> &[AsyncDependenciesBlock] {
+        self.data.built_content.parsed.dependencies_block.blocks()
+    }
+
+    pub fn presentational_dependencies(&self) -> &[Dependency] {
+        &self.data.built_content.parsed.presentational_dependencies
+    }
+
+    pub fn source(&self) -> &str {
+        self.data.built_content.source()
+    }
+
+    pub fn source_len(&self) -> usize {
+        self.data.built_content.source.len()
+    }
+
+    pub fn source_hash(&self) -> u64 {
+        self.data.built_content.source_hash()
+    }
+
+    pub(crate) fn source_bytes(&self) -> &[u8] {
+        self.data
+            .built_content
+            .binary_source()
+            .unwrap_or_else(|| self.source().as_bytes())
+    }
+
+    pub(crate) fn code_generation_local_input_digest(&self) -> u64 {
+        self.data.built_content.code_generation_local_input_digest()
+    }
+
+    pub(crate) fn parsed_data(&self) -> &crate::parser::ParsedModuleData {
+        &self.data.built_content.parsed().data
+    }
+
+    #[cfg(test)]
+    pub(crate) fn built_content(&self) -> &Arc<BuiltModuleContent> {
+        &self.data.built_content
+    }
+
+    pub fn build_error(&self) -> Option<&Error> {
+        self.data.build_error.as_ref()
+    }
+
+    pub(crate) fn is_harmony(&self) -> bool {
+        self.data.harmony
+    }
+
+    pub(crate) fn is_side_effect_free(&self) -> bool {
+        self.data
+            .factory_side_effect_free
+            .or(self.data.build_side_effect_free)
+            .unwrap_or(false)
+    }
+
+    pub(crate) fn provided_exports(&self) -> ExportsInfo {
+        match self.parsed_data() {
             crate::parser::ParsedModuleData::Json(value) => {
                 let mut names = vec!["default".to_string()];
                 if let serde_json::Value::Object(object) = value {
@@ -262,17 +286,13 @@ impl Module {
                 ExportsInfo::from_names(["default".to_string()])
             }
             crate::parser::ParsedModuleData::JavaScript => ExportsInfo::from_dependencies(
-                self.built_content.parsed.dependencies_block.dependencies(),
+                self.data
+                    .built_content
+                    .parsed
+                    .dependencies_block
+                    .dependencies(),
             ),
-        };
-    }
-
-    pub(crate) fn fail_build(&mut self, error: Error, source: String) {
-        self.exports_info = ExportsInfo::default();
-        self.built_content = Arc::new(BuiltModuleContent::new(ParsedModule::default(), source));
-        self.build_error = Some(error);
-        self.build_side_effect_free = None;
-        self.harmony = false;
+        }
     }
 }
 

--- a/crates/unpack_core/src/module_computation_cache.rs
+++ b/crates/unpack_core/src/module_computation_cache.rs
@@ -379,12 +379,9 @@ fn post_id_assignment_signature(
     chunk_graph: &ChunkGraph,
     handle: ModuleHandle,
 ) -> PostIdAssignmentSignature {
-    let module = module_graph
-        .module(handle)
-        .expect("a Module Graph handle should address a Module");
     PostIdAssignmentSignature {
         references: chunk_graph.module_references(module_graph, handle),
-        exports_info: module.exports_info().clone(),
+        exports_info: module_graph.exports_info(handle).clone(),
     }
 }
 

--- a/crates/unpack_core/src/module_graph.rs
+++ b/crates/unpack_core/src/module_graph.rs
@@ -1,21 +1,48 @@
 // Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/ModuleGraph.js
 
+use std::sync::Arc;
+
 use rustc_hash::FxHashMap;
 
-use crate::index_vec::IndexVec;
 use crate::{
-    Dependency, Module, ModuleGraphConnection, ModuleGraphConnectionHandle,
-    ModuleGraphConnectionState, ModuleHandle, ModuleIdentity,
+    Dependency, Error, ExportsInfo, Module, ModuleGraphConnection, ModuleGraphConnectionHandle,
+    ModuleGraphConnectionState, ModuleHandle, ModuleIdentity, module::BuildingModule,
 };
+use crate::{index_vec::IndexVec, module::BuiltModuleContent};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct ModuleGraph {
-    modules: Vec<Module>,
+    storage: ModuleGraphStorage<Module>,
+    exports_info: IndexVec<ModuleHandle, ExportsInfo>,
+}
+
+/// Make-owned graph state. Consuming `finish` is the only way to obtain the
+/// immutable `ModuleGraph` used by finishModules and sealing.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct BuildingModuleGraph {
+    storage: ModuleGraphStorage<BuildingModule>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ModuleGraphStorage<M> {
+    modules: Vec<M>,
     connections: Vec<ModuleGraphConnection>,
     outgoing: IndexVec<ModuleHandle, Vec<ModuleGraphConnectionHandle>>,
     incoming: IndexVec<ModuleHandle, Vec<ModuleGraphConnectionHandle>>,
     outgoing_by_location:
         IndexVec<ModuleHandle, FxHashMap<DependencyLocation, ModuleGraphConnectionHandle>>,
+}
+
+impl<M> Default for ModuleGraphStorage<M> {
+    fn default() -> Self {
+        Self {
+            modules: Vec::new(),
+            connections: Vec::new(),
+            outgoing: IndexVec::default(),
+            incoming: IndexVec::default(),
+            outgoing_by_location: IndexVec::default(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -45,70 +72,28 @@ impl AsyncDependenciesBlockIndex {
 }
 
 impl ModuleGraph {
-    pub(crate) fn add_module(&mut self, identity: ModuleIdentity) -> ModuleHandle {
-        let handle = ModuleHandle::new(self.modules.len());
-        self.modules.push(Module::new(handle, identity));
-        let outgoing_handle = self.outgoing.push(Vec::new());
-        let incoming_handle = self.incoming.push(Vec::new());
-        let location_handle = self.outgoing_by_location.push(FxHashMap::default());
-        debug_assert_eq!(outgoing_handle, handle);
-        debug_assert_eq!(incoming_handle, handle);
-        debug_assert_eq!(location_handle, handle);
-        handle
+    pub fn exports_info(&self, handle: ModuleHandle) -> &ExportsInfo {
+        &self.exports_info[handle]
     }
 
-    pub(crate) fn module_mut(&mut self, handle: ModuleHandle) -> Option<&mut Module> {
-        self.modules.get_mut(handle.index())
-    }
-
-    pub(crate) fn connect(
-        &mut self,
-        origin_module: Option<ModuleHandle>,
-        origin_block: Option<AsyncDependenciesBlockIndex>,
-        origin_dependency_index: Option<DependencyIndex>,
-        dependency: Dependency,
-        module: ModuleHandle,
-    ) {
-        let connection_handle = ModuleGraphConnectionHandle::new(self.connections.len());
-        self.connections.push(ModuleGraphConnection {
-            handle: connection_handle,
-            origin_module,
-            origin_block,
-            origin_dependency_index,
-            dependency,
-            resolved_module: module,
-            module,
-            state: ModuleGraphConnectionState::Active,
-        });
-        if let Some(origin_module) = origin_module {
-            self.outgoing[origin_module].push(connection_handle);
-            if let Some(dependency_index) = origin_dependency_index {
-                self.outgoing_by_location[origin_module].insert(
-                    DependencyLocation {
-                        block: origin_block,
-                        dependency_index,
-                    },
-                    connection_handle,
-                );
-            }
-        }
-        self.incoming[module].push(connection_handle);
+    pub(crate) fn exports_info_mut(&mut self, handle: ModuleHandle) -> &mut ExportsInfo {
+        &mut self.exports_info[handle]
     }
 
     pub fn modules(&self) -> &[Module] {
-        &self.modules
+        &self.storage.modules
     }
 
     pub fn module(&self, handle: ModuleHandle) -> Option<&Module> {
-        self.modules.get(handle.index())
+        self.storage.modules.get(handle.index())
     }
 
     pub fn connections(&self) -> &[ModuleGraphConnection] {
-        &self.connections
+        &self.storage.connections
     }
 
     pub(crate) fn connections_mut(&mut self) -> &mut [ModuleGraphConnection] {
-        &mut self.connections
+        &mut self.storage.connections
     }
 
     pub(crate) fn update_connection_module(
@@ -116,12 +101,12 @@ impl ModuleGraph {
         handle: ModuleGraphConnectionHandle,
         module: ModuleHandle,
     ) {
-        let connection = &mut self.connections[handle.index()];
+        let connection = &mut self.storage.connections[handle.index()];
         if connection.module == module {
             return;
         }
-        self.incoming[connection.module].retain(|candidate| *candidate != handle);
-        self.incoming[module].push(handle);
+        self.storage.incoming[connection.module].retain(|candidate| *candidate != handle);
+        self.storage.incoming[module].push(handle);
         connection.module = module;
     }
 
@@ -129,25 +114,25 @@ impl ModuleGraph {
         &mut self,
         handle: ModuleGraphConnectionHandle,
     ) -> &mut ModuleGraphConnection {
-        &mut self.connections[handle.index()]
+        &mut self.storage.connections[handle.index()]
     }
 
     pub fn outgoing_connections(
         &self,
         module: ModuleHandle,
     ) -> impl Iterator<Item = &ModuleGraphConnection> {
-        self.outgoing[module]
+        self.storage.outgoing[module]
             .iter()
-            .map(|connection_handle| &self.connections[connection_handle.index()])
+            .map(|connection_handle| &self.storage.connections[connection_handle.index()])
     }
 
     pub fn incoming_connections(
         &self,
         module: ModuleHandle,
     ) -> impl Iterator<Item = &ModuleGraphConnection> {
-        self.incoming[module]
+        self.storage.incoming[module]
             .iter()
-            .map(|connection_handle| &self.connections[connection_handle.index()])
+            .map(|connection_handle| &self.storage.connections[connection_handle.index()])
     }
 
     pub fn module_for_dependency(
@@ -160,10 +145,119 @@ impl ModuleGraph {
             block: origin_block,
             dependency_index,
         };
-        self.outgoing_by_location
+        self.storage
+            .outgoing_by_location
             .get(origin_module)?
             .get(&location)
-            .map(|connection_handle| self.connections[connection_handle.index()].module)
+            .map(|connection_handle| self.storage.connections[connection_handle.index()].module)
+    }
+}
+
+impl BuildingModuleGraph {
+    pub(crate) fn add_module(
+        &mut self,
+        identity: ModuleIdentity,
+        factory_side_effect_free: Option<bool>,
+    ) -> ModuleHandle {
+        let handle = ModuleHandle::new(self.storage.modules.len());
+        let mut module = BuildingModule::new(handle, identity);
+        module.set_factory_side_effect_free(factory_side_effect_free);
+        self.storage.modules.push(module);
+        let outgoing_handle = self.storage.outgoing.push(Vec::new());
+        let incoming_handle = self.storage.incoming.push(Vec::new());
+        let location_handle = self.storage.outgoing_by_location.push(FxHashMap::default());
+        debug_assert_eq!(outgoing_handle, handle);
+        debug_assert_eq!(incoming_handle, handle);
+        debug_assert_eq!(location_handle, handle);
+        handle
+    }
+
+    pub(crate) fn connect(
+        &mut self,
+        origin_module: Option<ModuleHandle>,
+        origin_block: Option<AsyncDependenciesBlockIndex>,
+        origin_dependency_index: Option<DependencyIndex>,
+        dependency: Dependency,
+        module: ModuleHandle,
+    ) {
+        let connection_handle = ModuleGraphConnectionHandle::new(self.storage.connections.len());
+        self.storage.connections.push(ModuleGraphConnection {
+            handle: connection_handle,
+            origin_module,
+            origin_block,
+            origin_dependency_index,
+            dependency,
+            resolved_module: module,
+            module,
+            state: ModuleGraphConnectionState::Active,
+        });
+        if let Some(origin_module) = origin_module {
+            self.storage.outgoing[origin_module].push(connection_handle);
+            if let Some(dependency_index) = origin_dependency_index {
+                self.storage.outgoing_by_location[origin_module].insert(
+                    DependencyLocation {
+                        block: origin_block,
+                        dependency_index,
+                    },
+                    connection_handle,
+                );
+            }
+        }
+        self.storage.incoming[module].push(connection_handle);
+    }
+
+    pub(crate) fn finish_module_build(
+        &mut self,
+        handle: ModuleHandle,
+        content: Arc<BuiltModuleContent>,
+    ) -> Result<(), Error> {
+        let module = self
+            .storage
+            .modules
+            .get_mut(handle.index())
+            .ok_or(Error::MissingModule(handle))?;
+        module.finish_build_content(content);
+        Ok(())
+    }
+
+    pub(crate) fn fail_module(
+        &mut self,
+        handle: ModuleHandle,
+        error: Error,
+        source: String,
+    ) -> Result<(), Error> {
+        let module = self
+            .storage
+            .modules
+            .get_mut(handle.index())
+            .ok_or(Error::MissingModule(handle))?;
+        module.fail_build(error, source);
+        Ok(())
+    }
+
+    pub(crate) fn finish(self) -> ModuleGraph {
+        let mut exports_info = IndexVec::default();
+        for module in &self.storage.modules {
+            let handle = exports_info.push(ExportsInfo::default());
+            debug_assert_eq!(handle, module.handle());
+        }
+        let ModuleGraphStorage {
+            modules,
+            connections,
+            outgoing,
+            incoming,
+            outgoing_by_location,
+        } = self.storage;
+        ModuleGraph {
+            storage: ModuleGraphStorage {
+                modules: modules.into_iter().map(BuildingModule::finish).collect(),
+                connections,
+                outgoing,
+                incoming,
+                outgoing_by_location,
+            },
+            exports_info,
+        }
     }
 }
 
@@ -175,13 +269,15 @@ struct DependencyLocation {
 
 #[cfg(test)]
 mod tests {
-    use super::ModuleGraph;
+    use super::BuildingModuleGraph;
     use crate::ModuleIdentity;
 
     #[test]
     fn adding_a_module_initializes_its_connection_indices() {
-        let mut module_graph = ModuleGraph::default();
-        let module = module_graph.add_module(ModuleIdentity::new("/project/src/index.js"));
+        let mut building_module_graph = BuildingModuleGraph::default();
+        let module =
+            building_module_graph.add_module(ModuleIdentity::new("/project/src/index.js"), None);
+        let module_graph = building_module_graph.finish();
 
         assert_eq!(module_graph.outgoing_connections(module).count(), 0);
         assert_eq!(module_graph.incoming_connections(module).count(), 0);

--- a/crates/unpack_core/src/optimize/side_effects_flag_plugin.rs
+++ b/crates/unpack_core/src/optimize/side_effects_flag_plugin.rs
@@ -243,8 +243,8 @@ fn connection_is_active(
             dependency.name.as_ref().is_some_and(|name| {
                 connection.origin_module.is_some_and(|origin| {
                     module_graph
-                        .module(origin)
-                        .and_then(|module| module.exports_info().get_used_name(name))
+                        .exports_info(origin)
+                        .get_used_name(name)
                         .is_some()
                 })
             }) || (dependency.is_star && module_exports_are_used(module_graph, connection.module))
@@ -254,13 +254,11 @@ fn connection_is_active(
 }
 
 fn module_exports_are_used(module_graph: &ModuleGraph, handle: ModuleHandle) -> bool {
-    module_graph.module(handle).is_some_and(|module| {
-        module.exports_info().are_all_exports_used()
-            || module
-                .exports_info()
-                .used_exports()
-                .is_some_and(|mut used| used.next().is_some())
-    })
+    let exports_info = module_graph.exports_info(handle);
+    exports_info.are_all_exports_used()
+        || exports_info
+            .used_exports()
+            .is_some_and(|mut used| used.next().is_some())
 }
 
 fn module_has_side_effects(module_graph: &ModuleGraph, handle: ModuleHandle) -> bool {

--- a/crates/unpack_core/tests/make.rs
+++ b/crates/unpack_core/tests/make.rs
@@ -79,7 +79,9 @@ async fn make_constructs_static_esm_module_graph() -> Result<(), Box<dyn std::er
         .find(|module| module.identity().resource.ends_with("dep.ts"))
         .expect("dep module should exist");
     assert_eq!(
-        dep_module.exports_info().is_export_provided("value"),
+        graph
+            .exports_info(dep_module.handle())
+            .is_export_provided("value"),
         Some(true)
     );
 

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -357,11 +357,11 @@ impl Drop for NativeCompilation {
 impl NativeCompilation {
     #[napi]
     pub fn modules(&self) -> Result<Vec<NativeModule>> {
-        Ok(self
-            .module_graph()?
+        let module_graph = self.module_graph()?;
+        Ok(module_graph
             .modules()
             .iter()
-            .map(native_module)
+            .map(|module| native_module(module_graph, module))
             .collect())
     }
 
@@ -1310,7 +1310,7 @@ fn native_module_graph_connection(
     }
 }
 
-fn native_module(module: &Module) -> NativeModule {
+fn native_module(module_graph: &unpack_core::ModuleGraph, module: &Module) -> NativeModule {
     let identity = module.identity();
     let resource = format!(
         "{}{}{}",
@@ -1331,21 +1331,20 @@ fn native_module(module: &Module) -> NativeModule {
         ModuleType::AssetInline => "asset/inline",
         ModuleType::AssetSource => "asset/source",
     };
+    let exports_info = module_graph.exports_info(module.handle());
 
     NativeModule {
         handle: native_module_handle(module.handle()),
         identifier: format!("{module_type}|{request}"),
         resource,
         module_type: module_type.to_string(),
-        provided_exports: module
-            .exports_info()
+        provided_exports: exports_info
             .provided_exports()
             .map(|exports| exports.map(str::to_string).collect()),
-        used_exports: module
-            .exports_info()
+        used_exports: exports_info
             .used_exports()
             .map(|exports| exports.map(str::to_string).collect()),
-        all_exports_used: module.exports_info().are_all_exports_used(),
+        all_exports_used: exports_info.are_all_exports_used(),
     }
 }
 

--- a/docs/adr/0147-freeze-modules-before-the-finished-modules-boundary.md
+++ b/docs/adr/0147-freeze-modules-before-the-finished-modules-boundary.md
@@ -1,0 +1,30 @@
+# Freeze Modules before the Finished Modules Boundary
+
+Unpack will represent Make-time Module construction with `BuildingModule`
+values in a Make-owned `BuildingModuleGraph`. Make consumes those values into
+`Module` values in the Compilation's `ModuleGraph`; the resulting `Module`
+type exposes no mutation interface.
+Consequently all internal and host `finishModules` hooks, sealing phases, and
+later lifecycle work can read Module build state but cannot mutate it through
+the Rust type system.
+
+`ExportsInfo` is Compilation-specific graph analysis rather than Module build
+state. It is indexed by `ModuleHandle` and owned by `ModuleGraph`, matching
+webpack's responsibility boundary. `FlagDependencyExportsPlugin` may write its
+provided-export state during `finish_modules`, and
+`FlagDependencyUsagePlugin` may write its used-export state during
+`optimize_dependencies`; these mutations do not mutate `Module` values.
+Render IDs, chunk membership, Module Hashes, Code Generation Results, and
+assets remain in their existing Compilation-owned phase structures.
+
+The Finished Modules Boundary remains after both the internal and awaited host
+`finishModules` work. Modules are currently frozen slightly earlier, when Make
+consumes `BuildingModuleGraph`, which gives the boundary the stronger invariant
+without removing the webpack-shaped hook timing. A future webpack-compatible
+surface that requires post-build Module transformation must model that work as
+an explicit transform result or supersede this decision rather than restoring
+a general `ModuleGraph::module_mut` escape hatch.
+
+This refines ADR 0025's Exports Info model and ADR 0139's Module Computation
+Cache inputs by assigning Exports Info to Module Graph metadata; their phase
+ordering and cache semantics remain unchanged.


### PR DESCRIPTION
## Summary

- introduce distinct `BuildingModule` and `Module` types with a consuming Make-time transition
- move `ExportsInfo` from Module build state into Module Graph metadata
- prevent `finishModules` and sealing phases from obtaining mutable Module values through the Rust type system
- document the Finished Modules Boundary and its ownership rules in the domain glossary and ADR 0147

## Why

Module build state previously remained mutable after Make because export analysis lived directly on `Module`. Separating Make-owned construction from the completed Module type gives later compilation phases a clear immutable input while preserving mutable, Compilation-specific graph analysis.

## Tests

- `cargo check --workspace`
- `cargo test -p unpack_core --no-fail-fast`
- `pnpm test`
