### PR TITLE
Implement loader loadModule and importModule APIs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -224,6 +224,18 @@ _Avoid_: Template prefix, runtime snippet
 A dependency declared by an ECMAScript `import()` expression whose specifier is known before code execution.
 _Avoid_: Lazy import, runtime import
 
+**Loader Module Request**:
+A module request issued while a loader is running through `this.loadModule` or
+`this.importModule`. It is resolved from the current resource, participates in
+the same Compilation's Module Graph and dependency snapshots, and may itself be
+transformed by a matching configured loader.
+_Avoid_: Loader filesystem read, detached import
+
+**Build-Time Module Execution**:
+Execution requested by a loader through `this.importModule` so the loader can
+consume a requested module's exports while building the current module.
+_Avoid_: Runtime dynamic import, Node require
+
 **Async Split Point**:
 A module graph edge introduced by a dynamic import dependency where the target module should belong to asynchronously loaded bundle output.
 _Avoid_: Lazy boundary, chunk trigger

--- a/crates/unpack_core/src/cache/pack_file.rs
+++ b/crates/unpack_core/src/cache/pack_file.rs
@@ -2327,6 +2327,12 @@ pub(crate) enum DependencyDto {
     Import {
         module: ModuleDependencyDto,
     },
+    Loader {
+        module: ModuleDependencyDto,
+    },
+    LoaderImport {
+        module: ModuleDependencyDto,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3061,6 +3067,12 @@ fn dependency_to_dto(dependency: &Dependency) -> io::Result<DependencyDto> {
         Dependency::Import(dependency) => DependencyDto::Import {
             module: module_dependency_to_dto(&dependency.module)?,
         },
+        Dependency::Loader(dependency) => DependencyDto::Loader {
+            module: module_dependency_to_dto(&dependency.module)?,
+        },
+        Dependency::LoaderImport(dependency) => DependencyDto::LoaderImport {
+            module: module_dependency_to_dto(&dependency.module)?,
+        },
     })
 }
 
@@ -3126,6 +3138,14 @@ fn dependency_from_dto(dependency: DependencyDto) -> io::Result<Dependency> {
         DependencyDto::Import { module } => Dependency::Import(ImportDependency {
             module: module_dependency_from_dto(module)?,
         }),
+        DependencyDto::Loader { module } => Dependency::Loader(crate::LoaderDependency {
+            module: module_dependency_from_dto(module)?,
+        }),
+        DependencyDto::LoaderImport { module } => {
+            Dependency::LoaderImport(crate::LoaderImportDependency {
+                module: module_dependency_from_dto(module)?,
+            })
+        }
     })
 }
 
@@ -3631,6 +3651,14 @@ fn encode_dependency(encoder: &mut Encoder, dependency: &DependencyDto) -> io::R
             encoder.write_u8(9);
             encode_module_dependency(encoder, module)
         }
+        DependencyDto::Loader { module } => {
+            encoder.write_u8(10);
+            encode_module_dependency(encoder, module)
+        }
+        DependencyDto::LoaderImport { module } => {
+            encoder.write_u8(11);
+            encode_module_dependency(encoder, module)
+        }
     }
 }
 
@@ -3675,6 +3703,12 @@ fn decode_dependency(decoder: &mut Decoder<'_>) -> Option<DependencyDto> {
             range: decode_source_range(decoder)?,
         },
         9 => DependencyDto::Import {
+            module: decode_module_dependency(decoder)?,
+        },
+        10 => DependencyDto::Loader {
+            module: decode_module_dependency(decoder)?,
+        },
+        11 => DependencyDto::LoaderImport {
             module: decode_module_dependency(decoder)?,
         },
         _ => return None,
@@ -3758,6 +3792,8 @@ fn dependency_ranges_are_valid(dependency: &DependencyDto, source: &str) -> bool
     };
     match dependency {
         DependencyDto::Entry { module }
+        | DependencyDto::Loader { module }
+        | DependencyDto::LoaderImport { module }
         | DependencyDto::HarmonyImportSideEffect { module, .. }
         | DependencyDto::HarmonyExportImportedSpecifier { module, .. } => {
             module_range_is_valid(module)

--- a/crates/unpack_core/src/dependencies/loader_dependency.rs
+++ b/crates/unpack_core/src/dependencies/loader_dependency.rs
@@ -1,0 +1,18 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/dependencies/LoaderDependency.js
+
+use serde::{Deserialize, Serialize};
+
+use super::ModuleDependency;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct LoaderDependency {
+    pub module: ModuleDependency,
+}
+
+impl LoaderDependency {
+    pub fn new(request: impl Into<String>) -> Self {
+        Self {
+            module: ModuleDependency::new(request, None),
+        }
+    }
+}

--- a/crates/unpack_core/src/dependencies/loader_import_dependency.rs
+++ b/crates/unpack_core/src/dependencies/loader_import_dependency.rs
@@ -1,0 +1,18 @@
+// Webpack source: https://github.com/webpack/webpack/blob/da91761ed92c8e133ee321c7db4ad6c4698cae0a/lib/dependencies/LoaderImportDependency.js
+
+use serde::{Deserialize, Serialize};
+
+use super::ModuleDependency;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct LoaderImportDependency {
+    pub module: ModuleDependency,
+}
+
+impl LoaderImportDependency {
+    pub fn new(request: impl Into<String>) -> Self {
+        let mut module = ModuleDependency::new(request, None);
+        module.weak = true;
+        Self { module }
+    }
+}

--- a/crates/unpack_core/src/dependencies/mod.rs
+++ b/crates/unpack_core/src/dependencies/mod.rs
@@ -9,6 +9,8 @@ mod harmony_export_specifier_dependency;
 mod harmony_import_side_effect_dependency;
 mod harmony_import_specifier_dependency;
 mod import_dependency;
+mod loader_dependency;
+mod loader_import_dependency;
 mod module_dependency;
 mod null_dependency;
 
@@ -21,6 +23,8 @@ pub use harmony_export_specifier_dependency::HarmonyExportSpecifierDependency;
 pub use harmony_import_side_effect_dependency::HarmonyImportSideEffectDependency;
 pub use harmony_import_specifier_dependency::HarmonyImportSpecifierDependency;
 pub use import_dependency::ImportDependency;
+pub use loader_dependency::LoaderDependency;
+pub use loader_import_dependency::LoaderImportDependency;
 pub use module_dependency::ModuleDependency;
 pub use null_dependency::NullDependency;
 

--- a/crates/unpack_core/src/dependency.rs
+++ b/crates/unpack_core/src/dependency.rs
@@ -11,7 +11,8 @@ use crate::dependencies::{
     HarmonyExportSpecifierDependencyTemplate, HarmonyImportSideEffectDependency,
     HarmonyImportSideEffectDependencyTemplate, HarmonyImportSpecifierDependency,
     HarmonyImportSpecifierDependencyTemplate, ImportDependency, ImportDependencyTemplate,
-    ModuleDependency, NullDependency, NullDependencyTemplate,
+    LoaderDependency, LoaderImportDependency, ModuleDependency, NullDependency,
+    NullDependencyTemplate,
 };
 use crate::dependency_template::{DependencyTemplateContext, apply_dependency_template};
 use crate::{ExportsInfo, cache_hash::StableHasher};
@@ -51,6 +52,8 @@ pub enum Dependency {
     Null(NullDependency),
     Const(ConstDependency),
     Import(ImportDependency),
+    Loader(LoaderDependency),
+    LoaderImport(LoaderImportDependency),
 }
 
 impl Dependency {
@@ -62,6 +65,8 @@ impl Dependency {
             }
             Self::HarmonyExportImportedSpecifier(_) => DependencyKind::StaticExport,
             Self::Import(_) => DependencyKind::DynamicImport,
+            Self::Loader(_) => DependencyKind::Loader,
+            Self::LoaderImport(_) => DependencyKind::LoaderImport,
             Self::HarmonyExportHeader(_)
             | Self::HarmonyExportSpecifier(_)
             | Self::HarmonyExportExpression(_)
@@ -92,6 +97,8 @@ impl Dependency {
             Self::HarmonyImportSpecifier(dep) => Some(&dep.module),
             Self::HarmonyExportImportedSpecifier(dep) => Some(&dep.module),
             Self::Import(dep) => Some(&dep.module),
+            Self::Loader(dep) => Some(&dep.module),
+            Self::LoaderImport(dep) => Some(&dep.module),
             Self::HarmonyExportHeader(_)
             | Self::HarmonyExportSpecifier(_)
             | Self::HarmonyExportExpression(_)
@@ -182,6 +189,7 @@ impl Dependency {
             Self::Import(dependency) => {
                 apply_dependency_template(&ImportDependencyTemplate, dependency, source, context)
             }
+            Self::Loader(_) | Self::LoaderImport(_) => Ok(()),
         }
     }
 
@@ -218,5 +226,7 @@ pub enum DependencyKind {
     StaticImport,
     StaticExport,
     DynamicImport,
+    Loader,
+    LoaderImport,
     Presentational,
 }

--- a/crates/unpack_core/src/exports_info.rs
+++ b/crates/unpack_core/src/exports_info.rs
@@ -47,7 +47,9 @@ impl ExportsInfo {
                 | Dependency::HarmonyExportHeader(_)
                 | Dependency::Null(_)
                 | Dependency::Const(_)
-                | Dependency::Import(_) => {}
+                | Dependency::Import(_)
+                | Dependency::Loader(_)
+                | Dependency::LoaderImport(_) => {}
             }
         }
         exports_info

--- a/crates/unpack_core/src/lib.rs
+++ b/crates/unpack_core/src/lib.rs
@@ -60,14 +60,18 @@ pub use dependencies::{
     ConstDependency, EntryDependency, HarmonyExportExpressionDependency,
     HarmonyExportHeaderDependency, HarmonyExportImportedSpecifierDependency,
     HarmonyExportSpecifierDependency, HarmonyImportSideEffectDependency,
-    HarmonyImportSpecifierDependency, ImportDependency, ModuleDependency, NullDependency,
+    HarmonyImportSpecifierDependency, ImportDependency, LoaderDependency, LoaderImportDependency,
+    ModuleDependency, NullDependency,
 };
 pub use dependencies_block::DependenciesBlock;
 pub use dependency::{Dependency, DependencyKind, SourceRange};
 pub use error::{Error, Result};
 pub use exports_info::ExportsInfo;
 pub use hooks::{CompilationHooks, HookFuture};
-pub use loader::{LoaderFuture, LoaderRequest, LoaderRunner, MatchedLoader, ModuleRule};
+pub use loader::{
+    LoadedLoaderModule, LoaderFuture, LoaderModuleFuture, LoaderModuleRequest, LoaderModuleRunner,
+    LoaderRequest, LoaderRequestKind, LoaderResult, LoaderRunner, MatchedLoader, ModuleRule,
+};
 pub use logging::{InfrastructureLogEvent, InfrastructureLogLevel, InfrastructureLoggingOptions};
 pub use make::MakeOptions;
 pub use module::{Module, ModuleHandle, ModuleIdentity, ModuleType};

--- a/crates/unpack_core/src/loader.rs
+++ b/crates/unpack_core/src/loader.rs
@@ -5,6 +5,7 @@ use std::{
     future::Future,
     path::{Path, PathBuf},
     pin::Pin,
+    sync::Arc,
 };
 
 use regex::Regex;
@@ -92,9 +93,50 @@ pub struct LoaderRequest {
     pub resource: PathBuf,
     pub source: String,
     pub options: String,
+    pub module_runner: Arc<dyn LoaderModuleRunner>,
 }
 
-pub type LoaderFuture<'a> = Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>>;
+#[derive(Debug, Clone)]
+pub struct LoadedLoaderModule {
+    pub source: String,
+    pub resource: PathBuf,
+    pub identifier: String,
+    pub file_dependencies: Vec<PathBuf>,
+    pub dependency_requests: Vec<String>,
+}
+
+pub type LoaderModuleFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<LoadedLoaderModule>> + Send + 'a>>;
+
+pub trait LoaderModuleRunner: Debug + Send + Sync {
+    fn load(
+        &self,
+        request: String,
+        kind: LoaderRequestKind,
+        context: Option<PathBuf>,
+    ) -> LoaderModuleFuture<'_>;
+}
+
+#[derive(Debug, Clone)]
+pub struct LoaderResult {
+    pub source: String,
+    pub requests: Vec<LoaderModuleRequest>,
+    pub file_dependencies: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LoaderModuleRequest {
+    pub kind: LoaderRequestKind,
+    pub request: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoaderRequestKind {
+    Load,
+    Import,
+}
+
+pub type LoaderFuture<'a> = Pin<Box<dyn Future<Output = Result<LoaderResult>> + Send + 'a>>;
 
 pub trait LoaderRunner: Debug + Send + Sync {
     fn run(&self, request: LoaderRequest) -> LoaderFuture<'_>;

--- a/crates/unpack_core/src/make.rs
+++ b/crates/unpack_core/src/make.rs
@@ -12,12 +12,13 @@ use std::{
 
 use futures::{FutureExt, StreamExt, future::BoxFuture, stream::FuturesUnordered};
 use rustc_hash::{FxHashMap, FxHashSet};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, watch};
 
 use crate::{
     AsyncDependenciesBlockIndex, CompilerOptions, Dependency, DependencyIndex, EntryDependency,
-    Error, FactorizedModule, LoaderRequest, LoaderRunner, MatchedLoader, ModuleHandle,
-    ModuleIdentity, NormalModuleFactory, Result, SnapshotStrategy, UnpackResolver,
+    Error, FactorizedModule, LoaderDependency, LoaderImportDependency, LoaderRequest, LoaderRunner,
+    MatchedLoader, ModuleHandle, ModuleIdentity, NormalModuleFactory, Result, SnapshotStrategy,
+    UnpackResolver,
     cache::{Cache, ModuleBuildRecord},
     cache_facade::{CacheETag, ModuleBuildCache},
     module::BuiltModuleContent,
@@ -36,6 +37,8 @@ pub(crate) struct MakeState {
     pub context_dependencies: FxHashSet<PathBuf>,
     pub missing_dependencies: FxHashSet<PathBuf>,
     modules_by_identity: FxHashMap<ModuleIdentity, ModuleHandle>,
+    building_modules: FxHashMap<ModuleHandle, watch::Sender<bool>>,
+    loader_waits: FxHashMap<ModuleHandle, ModuleHandle>,
 }
 
 struct MakeServices {
@@ -51,6 +54,147 @@ struct MakeServices {
     module_types: ModuleTypeRegistry,
     unsafe_watch_cache: Option<crate::unsafe_watch_cache::UnsafeWatchCache>,
     watch_change_set: Option<crate::WatchChangeSet>,
+}
+
+struct MakeLoaderModuleRunner {
+    services: Arc<MakeServices>,
+    state: Arc<Mutex<MakeState>>,
+    origin_module: ModuleHandle,
+    context: PathBuf,
+}
+
+impl std::fmt::Debug for MakeLoaderModuleRunner {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("MakeLoaderModuleRunner")
+    }
+}
+
+impl crate::LoaderModuleRunner for MakeLoaderModuleRunner {
+    fn load(
+        &self,
+        request: String,
+        kind: crate::LoaderRequestKind,
+        context: Option<PathBuf>,
+    ) -> crate::LoaderModuleFuture<'_> {
+        Box::pin(async move {
+            let context = context.as_deref().unwrap_or(&self.context);
+            let dependency = match kind {
+                crate::LoaderRequestKind::Load => {
+                    Dependency::Loader(LoaderDependency::new(request))
+                }
+                crate::LoaderRequestKind::Import => {
+                    Dependency::LoaderImport(LoaderImportDependency::new(request))
+                }
+            };
+            let factorized = self
+                .services
+                .normal_module_factory
+                .factorize(context, &dependency)
+                .await?;
+            let resource = factorized.resource.clone();
+            let identity = factorized.identity.clone();
+            let (add_result, mut build_waiter, creates_cycle) = {
+                let mut state = self.state.lock().await;
+                state
+                    .file_dependencies
+                    .extend(factorized.file_dependencies.iter().cloned());
+                state
+                    .context_dependencies
+                    .extend(factorized.context_dependencies.iter().cloned());
+                state
+                    .missing_dependencies
+                    .extend(factorized.missing_dependencies.iter().cloned());
+                let add_result = state.add_or_connect(
+                    None,
+                    Vec::new(),
+                    identity.clone(),
+                    factorized.side_effect_free,
+                );
+                let build_waiter = if add_result.is_new {
+                    None
+                } else {
+                    state
+                        .building_modules
+                        .get(&add_result.module_handle)
+                        .map(watch::Sender::subscribe)
+                };
+                let creates_cycle =
+                    state.loader_wait_creates_cycle(self.origin_module, add_result.module_handle);
+                if !creates_cycle {
+                    state
+                        .loader_waits
+                        .insert(self.origin_module, add_result.module_handle);
+                }
+                (add_result, build_waiter, creates_cycle)
+            };
+
+            if creates_cycle {
+                return Err(Error::MakeTask {
+                    message: format!(
+                        "There is a circular build dependency involving {}",
+                        identity.resource.to_string_lossy()
+                    ),
+                });
+            }
+
+            if let Some(waiter) = build_waiter.as_mut() {
+                while !*waiter.borrow_and_update() {
+                    waiter.changed().await.map_err(|_| Error::MakeTask {
+                        message: format!(
+                            "build waiter closed before {} completed",
+                            identity.resource.to_string_lossy()
+                        ),
+                    })?;
+                }
+            }
+
+            if add_result.is_new {
+                let mut queue = VecDeque::from([MakeTask::Build(BuildTask {
+                    module_handle: add_result.module_handle,
+                    identity: identity.clone(),
+                    resource: resource.clone(),
+                    loader: factorized.loader,
+                })]);
+                while let Some(task) = queue.pop_front() {
+                    queue.extend(
+                        task.run(Arc::clone(&self.services), Arc::clone(&self.state))
+                            .await?,
+                    );
+                }
+            }
+
+            let mut state = self.state.lock().await;
+            state.loader_waits.remove(&self.origin_module);
+            let module = state
+                .module_graph
+                .module(add_result.module_handle)
+                .ok_or(Error::MissingModule(add_result.module_handle))?;
+            if let Some(error) = module.build_error() {
+                return Err(error.clone());
+            }
+            Ok(crate::LoadedLoaderModule {
+                source: module.source().to_string(),
+                resource,
+                identifier: module.identity().identifier(),
+                // Loader results may embed any transitive build input. Until Module Build Info
+                // owns dependency sets per Module, conservatively snapshot the Compilation's
+                // complete file dependency set to prevent stale loader output.
+                file_dependencies: state.file_dependencies.iter().cloned().collect(),
+                dependency_requests: module
+                    .dependencies()
+                    .iter()
+                    .chain(
+                        module
+                            .blocks()
+                            .iter()
+                            .flat_map(|block| block.dependencies()),
+                    )
+                    .filter_map(Dependency::request)
+                    .map(str::to_string)
+                    .collect(),
+            })
+        })
+    }
 }
 
 #[derive(Debug)]
@@ -584,6 +728,8 @@ impl BuildTask {
                 return Ok(Vec::new());
             }
         };
+        let mut loader_module_requests = Vec::new();
+        let mut loader_file_dependencies = Vec::new();
         let source = if let Some(loader) = self.loader.as_ref() {
             let Some(loader_runner) = services.loader_runner.as_ref() else {
                 let error = Error::Loader {
@@ -603,10 +749,20 @@ impl BuildTask {
                     resource: self.resource.clone(),
                     source: raw_source.clone(),
                     options: loader.options.clone(),
+                    module_runner: Arc::new(MakeLoaderModuleRunner {
+                        services: Arc::clone(&services),
+                        state: Arc::clone(&state),
+                        origin_module: self.module_handle,
+                        context: issuer_context.clone(),
+                    }),
                 })
                 .await
             {
-                Ok(source) => source,
+                Ok(result) => {
+                    loader_module_requests = result.requests;
+                    loader_file_dependencies = result.file_dependencies;
+                    result.source
+                }
                 Err(error) if error.is_compilation_error() => {
                     state
                         .lock()
@@ -624,7 +780,7 @@ impl BuildTask {
         } else {
             raw_bytes.as_slice()
         };
-        let parsed = match services.module_types.parse(ModuleParserContext {
+        let mut parsed = match services.module_types.parse(ModuleParserContext {
             module_type: self.identity.module_type,
             resource: &self.resource,
             source: &source,
@@ -641,6 +797,21 @@ impl BuildTask {
             }
             Err(error) => return Err(error),
         };
+        parsed
+            .dependencies_block
+            .dependencies
+            .extend(
+                loader_module_requests
+                    .into_iter()
+                    .map(|request| match request.kind {
+                        crate::LoaderRequestKind::Load => {
+                            Dependency::Loader(LoaderDependency::new(request.request))
+                        }
+                        crate::LoaderRequestKind::Import => {
+                            Dependency::LoaderImport(LoaderImportDependency::new(request.request))
+                        }
+                    }),
+            );
         let process_dependencies =
             process_dependencies_task(self.module_handle, &issuer_context, &parsed);
 
@@ -677,6 +848,21 @@ impl BuildTask {
                 services
                     .file_system_info
                     .create_file_snapshot(loader, &loader_source, services.module_snapshot_strategy)
+                    .await?,
+            );
+        }
+        for dependency in loader_file_dependencies {
+            let dependency_source = tokio::fs::read(&dependency)
+                .await
+                .map_err(|error| Error::read(&dependency, error))?;
+            snapshots.push(
+                services
+                    .file_system_info
+                    .create_file_snapshot_bytes(
+                        &dependency,
+                        &dependency_source,
+                        services.module_snapshot_strategy,
+                    )
                     .await?,
             );
         }
@@ -852,6 +1038,21 @@ fn normalize_missing_resource(path: PathBuf) -> PathBuf {
 }
 
 impl MakeState {
+    fn loader_wait_creates_cycle(&self, origin: ModuleHandle, target: ModuleHandle) -> bool {
+        let mut current = target;
+        let mut visited = FxHashSet::default();
+        while visited.insert(current) {
+            if current == origin {
+                return true;
+            }
+            let Some(next) = self.loader_waits.get(&current).copied() else {
+                return false;
+            };
+            current = next;
+        }
+        false
+    }
+
     fn add_or_connect(
         &mut self,
         origin_module: Option<ModuleHandle>,
@@ -867,6 +1068,8 @@ impl MakeState {
                     .module_graph
                     .add_module(identity.clone(), side_effect_free);
                 self.modules_by_identity.insert(identity, module_handle);
+                let (sender, _) = watch::channel(false);
+                self.building_modules.insert(module_handle, sender);
                 (module_handle, true)
             };
 
@@ -895,7 +1098,11 @@ impl MakeState {
         built_content: Arc<BuiltModuleContent>,
     ) -> Result<()> {
         self.module_graph
-            .finish_module_build(module_handle, built_content)
+            .finish_module_build(module_handle, built_content)?;
+        if let Some(sender) = self.building_modules.remove(&module_handle) {
+            let _ = sender.send(true);
+        }
+        Ok(())
     }
 
     fn fail_module(
@@ -906,6 +1113,9 @@ impl MakeState {
     ) -> Result<()> {
         self.module_graph
             .fail_module(module_handle, error.clone(), source)?;
+        if let Some(sender) = self.building_modules.remove(&module_handle) {
+            let _ = sender.send(true);
+        }
         self.errors.push(error);
         Ok(())
     }

--- a/crates/unpack_core/src/module.rs
+++ b/crates/unpack_core/src/module.rs
@@ -171,6 +171,30 @@ impl BuildingModule {
         self.data.handle
     }
 
+    pub(crate) fn identity(&self) -> &ModuleIdentity {
+        &self.data.identity
+    }
+
+    pub(crate) fn source(&self) -> &str {
+        self.data.built_content.source()
+    }
+
+    pub(crate) fn build_error(&self) -> Option<&Error> {
+        self.data.build_error.as_ref()
+    }
+
+    pub(crate) fn dependencies(&self) -> &[Dependency] {
+        self.data
+            .built_content
+            .parsed
+            .dependencies_block
+            .dependencies()
+    }
+
+    pub(crate) fn blocks(&self) -> &[AsyncDependenciesBlock] {
+        self.data.built_content.parsed.dependencies_block.blocks()
+    }
+
     pub(crate) fn set_factory_side_effect_free(&mut self, side_effect_free: Option<bool>) {
         self.data.factory_side_effect_free = side_effect_free;
     }
@@ -316,6 +340,29 @@ impl ModuleIdentity {
             layer: None,
             loaders: Vec::new(),
         }
+    }
+
+    pub fn identifier(&self) -> String {
+        let resource = format!(
+            "{}{}{}",
+            self.resource.to_string_lossy(),
+            self.query.as_deref().unwrap_or_default(),
+            self.fragment.as_deref().unwrap_or_default()
+        );
+        let request = if self.loaders.is_empty() {
+            resource
+        } else {
+            format!("{}!{resource}", self.loaders.join("!"))
+        };
+        let module_type = match self.module_type {
+            ModuleType::JavaScriptAuto => "javascript/auto",
+            ModuleType::Json => "json",
+            ModuleType::Asset => "asset",
+            ModuleType::AssetResource => "asset/resource",
+            ModuleType::AssetInline => "asset/inline",
+            ModuleType::AssetSource => "asset/source",
+        };
+        format!("{module_type}|{request}")
     }
 }
 

--- a/crates/unpack_core/src/module_graph.rs
+++ b/crates/unpack_core/src/module_graph.rs
@@ -154,6 +154,10 @@ impl ModuleGraph {
 }
 
 impl BuildingModuleGraph {
+    pub(crate) fn module(&self, handle: ModuleHandle) -> Option<&BuildingModule> {
+        self.storage.modules.get(handle.index())
+    }
+
     pub(crate) fn add_module(
         &mut self,
         identity: ModuleIdentity,

--- a/crates/unpack_node/src/lib.rs
+++ b/crates/unpack_node/src/lib.rs
@@ -20,8 +20,8 @@ use unpack_core::{
     Asset, BuildDependency, CacheCompression, CacheIdleReason, CacheOptions, CompilationHooks,
     Compiler, CompilerOptions, Dependency, Entry, Error as CoreError, HookFuture,
     InfrastructureLogEvent, InfrastructureLogLevel, InfrastructureLoggingOptions, LoaderFuture,
-    LoaderRequest, LoaderRunner, Module, ModuleRule, ModuleType, SnapshotOptions,
-    SnapshotPathPattern, SnapshotStrategy,
+    LoaderModuleRequest, LoaderRequest, LoaderRequestKind, LoaderResult, LoaderRunner, Module,
+    ModuleRule, ModuleType, SnapshotOptions, SnapshotPathPattern, SnapshotStrategy,
 };
 
 #[global_allocator]
@@ -631,7 +631,11 @@ pub struct NativeFlushResult {
 pub fn create_compiler(
     options: NativeCompilerOptions,
     loader_callback: Option<
-        Function<'_, FnArgs<(String, String, String, String)>, Promise<String>>,
+        Function<
+            '_,
+            FnArgs<(String, String, String, String, NativeLoaderContext)>,
+            Promise<NativeLoaderResult>,
+        >,
     >,
     compilation_callback: Option<Function<'_, NativeCompilation, Promise<()>>>,
     finish_modules_callback: Option<Function<'_, NativeCompilation, Promise<()>>>,
@@ -647,13 +651,77 @@ pub fn create_compiler(
     )
 }
 
+#[napi(object)]
+pub struct NativeLoaderResult {
+    pub source: String,
+    pub requests: Vec<NativeLoaderModuleRequest>,
+    pub file_dependencies: Vec<String>,
+}
+
+#[napi(object)]
+pub struct NativeLoaderModuleRequest {
+    pub kind: String,
+    pub request: String,
+}
+
 type NativeLoaderCallback = ThreadsafeFunction<
-    FnArgs<(String, String, String, String)>,
-    Promise<String>,
-    FnArgs<(String, String, String, String)>,
+    FnArgs<(String, String, String, String, NativeLoaderContext)>,
+    Promise<NativeLoaderResult>,
+    FnArgs<(String, String, String, String, NativeLoaderContext)>,
     Status,
     false,
 >;
+
+#[napi]
+pub struct NativeLoaderContext {
+    module_runner: Arc<dyn unpack_core::LoaderModuleRunner>,
+}
+
+#[napi(object)]
+pub struct NativeLoadedLoaderModule {
+    pub source: String,
+    pub resource: String,
+    pub identifier: String,
+    pub file_dependencies: Vec<String>,
+    pub dependency_requests: Vec<String>,
+}
+
+#[napi]
+impl NativeLoaderContext {
+    #[napi]
+    pub async fn load_module(
+        &self,
+        request: String,
+        kind: String,
+        context: Option<String>,
+    ) -> Result<NativeLoadedLoaderModule> {
+        let kind = match kind.as_str() {
+            "load" => LoaderRequestKind::Load,
+            "import" => LoaderRequestKind::Import,
+            _ => {
+                return Err(napi::Error::from_reason(
+                    "unknown loader module request kind",
+                ));
+            }
+        };
+        let loaded = self
+            .module_runner
+            .load(request, kind, context.map(PathBuf::from))
+            .await
+            .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+        Ok(NativeLoadedLoaderModule {
+            source: loaded.source,
+            resource: loaded.resource.to_string_lossy().into_owned(),
+            identifier: loaded.identifier,
+            file_dependencies: loaded
+                .file_dependencies
+                .into_iter()
+                .map(|path| path.to_string_lossy().into_owned())
+                .collect(),
+            dependency_requests: loaded.dependency_requests,
+        })
+    }
+}
 
 struct NativeLoaderRunner {
     callback: Arc<NativeLoaderCallback>,
@@ -677,6 +745,9 @@ impl LoaderRunner for NativeLoaderRunner {
                     resource.clone(),
                     request.source,
                     request.options,
+                    NativeLoaderContext {
+                        module_runner: request.module_runner,
+                    },
                 )))
                 .await
                 .map_err(|error| CoreError::Loader {
@@ -684,10 +755,37 @@ impl LoaderRunner for NativeLoaderRunner {
                     path: PathBuf::from(&resource),
                     message: error.to_string(),
                 })?;
-            promise.await.map_err(|error| CoreError::Loader {
+            let result = promise.await.map_err(|error| CoreError::Loader {
                 loader: PathBuf::from(loader),
                 path: PathBuf::from(resource),
                 message: error.to_string(),
+            })?;
+            Ok(LoaderResult {
+                source: result.source,
+                requests: result
+                    .requests
+                    .into_iter()
+                    .map(|request| {
+                        let kind = match request.kind.as_str() {
+                            "load" => LoaderRequestKind::Load,
+                            "import" => LoaderRequestKind::Import,
+                            kind => {
+                                return Err(CoreError::MakeTask {
+                                    message: format!("unknown loader module request kind: {kind}"),
+                                });
+                            }
+                        };
+                        Ok(LoaderModuleRequest {
+                            kind,
+                            request: request.request,
+                        })
+                    })
+                    .collect::<std::result::Result<Vec<_>, CoreError>>()?,
+                file_dependencies: result
+                    .file_dependencies
+                    .into_iter()
+                    .map(PathBuf::from)
+                    .collect(),
             })
         })
     }
@@ -953,7 +1051,11 @@ impl NativeCompiler {
     fn new(
         options: NativeCompilerOptions,
         loader_callback: Option<
-            Function<'_, FnArgs<(String, String, String, String)>, Promise<String>>,
+            Function<
+                '_,
+                FnArgs<(String, String, String, String, NativeLoaderContext)>,
+                Promise<NativeLoaderResult>,
+            >,
         >,
         compilation_callback: Option<Function<'_, NativeCompilation, Promise<()>>>,
         finish_modules_callback: Option<Function<'_, NativeCompilation, Promise<()>>>,
@@ -1364,6 +1466,8 @@ fn dependency_type(dependency: &Dependency) -> &'static str {
         Dependency::Null(_) => "null",
         Dependency::Const(_) => "const",
         Dependency::Import(_) => "import()",
+        Dependency::Loader(_) => "loader",
+        Dependency::LoaderImport(_) => "loader import",
     }
 }
 
@@ -1374,6 +1478,8 @@ fn dependency_is_weak(dependency: &Dependency) -> bool {
         Dependency::HarmonyImportSpecifier(dependency) => dependency.module.weak,
         Dependency::HarmonyExportImportedSpecifier(dependency) => dependency.module.weak,
         Dependency::Import(dependency) => dependency.module.weak,
+        Dependency::Loader(dependency) => dependency.module.weak,
+        Dependency::LoaderImport(dependency) => dependency.module.weak,
         Dependency::HarmonyExportHeader(_)
         | Dependency::HarmonyExportSpecifier(_)
         | Dependency::HarmonyExportExpression(_)

--- a/docs/adr/0148-support-loader-module-requests.md
+++ b/docs/adr/0148-support-loader-module-requests.md
@@ -1,0 +1,30 @@
+# Support loader module requests through the current Compilation
+
+Loader contexts will expose a first webpack-shaped `loadModule` and
+`importModule` slice. Requests resolve relative to the resource whose loader is
+running, pass through matching configured module rules, become dependencies of
+the requesting Module in the current Compilation, and contribute their direct
+resource and loader files to watch dependency sets and Module Build Record
+snapshots.
+
+This extends the already Implemented Webpack Surface from ADR 0136 rather than
+opening an unrelated feature area. It follows ADR 0116 by closing loader-context
+alignment gaps in the existing Normal Module build pipeline.
+
+`loadModule` keeps webpack's callback-only contract and returns transformed
+text, a null source map, and a minimal module facade. `importModule` keeps the
+Promise and callback overloads and returns an ECMAScript module namespace.
+Non-empty execution options and inline loader requests fail clearly instead of
+being accepted as no-ops.
+
+The first Build-Time Module Execution slice asks the Rust Make Phase to resolve,
+build, cache, and connect every requested Module, then evaluates the resulting
+transformed ECMAScript module text on the JavaScript host thread. It does not claim webpack's full
+Compilation execution runtime: CommonJS execution, emitted loader assets,
+source maps, layers, public paths, base URIs, and arbitrary transformed relative
+dependencies remain closed. Opening those surfaces requires a
+Compilation-owned code-generation runtime. The Loader Runtime remains an internal
+N-API transport and host-execution helper; request resolution, rule matching,
+Module Graph ownership, dependency discovery, caching, and snapshots remain in
+the Rust Make Phase. Loader requests use dedicated `LoaderDependency` and
+`LoaderImportDependency` records and do not become runtime Chunk members.

--- a/docs/implementation/webpack-implementation-differences.md
+++ b/docs/implementation/webpack-implementation-differences.md
@@ -151,6 +151,25 @@ loads and invokes configured CommonJS loaders for the internal N-API bridge.
 It is an internal host-transport boundary rather than a separate webpack public
 surface or a replacement for the Normal Module Factory responsibility.
 
+The loader context exposes the first `loadModule` and `importModule` slice.
+Both ask the Rust Make Phase to resolve requests relative to the current
+resource, apply matching configured loaders, add dedicated Loader Dependency
+records to the current Compilation's Module Graph,
+and propagate the loaded resource and loader files into watch dependencies and
+Module Build Record snapshots. `loadModule` uses webpack's asynchronous
+callback shape and returns transformed text, a null source map, and a minimal
+module facade. `importModule` supports both Promise and callback forms and
+returns an ECMAScript module namespace.
+
+Loader Dependency connections are excluded from runtime Chunk membership.
+This slice deliberately rejects inline loader request syntax and non-empty
+`importModule` options. Build-Time Module Execution currently uses Node's ESM
+evaluator for transformed JavaScript text after recursively asking Make to
+build static ESM dependencies, and does not yet provide webpack's execution runtime, emitted assets,
+CommonJS execution, layer/publicPath/baseUri behavior, or source maps. Those
+surfaces require a Compilation-owned code-generation runtime before they can be
+exposed.
+
 Webpack's `NormalModuleFactory` owns a large part of public configurability: hooks, scheme-specific resolution, rule matching, loader resolution, parser/generator selection, layers, import attributes, dependency categories, file/missing/context dependency tracking, and ignored modules.
 
 Necessity:

--- a/packages/unpack/src/LoaderRuntime.ts
+++ b/packages/unpack/src/LoaderRuntime.ts
@@ -1,6 +1,9 @@
 // JavaScript loader execution used by the native NormalModuleFactory bridge.
 
+import { dirname } from "node:path";
+
 import { LoaderFunction, LoaderState, require } from "./binding.js";
+import type { LoaderRunResult, LoaderModule, NativeLoaderContext } from "./binding.js";
 
 export class LoaderRuntime {
   readonly #loaders = new Map<string, LoaderState>();
@@ -15,8 +18,9 @@ export class LoaderRuntime {
     loaderPath: string,
     resourcePath: string,
     source: string,
-    serializedOptions: string
-  ): Promise<string> => {
+    serializedOptions: string,
+    nativeContext: NativeLoaderContext
+  ): Promise<LoaderRunResult> => {
     let state = this.#loaders.get(loaderPath);
     if (state === undefined) {
       try {
@@ -34,7 +38,9 @@ export class LoaderRuntime {
     }
     if (state.failed) throw state.error;
 
-    return new Promise<string>((resolve, reject) => {
+    return new Promise<LoaderRunResult>((resolve, reject) => {
+      const requests = new Map<string, { request: string; kind: "load" | "import" }>();
+      const fileDependencies = new Set<string>();
       let callbackRequested = false;
       let settled = false;
       const complete = (error: unknown, transformedSource?: unknown): void => {
@@ -43,13 +49,74 @@ export class LoaderRuntime {
         if (error != null) {
           reject(error);
         } else if (typeof transformedSource === "string") {
-          resolve(transformedSource);
+          resolve({
+            source: transformedSource,
+            requests: [...requests.values()],
+            fileDependencies: [...fileDependencies]
+          });
         } else {
           reject(new TypeError(`loader ${loaderPath} callback must provide a string`));
         }
       };
       const callback = (error: unknown, transformedSource?: unknown): void => {
         complete(error, transformedSource);
+      };
+
+      const loadModule = (
+        request: string,
+        loadCallback: (
+          error: Error | null,
+          source?: string,
+          sourceMap?: null,
+          module?: LoaderModule
+        ) => void
+      ): void => {
+        if (typeof request !== "string" || typeof loadCallback !== "function") {
+          throw new TypeError("this.loadModule requires a request and callback");
+        }
+        void nativeContext.loadModule(request, "load").then(
+          ({ resource, source, identifier, fileDependencies: loadedDependencies }) => {
+            requests.set(`load\0${request}`, { request, kind: "load" });
+            for (const dependency of loadedDependencies) fileDependencies.add(dependency);
+            loadCallback(null, source, null, {
+              resource,
+              identifier: () => identifier
+            });
+          },
+          (error) => loadCallback(toError(error))
+        );
+      };
+
+      const importModule = (
+        request: string,
+        importOptions: Record<string, unknown> | ((error: Error | null, exports?: unknown) => void) = {},
+        importCallback?: (error: Error | null, exports?: unknown) => void
+      ): Promise<unknown> | void => {
+        const callback = typeof importOptions === "function" ? importOptions : importCallback;
+        const options = typeof importOptions === "function" ? {} : importOptions;
+        if (typeof request !== "string") throw new TypeError("this.importModule requires a request");
+        if (options == null || typeof options !== "object" || Array.isArray(options)) {
+          throw new TypeError("this.importModule options must be an object");
+        }
+        const unsupported = Object.keys(options).filter(
+          (key) => !["layer", "publicPath", "baseUri"].includes(key)
+        );
+        if (unsupported.length > 0) {
+          throw new TypeError(`this.importModule does not support option '${unsupported[0]}'`);
+        }
+        if (Object.keys(options).length > 0) {
+          throw new TypeError("this.importModule options are not supported yet");
+        }
+        const imported = this.#importModule(request, nativeContext).then(({ exports, dependencies }) => {
+          requests.set(`import\0${request}`, { request, kind: "import" });
+          for (const dependency of dependencies) fileDependencies.add(dependency);
+          return exports;
+        });
+        if (!callback) return imported;
+        void imported.then(
+          (exports) => callback(null, exports),
+          (error) => callback(toError(error))
+        );
       };
 
       let result: unknown;
@@ -60,6 +127,8 @@ export class LoaderRuntime {
             rootContext: this.rootContext,
             sourceMap: false,
             getOptions: () => JSON.parse(serializedOptions) as Record<string, unknown>,
+            loadModule,
+            importModule,
             async: () => {
               callbackRequested = true;
               return callback;
@@ -88,4 +157,60 @@ export class LoaderRuntime {
       }
     });
   };
+
+  async #importModule(
+    request: string,
+    nativeContext: NativeLoaderContext
+  ): Promise<{ exports: unknown; dependencies: string[] }> {
+    const loaded = await nativeContext.loadModule(request, "import");
+    const executed = await createModuleUrl(loaded, nativeContext, new Set());
+    return { exports: await import(executed.url), dependencies: executed.dependencies };
+  }
+}
+
+async function createModuleUrl(
+  loaded: {
+    source: string;
+    resource: string;
+    identifier: string;
+    fileDependencies: string[];
+    dependencyRequests: string[];
+  },
+  nativeContext: NativeLoaderContext,
+  ancestors: Set<string>
+): Promise<{ url: string; dependencies: string[] }> {
+  if (ancestors.has(loaded.identifier)) {
+    throw new Error(`circular importModule execution is not supported yet: ${loaded.identifier}`);
+  }
+  const nextAncestors = new Set(ancestors).add(loaded.identifier);
+  const dependencyRequests = new Set(loaded.dependencyRequests);
+  // Rust's parser owns dependency discovery. This expression only locates the already-known
+  // string specifiers so the host ESM evaluator can link them to their built module URLs.
+  const matches = [...loaded.source.matchAll(/\b(?:from\s*|import\s*(?:\(\s*)?)(["'])([^"']+)\1/g)]
+    .filter((match) => dependencyRequests.has(match[2]));
+  const replacements = await Promise.all(matches.map(async (match) => {
+    const request = match[2];
+    const requestOffset = match.index + match[0].lastIndexOf(request);
+    const dependency = await nativeContext.loadModule(request, "import", dirname(loaded.resource));
+    return {
+      start: requestOffset,
+      end: requestOffset + request.length,
+      executed: await createModuleUrl(dependency, nativeContext, nextAncestors)
+    };
+  }));
+  let source = loaded.source;
+  for (const replacement of replacements.reverse()) {
+    source = `${source.slice(0, replacement.start)}${replacement.executed.url}${source.slice(replacement.end)}`;
+  }
+  return {
+    url: `data:text/javascript;base64,${Buffer.from(source).toString("base64")}#${encodeURIComponent(loaded.identifier)}`,
+    dependencies: [
+      ...loaded.fileDependencies,
+      ...replacements.flatMap((replacement) => replacement.executed.dependencies)
+    ]
+  };
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }

--- a/packages/unpack/src/binding.ts
+++ b/packages/unpack/src/binding.ts
@@ -128,8 +128,9 @@ export interface NativeBinding {
       loader: string,
       resource: string,
       source: string,
-      options: string
-    ) => Promise<string>,
+      options: string,
+      context: NativeLoaderContext
+    ) => Promise<LoaderRunResult>,
     compilation?: (compilation: NativeCompilation) => Promise<void>,
     finishModules?: (compilation: NativeCompilation) => Promise<void>,
     processAssets?: (assets: NativeAssets) => Promise<void>
@@ -179,9 +180,50 @@ export type LoaderFunction = (
     sourceMap: false;
     getOptions(): Record<string, unknown>;
     async(): (error: unknown, source?: unknown) => void;
+    loadModule(
+      request: string,
+      callback: (error: Error | null, source?: string, sourceMap?: null, module?: LoaderModule) => void
+    ): void;
+    importModule(
+      request: string,
+      options?: Record<string, unknown>,
+      callback?: (error: Error | null, exports?: unknown) => void
+    ): Promise<unknown> | void;
   },
   source: string
 ) => unknown;
+
+export interface LoaderModule {
+  readonly resource: string;
+  identifier(): string;
+}
+
+export interface LoaderRunResult {
+  source: string;
+  requests: LoaderModuleRequest[];
+  fileDependencies: string[];
+}
+
+export interface LoaderModuleRequest {
+  kind: "load" | "import";
+  request: string;
+}
+
+export interface NativeLoaderContext {
+  loadModule(
+    request: string,
+    kind: "load" | "import",
+    context?: string
+  ): Promise<NativeLoadedLoaderModule>;
+}
+
+export interface NativeLoadedLoaderModule {
+  source: string;
+  resource: string;
+  identifier: string;
+  fileDependencies: string[];
+  dependencyRequests: string[];
+}
 
 export type LoaderState =
   | { failed: false; loader: LoaderFunction }

--- a/packages/unpack/test/loader.test.ts
+++ b/packages/unpack/test/loader.test.ts
@@ -6,6 +6,8 @@ import test from "node:test";
 
 import unpack from "@unpack-js/core";
 import type { Compiler, Stats, UnpackOptions } from "@unpack-js/core";
+import webpack from "webpack";
+import type { Compiler as WebpackCompiler } from "webpack";
 
 test("a synchronous CommonJS loader transforms a module before parsing", async () => {
   const fixture = await mkdtemp(join(tmpdir(), "unpack-loader-"));
@@ -86,6 +88,190 @@ test("an asynchronous loader callback transforms a module with rule options", as
     assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /42/);
   } finally {
     await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("loadModule builds a requested module and provides its transformed source", async () => {
+  const fixture = await mkdtemp(join(tmpdir(), "unpack-loader-load-module-"));
+  const outerLoader = join(fixture, "outer-loader.cjs");
+  const valueLoader = join(fixture, "value-loader.cjs");
+  const valueLoaderCalls = join(fixture, "value-loader-calls.txt");
+  await writeFixtureFile(
+    join(fixture, "src/index.js"),
+    'import value from "./entry.data";\nexport { value };\n'
+  );
+  await writeFixtureFile(join(fixture, "src/entry.data"), "ignored\n");
+  await writeFixtureFile(join(fixture, "src/value.txt"), "21\n");
+  await writeFixtureFile(
+    valueLoader,
+    [
+      'const { appendFileSync } = require("node:fs");',
+      "module.exports = source => {",
+      `  appendFileSync(${JSON.stringify(valueLoaderCalls)}, "call\\n");`,
+      "  return `export default ${Number(source.trim()) * 2};`;",
+      "};",
+      ""
+    ].join("\n")
+  );
+  await writeFixtureFile(
+    outerLoader,
+    [
+      "module.exports = function () {",
+      "  const done = this.async();",
+      '  this.loadModule("./value.txt?query#fragment", (error, source, map, module) => {',
+      "    if (error) return done(error);",
+      "    if (map !== null) return done(new Error('expected a null source map'));",
+      "    if (!module.resource.endsWith('value.txt')) return done(new Error('unexpected module'));",
+      "    done(null, source);",
+      "  });",
+      "};",
+      ""
+    ].join("\n")
+  );
+
+  const compiler = unpack({
+    context: fixture,
+    entry: "./src/index.js",
+    output: { path: join(fixture, "dist") },
+    sourcemap: false,
+    module: {
+      rules: [
+        { test: /\.data$/, loader: outerLoader },
+        { test: /\.txt$/, loader: valueLoader }
+      ]
+    }
+  });
+
+  try {
+    const first = await runCompiler(compiler);
+    assert.equal(first.hasErrors(), false);
+    assert.equal(
+      first.toJson().watchDependencies.files.some((path) => path.endsWith(join("src", "value.txt"))),
+      true
+    );
+    assert.equal(first.toJson().watchDependencies.files.includes(valueLoader), true);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /42/);
+
+    await writeFixtureFile(join(fixture, "src/value.txt"), "22\n");
+    const second = await runCompiler(compiler);
+    assert.equal(second.hasErrors(), false);
+    const rebuiltBundle = await readFile(join(fixture, "dist/main.js"), "utf8");
+    assert.match(rebuiltBundle, /44/);
+    assert.doesNotMatch(rebuiltBundle, /42/);
+    assert.deepEqual((await readFile(valueLoaderCalls, "utf8")).trim().split("\n"), [
+      "call",
+      "call"
+    ]);
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("importModule supports promise and callback forms", async () => {
+  const fixture = await mkdtemp(join(tmpdir(), "unpack-loader-import-module-"));
+  const loader = join(fixture, "loader.cjs");
+  await writeFixtureFile(
+    join(fixture, "src/index.js"),
+    'import value from "./entry.data";\nexport { value };\n'
+  );
+  await writeFixtureFile(join(fixture, "src/entry.data"), "ignored\n");
+  await writeFixtureFile(
+    join(fixture, "src/value.js"),
+    'import { delta } from "./delta.js";\nexport const value = 39 + delta;\n'
+  );
+  await writeFixtureFile(join(fixture, "src/delta.js"), "export const delta = 1;\n");
+  await writeFixtureFile(
+    loader,
+    [
+      "module.exports = async function () {",
+      '  const promiseExports = await this.importModule("./value.js");',
+      "  const callbackExports = await new Promise((resolve, reject) => {",
+      '    this.importModule("./value.js", {}, (error, exports) => error ? reject(error) : resolve(exports));',
+      "  });",
+      "  return `export default ${promiseExports.value + callbackExports.value - 38};`;",
+      "};",
+      ""
+    ].join("\n")
+  );
+
+  const compiler = unpack({
+    context: fixture,
+    entry: "./src/index.js",
+    output: { path: join(fixture, "dist") },
+    sourcemap: false,
+    module: { rules: [{ test: /\.data$/, loader }] }
+  });
+
+  try {
+    const first = await runCompiler(compiler);
+    assert.equal(first.hasErrors(), false);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /42/);
+
+    await writeFixtureFile(join(fixture, "src/delta.js"), "export const delta = 2;\n");
+    const second = await runCompiler(compiler);
+    assert.equal(second.hasErrors(), false);
+    assert.match(await readFile(join(fixture, "dist/main.js"), "utf8"), /44/);
+  } finally {
+    await closeCompiler(compiler);
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("loadModule and importModule match webpack for loader-visible source and exports", async () => {
+  const fixture = await mkdtemp(join(tmpdir(), "unpack-loader-module-comparison-"));
+  const loader = join(fixture, "loader.cjs");
+  await writeFixtureFile(
+    join(fixture, "src/index.js"),
+    'import value from "./entry.data";\nexport { value };\n'
+  );
+  await writeFixtureFile(join(fixture, "src/entry.data"), "ignored\n");
+  await writeFixtureFile(join(fixture, "src/value.js"), "export const value = 21;\n");
+  await writeFixtureFile(
+    loader,
+    [
+      "module.exports = async function () {",
+      "  const source = await new Promise((resolve, reject) => {",
+      '    this.loadModule("./value.js", (error, loaded) => error ? reject(error) : resolve(loaded));',
+      "  });",
+      '  const exports = await this.importModule("./value.js", {});',
+      "  if (!source.includes('21')) throw new Error('unexpected loaded source');",
+      "  return `export default ${exports.value * 2};`;",
+      "};",
+      ""
+    ].join("\n")
+  );
+  const unpackOutput = join(fixture, "dist-unpack");
+  const webpackOutput = join(fixture, "dist-webpack");
+  const unpackCompiler = unpack({
+    context: fixture,
+    mode: "none",
+    entry: "./src/index.js",
+    output: { path: unpackOutput },
+    sourcemap: false,
+    module: { rules: [{ test: /\.data$/, loader }] }
+  });
+  const webpackCompiler = webpack({
+    context: fixture,
+    mode: "none",
+    entry: "./src/index.js",
+    output: { path: webpackOutput },
+    devtool: false,
+    module: { rules: [{ test: /\.data$/, loader }] }
+  });
+
+  try {
+    const [unpackStats] = await Promise.all([
+      runCompiler(unpackCompiler),
+      runWebpackCompiler(webpackCompiler)
+    ]);
+    assert.equal(unpackStats.hasErrors(), false);
+    for (const output of [unpackOutput, webpackOutput]) {
+      assert.match(await readFile(join(output, "main.js"), "utf8"), /42/);
+    }
+  } finally {
+    await Promise.all([closeCompiler(unpackCompiler), closeWebpackCompiler(webpackCompiler)]);
     await rm(fixture, { recursive: true, force: true });
   }
 });
@@ -321,6 +507,23 @@ function runCompiler(compiler: Compiler): Promise<Stats> {
 }
 
 function closeCompiler(compiler: Compiler): Promise<void> {
+  return new Promise((resolve, reject) => {
+    compiler.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function runWebpackCompiler(compiler: WebpackCompiler): Promise<void> {
+  return new Promise((resolve, reject) => {
+    compiler.run((error, stats) => {
+      if (error) reject(error);
+      else if (!stats) reject(new Error("webpack completed without Stats"));
+      else if (stats.hasErrors()) reject(new Error(stats.toString({ errors: true })));
+      else resolve();
+    });
+  });
+}
+
+function closeWebpackCompiler(compiler: WebpackCompiler): Promise<void> {
   return new Promise((resolve, reject) => {
     compiler.close((error) => (error ? reject(error) : resolve()));
   });


### PR DESCRIPTION
## Summary

- add webpack-shaped `loadModule` and `importModule` loader context APIs
- build loader-requested modules through the Rust Make phase with dedicated loader dependency types
- support Promise and callback import forms, ESM dependency execution, single-flight module builds, cycle detection, and cache snapshot propagation
- document the implemented surface and remaining deliberately rejected options
- add webpack comparison and cache invalidation coverage

This closes loader-context alignment gaps in the existing Normal Module pipeline. Requested modules stay in the current Compilation and loader import dependencies remain weak and outside runtime chunks.

The complete Rust workspace tests, public package tests, and benchmark tests pass. The public package reports 155 passing tests with 3 existing skips; benchmark tests report 22 passing tests.